### PR TITLE
Release v0.1.0a2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0a2] - 2026-03-18 (Pre-release)
+
 ### Fixed
 - Forward sanitized column names (`Genotype`, `Replicate`) from `CleanupTraitsStep`
   to `apply_data_cleanup_filters()` so `02_removed_samples_detail.csv` contains

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sleap-roots-analyze"
-version = "0.1.0a1"
+version = "0.1.0a2"
 description = "Analyze, visualize, and interpret root traits output from sleap-roots."
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Release v0.1.0a2

### Version Bump
Bumps version from `0.1.0a1` to `0.1.0a2`.

### Changes in this release
- Fix NaN-removed sample traceability (key mismatch in `apply_data_cleanup_filters()` caused `02_removed_samples_detail.csv` to always be header-only)
- Fix `CleanupTraitsStep` to forward sanitized column names (`Genotype`, `Replicate`) so removed samples detail contains correct values
- Fix `removed_samples` cleanup log to be an independent deep copy (not a mutable alias)
- Remove dead `removed_sample_indices` code from `cleanup_traits.py`
- Fix `from src.sleap_roots_analyze` import path in test files

### Pre-Release Checklist
- [x] All tests pass locally (1949 passing)
- [x] Linting checks pass (`black`, `ruff`)
- [x] Build artifacts verified (`uv build`)
- [x] Package installs correctly from wheel (`Version: 0.1.0a2`)
- [x] CLI entry point works (`sleap-roots-analyze --help`)
- [x] CHANGELOG.md updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)