### PR TITLE
fix: Handle zero-variance traits in PCA pipeline step (#74)

### DIFF
--- a/openspec/changes/fix-pca-zero-variance-crash/proposal.md
+++ b/openspec/changes/fix-pca-zero-variance-crash/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+The PCA analysis pipeline step crashes with a shape mismatch error when trait columns
+contain constant values (zero variance). The upstream `perform_pca_analysis()` function
+silently filters out zero-variance columns, but `PCAAnalysisStep` uses the original
+unfiltered `trait_cols` list as the DataFrame index for the loadings matrix, causing a
+dimension mismatch (e.g., 263 actual features vs. 267 expected). This blocks all pipeline
+executions when any trait exhibits zero variance—common in early-stage plant phenotyping
+where measurements remain uniform across samples.
+
+GitHub Issue: #74
+
+## What Changes
+
+- **Fix shape mismatch**: Use `pca_results["feature_names"]` (the post-filtering feature
+  list already returned by `perform_pca_analysis()`) instead of `trait_cols` for:
+  - Loadings DataFrame index (line 117)
+  - `n_features_total` in `select_top_features_from_pca()` (line 91)
+  - Top feature name lookup (line 96)
+- **Log excluded traits**: Log which traits were excluded due to zero variance and how
+  many remain, for traceability.
+- **Warn on high exclusion rate**: Emit a Python `UserWarning` when >50% of traits are
+  zero-variance, alerting users to potential data quality issues.
+- **Metadata tracking**: Store `excluded_zero_variance_traits` and
+  `n_traits_after_filtering` in the step's output metadata for downstream inspection.
+
+## Impact
+
+- Affected specs: `visualization-pipeline` (PCA analysis step behavior)
+- Affected code:
+  - `src/sleap_roots_analyze/pipeline/steps/pca_analysis.py` (primary fix)
+  - `tests/test_step_pca_analysis.py` (new tests)
+- No breaking changes to public API or config schema
+- No changes to `pca.py` (the filtering behavior is correct; the bug is in the step)

--- a/openspec/changes/fix-pca-zero-variance-crash/specs/visualization-pipeline/spec.md
+++ b/openspec/changes/fix-pca-zero-variance-crash/specs/visualization-pipeline/spec.md
@@ -1,0 +1,45 @@
+## MODIFIED Requirements
+
+### Requirement: Pipeline Step Parameter Passing
+The `GenerateStaticFiguresStep` SHALL pass genotype highlighting parameters from configuration to underlying plotting functions.
+
+The `PCAAnalysisStep` SHALL use the post-filtering feature names returned by
+`perform_pca_analysis()` (via `pca_results["feature_names"]`) instead of the original
+`trait_cols` list when constructing the loadings DataFrame index, computing
+`n_features_total` for feature selection, and mapping feature indices to names.
+
+The `PCAAnalysisStep` SHALL log the names and count of any traits excluded due to zero
+variance, and SHALL emit a Python `UserWarning` when more than 50% of input traits are
+excluded.
+
+The `PCAAnalysisStep` SHALL store `excluded_zero_variance_traits` (list of excluded trait
+names) and `n_traits_after_filtering` (int) in its output metadata for downstream
+inspection and reproducibility.
+
+#### Scenario: Pass parameters to PCA biplot
+- **WHEN** generating PCA biplot via `create_pca_biplot`
+- **THEN** the step SHALL pass `config.static_viz.genotypes_to_color` to the function
+- **AND** the step SHALL pass `config.static_viz.highlight_genotypes` to the function
+
+#### Scenario: Pass parameters to PC boxplots
+- **WHEN** generating PC boxplots via `create_pc_genotype_boxplots`
+- **THEN** the step SHALL pass `config.static_viz.highlight_genotypes` to the function
+- **AND** the highlighted genotypes SHALL appear in gold with bold labels
+
+#### Scenario: PCA step handles zero-variance traits gracefully
+- **WHEN** the input DataFrame contains traits with zero variance (constant values)
+- **THEN** the PCA step SHALL complete successfully using only non-zero-variance traits
+- **AND** the loadings CSV index SHALL match the actual features used in PCA
+- **AND** `excluded_zero_variance_traits` SHALL list the excluded trait names in metadata
+- **AND** `n_traits_after_filtering` SHALL reflect the count of traits actually used
+
+#### Scenario: PCA step warns on high zero-variance fraction
+- **WHEN** more than 50% of input traits have zero variance
+- **THEN** the PCA step SHALL emit a `UserWarning` indicating potential data quality issues
+- **AND** the step SHALL still complete successfully with the remaining traits
+
+#### Scenario: PCA step with no zero-variance traits
+- **WHEN** all input traits have non-zero variance
+- **THEN** the PCA step SHALL behave identically to current behavior
+- **AND** `excluded_zero_variance_traits` SHALL be an empty list
+- **AND** no warning SHALL be emitted

--- a/openspec/changes/fix-pca-zero-variance-crash/tasks.md
+++ b/openspec/changes/fix-pca-zero-variance-crash/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: fix-pca-zero-variance-crash
+
+## Task 1: Write failing tests — shape mismatch crash (TDD Red Phase)
+- [x] 1.1 Add `test_pca_with_zero_variance_traits` — data with some constant traits; verify step completes without error and loadings shape matches actual features used
+- [x] 1.2 Add `test_pca_with_all_zero_variance_traits` — all traits constant; verify step raises `ValueError` with clear message
+- [x] 1.3 Run tests, confirm both FAIL (red) on current code — confirmed 6 FAILED (shape mismatch ValueError), 1 PASSED (all-zero-variance already errors correctly)
+
+## Task 2: Write failing tests — metadata and logging (TDD Red Phase)
+- [x] 2.1 Add `test_pca_zero_variance_metadata_tracking` — verify `excluded_zero_variance_traits` and `n_traits_after_filtering` present in metadata when zero-variance traits exist
+- [x] 2.2 Add `test_pca_zero_variance_warning_threshold` — verify `UserWarning` emitted when >50% of traits are zero-variance
+- [x] 2.3 Add `test_pca_no_warning_below_threshold` — verify no warning when <=50% of traits are zero-variance
+- [x] 2.4 Run tests, confirm all 3 FAIL (red) on current code — confirmed all crash with shape mismatch before reaching metadata/warning assertions
+
+## Task 3: Write failing tests — feature selection correctness (TDD Red Phase)
+- [x] 3.1 Add `test_pca_top_features_use_filtered_names` — verify `top_features` metadata contains actual feature names (not indices into original trait list)
+- [x] 3.2 Add `test_pca_loadings_csv_index_matches_features` — verify saved loadings.csv has correct feature names as index
+- [x] 3.3 Run tests, confirm both FAIL (red) on current code — confirmed both crash with shape mismatch
+
+## Task 4: Implement the fix (TDD Green Phase)
+- [x] 4.1 After PCA, compute `feature_names = pca_results["feature_names"]` and derive `excluded_traits = set(trait_cols) - set(feature_names)`
+- [x] 4.2 Log excluded traits: count and names
+- [x] 4.3 Emit `warnings.warn()` if `len(excluded_traits) / len(trait_cols) > 0.5`
+- [x] 4.4 Replace `trait_cols` with `feature_names` in loadings DataFrame index (line 117)
+- [x] 4.5 Replace `len(trait_cols)` with `len(feature_names)` in `select_top_features_from_pca()` call (line 91)
+- [x] 4.6 Replace `trait_cols[i]` with `feature_names[i]` in top features lookup (line 96)
+- [x] 4.7 Add `excluded_zero_variance_traits` and `n_traits_after_filtering` to output metadata
+- [x] 4.8 Run all new tests, confirm all PASS (green) — 7 passed, 0 failed
+
+## Task 5: Write integration tests — full viz pipeline with zero-variance traits (TDD Red→Green)
+- [x] 5.1 Add `test_viz_pipeline_completes_with_zero_variance_traits` — full 12-step VizPipeline with PCA + static figures, UMAP/clustering disabled; asserts `summary.status == "success"`
+- [x] 5.2 Add `test_viz_pipeline_pca_metadata_propagates_to_figures` — verifies `excluded_zero_variance_traits` and `n_traits_after_filtering` in PCA metadata, and `GenerateStaticFiguresStep` completes without errors
+- [x] 5.3 Add `test_viz_pipeline_loadings_csv_dimensions_match` — verifies loadings.csv has 4 rows (variable traits) with correct index names
+- [x] 5.4 Run integration tests — 3 passed, 0 failed (26s)
+
+## Task 6: Verify no regressions
+- [x] 6.1 All existing `TestPCAAnalysisStep` tests pass unchanged — 13 existing + 7 new = 20 passed
+- [x] 6.2 All existing `TestPCADataOrganization` tests pass unchanged — 2 passed
+- [x] 6.3 Full test suite passes (`uv run pytest`) — 1893 passed, 6 flaky (pre-existing, pass in isolation)
+- [x] 6.4 Linting and formatting pass (`uv run ruff check`, `uv run black --check`) — all clean

--- a/src/sleap_roots_analyze/pipeline/steps/pca_analysis.py
+++ b/src/sleap_roots_analyze/pipeline/steps/pca_analysis.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import warnings
 from pathlib import Path
 from typing import Optional
 
@@ -84,16 +85,36 @@ class PCAAnalysisStep(BaseStep):
             f"PCA complete: {n_components} components explain {explained_var:.1%} variance"
         )
 
-        # Select top features
+        # Use the post-filtering feature names from PCA (zero-variance traits removed)
+        feature_names = pca_results["feature_names"]
+        excluded_traits = sorted(set(trait_cols) - set(feature_names))
+
+        if excluded_traits:
+            logger.info(
+                f"Excluded {len(excluded_traits)} zero-variance traits: "
+                f"{excluded_traits}"
+            )
+            if len(excluded_traits) / len(trait_cols) > 0.5:
+                warnings.warn(
+                    f"{len(excluded_traits)} of {len(trait_cols)} traits "
+                    f"({len(excluded_traits) / len(trait_cols):.0%}) have zero variance "
+                    f"and were excluded from PCA. This may indicate data quality issues.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+
+        logger.info(f"PCA used {len(feature_names)} of {len(trait_cols)} traits")
+
+        # Select top features using filtered feature names
         top_feature_indices = select_top_features_from_pca(
             loadings=pca_results["loadings"],
             eigenvalues=pca_results["eigenvalues"],
-            n_features_total=len(trait_cols),
+            n_features_total=len(feature_names),
             n_features_to_select=config.pca.n_top_features,
             method=config.pca.feature_selection_strategy,
         )
 
-        top_features = [trait_cols[i] for i in top_feature_indices]
+        top_features = [feature_names[i] for i in top_feature_indices]
 
         logger.info(
             f"Selected {len(top_features)} top features using {config.pca.feature_selection_strategy} method"
@@ -111,10 +132,10 @@ class PCAAnalysisStep(BaseStep):
         )
         pc_scores_df.to_csv(pca_dir / "pc_scores.csv")
 
-        # Save loadings
+        # Save loadings (use filtered feature names, not original trait_cols)
         loadings_df = pd.DataFrame(
             pca_results["loadings"],
-            index=trait_cols,
+            index=feature_names,
             columns=[f"PC{i + 1}" for i in range(n_components)],
         )
         loadings_df.to_csv(pca_dir / "loadings.csv")
@@ -148,6 +169,8 @@ class PCAAnalysisStep(BaseStep):
             "top_features": top_features,
             "n_pca_components": n_components,
             "pca_explained_variance": explained_var,
+            "excluded_zero_variance_traits": excluded_traits,
+            "n_traits_after_filtering": len(feature_names),
         }
 
         return StepResult(

--- a/tests/test_step_pca_analysis.py
+++ b/tests/test_step_pca_analysis.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from pathlib import Path
 from unittest.mock import MagicMock
 
@@ -398,3 +399,329 @@ class TestPCADataOrganization:
 
         top_features = pd.read_csv(data_pca_dir / "top_features.csv")
         assert len(top_features) == 5
+
+
+class TestPCAZeroVarianceHandling:
+    """Test PCA step handling of zero-variance (constant) traits.
+
+    Addresses GitHub Issue #74: PCA pipeline crashes with shape mismatch
+    when trait columns contain constant values.
+    """
+
+    @pytest.fixture
+    def config_zv(self):
+        """Config for zero-variance tests (request fewer top features)."""
+        return QCPipelineConfig(
+            pipeline_name="test_pca_zv",
+            columns=ColumnConfig(barcode="Barcode", genotype="geno", replicate="rep"),
+            data=DataConfig(csv_path="test.csv"),
+            pca=PCAConfig(
+                n_components=2,
+                standardize=True,
+                n_top_features=3,
+                feature_selection_strategy="top_absolute",
+            ),
+        )
+
+    @pytest.fixture
+    def data_with_some_zero_variance(self):
+        """Dataset where 4 of 8 traits are constant (zero variance).
+
+        Mimics the Alfalfa GWAS scenario from Issue #74: lateral root count
+        at Day 0 yields identical values across all seedlings.
+        """
+        np.random.seed(42)
+        n_samples = 50
+        return pd.DataFrame(
+            {
+                "Barcode": [f"sample_{i}" for i in range(n_samples)],
+                "geno": [f"geno_{i % 5}" for i in range(n_samples)],
+                "rep": [i % 3 + 1 for i in range(n_samples)],
+                # 4 variable traits
+                "primary_root_length": np.random.normal(15.0, 3.0, n_samples),
+                "lateral_root_density": np.random.normal(2.5, 0.8, n_samples),
+                "network_area": np.random.normal(120.0, 25.0, n_samples),
+                "root_depth": np.random.normal(8.0, 1.5, n_samples),
+                # 4 constant traits (zero variance)
+                "lateral_count_day0": np.full(n_samples, 1.0),
+                "lateral_length_day0": np.full(n_samples, 0.0),
+                "secondary_count_day0": np.full(n_samples, 0.0),
+                "tip_angle_day0": np.full(n_samples, 45.0),
+            }
+        )
+
+    @pytest.fixture
+    def prev_result_zv(self, data_with_some_zero_variance):
+        """Previous step result with mixed variable/constant traits."""
+        trait_cols = [
+            "primary_root_length",
+            "lateral_root_density",
+            "network_area",
+            "root_depth",
+            "lateral_count_day0",
+            "lateral_length_day0",
+            "secondary_count_day0",
+            "tip_angle_day0",
+        ]
+        return StepResult(
+            data=data_with_some_zero_variance,
+            metadata={
+                "trait_cols": trait_cols,
+                "metadata_cols": ["Barcode", "geno", "rep"],
+            },
+        )
+
+    @pytest.fixture
+    def data_all_zero_variance(self):
+        """Dataset where ALL traits are constant."""
+        n_samples = 30
+        return pd.DataFrame(
+            {
+                "Barcode": [f"sample_{i}" for i in range(n_samples)],
+                "geno": [f"geno_{i % 3}" for i in range(n_samples)],
+                "rep": [i % 3 + 1 for i in range(n_samples)],
+                "trait_a": np.full(n_samples, 5.0),
+                "trait_b": np.full(n_samples, 10.0),
+                "trait_c": np.full(n_samples, 0.0),
+            }
+        )
+
+    @pytest.fixture
+    def prev_result_all_zv(self, data_all_zero_variance):
+        """Previous step result where all traits are constant."""
+        return StepResult(
+            data=data_all_zero_variance,
+            metadata={
+                "trait_cols": ["trait_a", "trait_b", "trait_c"],
+                "metadata_cols": ["Barcode", "geno", "rep"],
+            },
+        )
+
+    @pytest.fixture
+    def data_majority_zero_variance(self):
+        """Dataset where >50% of traits are constant (triggers warning)."""
+        np.random.seed(42)
+        n_samples = 50
+        return pd.DataFrame(
+            {
+                "Barcode": [f"sample_{i}" for i in range(n_samples)],
+                "geno": [f"geno_{i % 5}" for i in range(n_samples)],
+                "rep": [i % 3 + 1 for i in range(n_samples)],
+                # 2 variable traits (< 50%)
+                "variable_trait1": np.random.normal(10.0, 2.0, n_samples),
+                "variable_trait2": np.random.normal(5.0, 1.0, n_samples),
+                # 5 constant traits (> 50%)
+                "const_a": np.full(n_samples, 1.0),
+                "const_b": np.full(n_samples, 2.0),
+                "const_c": np.full(n_samples, 3.0),
+                "const_d": np.full(n_samples, 4.0),
+                "const_e": np.full(n_samples, 5.0),
+            }
+        )
+
+    @pytest.fixture
+    def prev_result_majority_zv(self, data_majority_zero_variance):
+        """Previous step result where >50% traits are constant."""
+        return StepResult(
+            data=data_majority_zero_variance,
+            metadata={
+                "trait_cols": [
+                    "variable_trait1",
+                    "variable_trait2",
+                    "const_a",
+                    "const_b",
+                    "const_c",
+                    "const_d",
+                    "const_e",
+                ],
+                "metadata_cols": ["Barcode", "geno", "rep"],
+            },
+        )
+
+    # --- Task 1: Shape mismatch crash tests ---
+
+    def test_pca_with_zero_variance_traits(
+        self, config_zv, data_with_some_zero_variance, prev_result_zv, tmp_path
+    ):
+        """PCA step completes when some traits have zero variance.
+
+        Regression test for Issue #74: shape mismatch between loadings
+        matrix and trait_cols when zero-variance traits are filtered.
+        """
+        step = PCAAnalysisStep()
+
+        # Should NOT raise ValueError about shape mismatch
+        result = step.execute(
+            data=data_with_some_zero_variance,
+            config=config_zv,
+            run_dir=tmp_path,
+            prev_result=prev_result_zv,
+        )
+
+        assert isinstance(result, StepResult)
+        assert "pca_results" in result.metadata
+
+        # Loadings should have rows matching the 4 variable traits, not 8 total
+        pca_dir = tmp_path / "data" / "pca"
+        loadings = pd.read_csv(pca_dir / "loadings.csv", index_col=0)
+        assert (
+            loadings.shape[0] == 4
+        ), f"Expected 4 rows (variable traits only), got {loadings.shape[0]}"
+
+    def test_pca_with_all_zero_variance_traits(
+        self, config_zv, data_all_zero_variance, prev_result_all_zv, tmp_path
+    ):
+        """PCA step raises ValueError when ALL traits are constant."""
+        step = PCAAnalysisStep()
+
+        with pytest.raises(ValueError, match="zero variance"):
+            step.execute(
+                data=data_all_zero_variance,
+                config=config_zv,
+                run_dir=tmp_path,
+                prev_result=prev_result_all_zv,
+            )
+
+    # --- Task 2: Metadata and logging tests ---
+
+    def test_pca_zero_variance_metadata_tracking(
+        self, config_zv, data_with_some_zero_variance, prev_result_zv, tmp_path
+    ):
+        """Metadata tracks which traits were excluded due to zero variance."""
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=data_with_some_zero_variance,
+            config=config_zv,
+            run_dir=tmp_path,
+            prev_result=prev_result_zv,
+        )
+
+        # New metadata keys must be present
+        assert "excluded_zero_variance_traits" in result.metadata
+        assert "n_traits_after_filtering" in result.metadata
+
+        excluded = result.metadata["excluded_zero_variance_traits"]
+        n_after = result.metadata["n_traits_after_filtering"]
+
+        # Exactly 4 constant traits should be excluded
+        assert len(excluded) == 4
+        assert set(excluded) == {
+            "lateral_count_day0",
+            "lateral_length_day0",
+            "secondary_count_day0",
+            "tip_angle_day0",
+        }
+        # 4 variable traits should remain
+        assert n_after == 4
+
+    def test_pca_zero_variance_warning_threshold(
+        self, config_zv, data_majority_zero_variance, prev_result_majority_zv, tmp_path
+    ):
+        """UserWarning emitted when >50% of traits are zero-variance."""
+        step = PCAAnalysisStep()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            step.execute(
+                data=data_majority_zero_variance,
+                config=config_zv,
+                run_dir=tmp_path,
+                prev_result=prev_result_majority_zv,
+            )
+
+        user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
+        assert len(user_warnings) >= 1, "Expected UserWarning for >50% zero-variance"
+        assert "zero variance" in str(user_warnings[0].message).lower()
+
+    def test_pca_no_warning_below_threshold(
+        self, config_zv, data_with_some_zero_variance, prev_result_zv, tmp_path
+    ):
+        """No UserWarning when <=50% of traits are zero-variance."""
+        step = PCAAnalysisStep()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            step.execute(
+                data=data_with_some_zero_variance,
+                config=config_zv,
+                run_dir=tmp_path,
+                prev_result=prev_result_zv,
+            )
+
+        # 4 of 8 traits = 50%, which is NOT >50%, so no warning
+        user_warnings = [x for x in w if issubclass(x.category, UserWarning)]
+        zero_var_warnings = [
+            x for x in user_warnings if "zero variance" in str(x.message).lower()
+        ]
+        assert (
+            len(zero_var_warnings) == 0
+        ), "Should not warn when <=50% traits are zero-variance"
+
+    # --- Task 3: Feature selection correctness tests ---
+
+    def test_pca_top_features_use_filtered_names(
+        self, config_zv, data_with_some_zero_variance, prev_result_zv, tmp_path
+    ):
+        """Top features should be actual feature names used in PCA, not original indices."""
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=data_with_some_zero_variance,
+            config=config_zv,
+            run_dir=tmp_path,
+            prev_result=prev_result_zv,
+        )
+
+        top_features = result.metadata["top_features"]
+        variable_traits = {
+            "primary_root_length",
+            "lateral_root_density",
+            "network_area",
+            "root_depth",
+        }
+        constant_traits = {
+            "lateral_count_day0",
+            "lateral_length_day0",
+            "secondary_count_day0",
+            "tip_angle_day0",
+        }
+
+        # All top features must be from variable traits (actually used in PCA)
+        for feat in top_features:
+            assert feat in variable_traits, (
+                f"Top feature '{feat}' is not a variable trait — "
+                f"may be indexing into original trait_cols instead of filtered names"
+            )
+        # No constant trait should appear in top features
+        for feat in top_features:
+            assert feat not in constant_traits
+
+    def test_pca_loadings_csv_index_matches_features(
+        self, config_zv, data_with_some_zero_variance, prev_result_zv, tmp_path
+    ):
+        """Saved loadings.csv index must match the features actually used in PCA."""
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=data_with_some_zero_variance,
+            config=config_zv,
+            run_dir=tmp_path,
+            prev_result=prev_result_zv,
+        )
+
+        pca_dir = tmp_path / "data" / "pca"
+        loadings = pd.read_csv(pca_dir / "loadings.csv", index_col=0)
+
+        variable_traits = {
+            "primary_root_length",
+            "lateral_root_density",
+            "network_area",
+            "root_depth",
+        }
+
+        # Index should be exactly the 4 variable trait names
+        assert set(loadings.index) == variable_traits, (
+            f"Loadings index {set(loadings.index)} does not match "
+            f"expected variable traits {variable_traits}"
+        )

--- a/tests/test_viz_pipeline_zero_variance.py
+++ b/tests/test_viz_pipeline_zero_variance.py
@@ -1,0 +1,190 @@
+"""Integration tests: VizPipeline with zero-variance traits.
+
+Verifies that the full visualization pipeline runs end-to-end when
+the input dataset contains constant (zero-variance) trait columns.
+Addresses GitHub Issue #74.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sleap_roots_analyze.pipeline import VizPipelineConfig
+from sleap_roots_analyze.pipeline.pipelines.viz_pipeline import VizPipeline
+
+
+@pytest.fixture
+def csv_with_zero_variance_traits(tmp_path):
+    """Create a CSV file with a mix of variable and constant traits.
+
+    Mimics the Alfalfa GWAS scenario from Issue #74:
+    - 4 variable traits with realistic plant phenotyping variation
+    - 4 constant traits (zero variance) simulating early-stage measurements
+    - 60 samples across 4 genotypes with 5 replicates each
+    """
+    np.random.seed(42)
+    n_genotypes = 4
+    n_reps = 5
+    n_samples = n_genotypes * n_reps * 3  # 60 samples
+
+    genotypes = []
+    reps = []
+    for g in range(n_genotypes):
+        for r in range(n_reps):
+            for _ in range(3):
+                genotypes.append(f"GEN_{g:02d}")
+                reps.append(r + 1)
+
+    data = {
+        "Barcode": [f"S{i:03d}" for i in range(n_samples)],
+        "Genotype": genotypes,
+        "Replicate": reps,
+        # 4 variable traits with genotype-dependent means
+        "primary_root_length": [
+            np.random.normal(10 + int(g.split("_")[1]) * 2, 2.0) for g in genotypes
+        ],
+        "lateral_root_density": [
+            np.random.normal(3 + int(g.split("_")[1]) * 0.5, 0.8) for g in genotypes
+        ],
+        "network_area": [
+            np.random.normal(100 + int(g.split("_")[1]) * 10, 15.0) for g in genotypes
+        ],
+        "root_depth": [
+            np.random.normal(8 + int(g.split("_")[1]), 1.5) for g in genotypes
+        ],
+        # 4 constant traits (zero variance) — all seedlings identical
+        "lateral_count_day0": np.full(n_samples, 1.0),
+        "lateral_length_day0": np.full(n_samples, 0.0),
+        "secondary_count_day0": np.full(n_samples, 0.0),
+        "tip_angle_day0": np.full(n_samples, 45.0),
+    }
+
+    df = pd.DataFrame(data)
+    csv_path = tmp_path / "test_zero_variance.csv"
+    df.to_csv(csv_path, index=False)
+    return csv_path
+
+
+@pytest.fixture
+def viz_config_for_zero_variance(csv_with_zero_variance_traits):
+    """VizPipelineConfig with PCA enabled, optional steps disabled."""
+    config = VizPipelineConfig(pipeline_name="test_zero_variance_viz")
+    config.data.csv_path = str(csv_with_zero_variance_traits)
+    config.columns.barcode = "Barcode"
+    config.columns.genotype = "Genotype"
+    config.columns.replicate = "Replicate"
+
+    # PCA: request 2 components, top 3 features
+    config.pca.n_components = 2
+    config.pca.standardize = True
+    config.pca.n_top_features = 3
+    config.pca.feature_selection_strategy = "top_absolute"
+
+    # Statistics needed for PCA step dependency
+    config.statistics.calculate_anova = True
+    config.statistics.calculate_heritability = True
+
+    # Disable optional steps to keep test fast and focused
+    config.umap.enabled = False
+    config.clustering.enabled = False
+    config.heritability.enabled = False
+    config.interesting_genotypes.enabled = False
+    config.interactive_viz.enabled = False
+    config.dashboard.enabled = False
+
+    # Enable static viz to test PCA figures don't crash
+    config.static_viz.enabled = True
+
+    return config
+
+
+class TestVizPipelineZeroVariance:
+    """Integration tests: VizPipeline with zero-variance traits (Issue #74)."""
+
+    def test_viz_pipeline_completes_with_zero_variance_traits(
+        self, viz_config_for_zero_variance, tmp_path
+    ):
+        """Full viz pipeline succeeds when some traits have zero variance."""
+        pipeline = VizPipeline(
+            viz_config_for_zero_variance,
+            output_dir=tmp_path / "viz_runs",
+            validate=False,
+        )
+        results = pipeline.run()
+
+        # All 12 steps should complete
+        assert len(results) == 12
+        for step_name, result in results.items():
+            assert result.data is not None, f"{step_name} returned no data"
+
+        summary = pipeline.get_summary()
+        assert summary.status == "success"
+
+    def test_viz_pipeline_pca_metadata_propagates_to_figures(
+        self, viz_config_for_zero_variance, tmp_path
+    ):
+        """PCA metadata (filtered feature names) propagates correctly to figure step."""
+        pipeline = VizPipeline(
+            viz_config_for_zero_variance,
+            output_dir=tmp_path / "viz_runs",
+            validate=False,
+        )
+        results = pipeline.run()
+
+        # PCA step metadata should have the new fields
+        pca_result = results["03_pca_analysis"].data
+        assert "excluded_zero_variance_traits" in pca_result.metadata
+        assert "n_traits_after_filtering" in pca_result.metadata
+
+        excluded = pca_result.metadata["excluded_zero_variance_traits"]
+        n_after = pca_result.metadata["n_traits_after_filtering"]
+
+        assert len(excluded) == 4  # 4 constant traits
+        assert n_after == 4  # 4 variable traits remain
+
+        # The figure generation step should have completed successfully
+        # (it would have crashed if it received mismatched dimensions)
+        figures_result = results["09_generate_static_figures"]
+        assert figures_result.data is not None
+
+        # Figures directory should exist and contain PCA plots
+        figures_dir = pipeline.run_dir / "figures"
+        assert figures_dir.exists()
+
+    def test_viz_pipeline_loadings_csv_dimensions_match(
+        self, viz_config_for_zero_variance, tmp_path
+    ):
+        """Loadings CSV has rows for variable traits only, not all original traits."""
+        pipeline = VizPipeline(
+            viz_config_for_zero_variance,
+            output_dir=tmp_path / "viz_runs",
+            validate=False,
+        )
+        pipeline.run()
+
+        # Find the loadings CSV in the run directory
+        loadings_path = pipeline.run_dir / "data" / "pca" / "loadings.csv"
+        assert loadings_path.exists(), f"loadings.csv not found at {loadings_path}"
+
+        loadings = pd.read_csv(loadings_path, index_col=0)
+
+        # Should have 4 rows (variable traits), not 8 (all original traits)
+        assert loadings.shape[0] == 4, (
+            f"Expected 4 rows (variable traits only), got {loadings.shape[0]}. "
+            f"Index: {list(loadings.index)}"
+        )
+
+        # Index should be the variable trait names
+        variable_traits = {
+            "primary_root_length",
+            "lateral_root_density",
+            "network_area",
+            "root_depth",
+        }
+        assert set(loadings.index) == variable_traits
+
+        # Should have 2 columns (PC1, PC2) matching config.pca.n_components
+        assert loadings.shape[1] == 2
+        assert list(loadings.columns) == ["PC1", "PC2"]


### PR DESCRIPTION
## Summary
- Fix shape mismatch crash in `PCAAnalysisStep` when input data contains zero-variance (constant) traits
- Use post-filtering `feature_names` from `perform_pca_analysis()` instead of unfiltered `trait_cols` for loadings index, feature count, and feature name mapping
- Add logging of excluded traits, `UserWarning` when >50% traits are zero-variance, and metadata keys (`excluded_zero_variance_traits`, `n_traits_after_filtering`) for reproducibility

Closes #74

## Root Cause
`perform_pca_analysis()` silently drops zero-variance columns during standardization, returning a loadings matrix with fewer rows than the original trait list. The `PCAAnalysisStep` was using `trait_cols` (unfiltered) to index into the loadings matrix, causing a `ValueError: Shape of passed values is (N, K), indices imply (M, K)` where M > N.

## Changes
- **`src/sleap_roots_analyze/pipeline/steps/pca_analysis.py`**: 3 bug fixes (use `feature_names` instead of `trait_cols`), plus logging/warning/metadata additions
- **`tests/test_step_pca_analysis.py`**: 7 new unit tests in `TestPCAZeroVarianceHandling` class (TDD red/green)
- **`tests/test_viz_pipeline_zero_variance.py`**: 3 new integration tests running full 12-step VizPipeline with zero-variance data
- **`openspec/changes/fix-pca-zero-variance-crash/`**: OpenSpec proposal, tasks, and spec delta

## Test plan
- [x] 7 unit tests cover: shape mismatch fix, all-zero-variance error, metadata tracking, warning threshold, no-warning below threshold, top features correctness, loadings CSV index
- [x] 3 integration tests cover: full pipeline completion, metadata propagation to figure generation, loadings CSV dimensions
- [x] All 13 existing `TestPCAAnalysisStep` tests pass unchanged (no regressions)
- [x] Full suite: 1893 passed, 6 flaky (pre-existing, pass in isolation)
- [x] Linting (`ruff check`) and formatting (`black --check`) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)