### PR TITLE
Adopt canonical subagent-team review-pr; restore pre-merge Phase 3.5

### DIFF
--- a/.claude/commands/pre-merge-check.md
+++ b/.claude/commands/pre-merge-check.md
@@ -39,8 +39,8 @@ Run `/review-pr` on the **local branch diff** (no PR exists yet, so it runs in p
 reviews `git diff origin/main...HEAD`). This launches the subagent review team — Code Quality,
 Testing, Statistical Rigor, Performance/Memory, and Behavioural Correctness — against the change
 the same way it would review an external PR, and reports findings locally without posting.
-(`/code-review` remains available as a lighter single-pass alternative; `/review-openspec` covers
-an in-flight OpenSpec proposal.)
+(`/code-review` — a built-in skill, not a repo command — remains available as a lighter
+single-pass alternative; `/review-openspec` covers an in-flight OpenSpec proposal.)
 
 **Rationale:** Copilot reliably flags exactly what this team would catch (e.g. a test that
 bypasses the path it was meant to regression-test). Running our own review pre-PR fixes those

--- a/.claude/commands/pre-merge-check.md
+++ b/.claude/commands/pre-merge-check.md
@@ -35,13 +35,14 @@ Confirm the associated OpenSpec tasks are checked off (`openspec list`).
 
 ## Phase 3.5: Pre-PR self-review (do this BEFORE creating the PR)
 
-Critically review the **local branch diff** before the PR exists. Run `/code-review` on the
-current diff (and `/review-openspec` if an OpenSpec change is in flight) to surface
-correctness, test-gap, and maintainability issues, applying the same severity rubric used for
-PR comments (CRITICAL / IMPORTANT / nice-to-have). `/review-pr` itself triages comments on an
-*existing* PR, so it belongs to Phase 6 — this phase is the pre-PR equivalent.
+Run `/review-pr` on the **local branch diff** (no PR exists yet, so it runs in pre-PR mode and
+reviews `git diff origin/main...HEAD`). This launches the subagent review team — Code Quality,
+Testing, Statistical Rigor, Performance/Memory, and Behavioural Correctness — against the change
+the same way it would review an external PR, and reports findings locally without posting.
+(`/code-review` remains available as a lighter single-pass alternative; `/review-openspec` covers
+an in-flight OpenSpec proposal.)
 
-**Rationale:** Copilot reliably flags exactly what a diff review would catch (e.g. a test that
+**Rationale:** Copilot reliably flags exactly what this team would catch (e.g. a test that
 bypasses the path it was meant to regression-test). Running our own review pre-PR fixes those
 in one iteration instead of two, and avoids burning a Copilot review cycle. If any BLOCKING /
 IMPORTANT findings come back, fix them and restart from Phase 1.
@@ -96,7 +97,7 @@ git fetch origin main && git merge-base --is-ancestor origin/main HEAD   # branc
 ## Code Quality:  [x] black  [x] ruff
 ## Tests:         [x] pytest (X passed)  [x] coverage
 ## OpenSpec:      [x] validated (or N/A)
-## Self-review:   [x] /code-review clean (or findings fixed)
+## Self-review:   [x] /review-pr clean (or findings fixed)
 ## PR:            [x] #X created, checks green
 ## Copilot:       [x] CRITICAL/HIGH addressed; MEDIUM/LOW filed
 ## Changelog:     [x] entry added (or N/A)
@@ -109,8 +110,8 @@ git fetch origin main && git merge-base --is-ancestor origin/main HEAD   # branc
 - `/fix-formatting` — auto-fix formatting and lint issues
 - `/coverage` — detailed test coverage analysis
 - `/run-ci-locally` — run exact CI checks locally
-- `/code-review` — pre-PR critical review of the local diff (Phase 3.5)
-- `/review-pr` — triage human comments on an existing PR (Phase 6)
+- `/review-pr` — subagent review team: pre-PR local-diff self-review (Phase 3.5) and existing-PR review (Phase 6)
+- `/code-review` — lighter single-pass diff review alternative for Phase 3.5
 - `/copilot-review` — fetch Copilot review comments on an existing PR, repo-agnostic (Phase 6)
 - `/update-changelog` — update CHANGELOG before merge
 

--- a/.claude/commands/pre-merge-check.md
+++ b/.claude/commands/pre-merge-check.md
@@ -36,7 +36,8 @@ Confirm the associated OpenSpec tasks are checked off (`openspec list`).
 ## Phase 3.5: Pre-PR self-review (do this BEFORE creating the PR)
 
 Run `/review-pr` on the **local branch diff** (no PR exists yet, so it runs in pre-PR mode and
-reviews `git diff origin/main...HEAD`). This launches the subagent review team — Code Quality,
+reviews the diff against the repo's default branch, which `/review-pr` resolves dynamically —
+`git diff origin/<default-branch>...HEAD`, usually `origin/main`). This launches the subagent review team — Code Quality,
 Testing, Statistical Rigor, Performance/Memory, and Behavioural Correctness — against the change
 the same way it would review an external PR, and reports findings locally without posting.
 (`/code-review` — a built-in skill, not a repo command — remains available as a lighter

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -6,9 +6,9 @@ ANOVA, PCA/UMAP, outlier detection, and visualization) from SLEAP Roots phenotyp
 You value testing, code quality, reproducibility, metadata preservation, statistical
 correctness, interpretability, and performance above all else.
 
-## How This Skill Works
+## How This Command Works
 
-This skill launches **5 specialized subagents in parallel** to critically review the change.
+This command launches **5 specialized subagents in parallel** to critically review the change.
 Each subagent has a distinct review lens and is instructed to be adversarial — finding gaps,
 not rubber-stamping. After all subagents return, synthesize findings into a unified review.
 
@@ -63,8 +63,13 @@ Also read any OpenSpec proposal linked in the PR body or present on the branch (
 
 ## Step 2: Launch Subagent Review Team
 
-Launch ALL 5 subagents in a single message (parallel execution). Embed the full diff, the PR
+Launch ALL 5 subagents in a single message (parallel execution). Embed the diff, the PR
 description (or commit log in pre-PR mode), CI status, and any Copilot comments in each prompt.
+
+> **Large diffs:** embedding the full diff into all 5 prompts can exceed token limits and
+> truncate context. If the diff is large, embed only the changed-file list plus the most
+> relevant hunks, and instruct each subagent to read the specific files it needs with Read/Grep
+> (they have tool access) rather than relying on a fully inlined diff.
 
 ---
 
@@ -96,7 +101,9 @@ description: "Review code quality and architecture"
 > **Check:**
 >
 > 1. Style: PEP 8 enforced by Black (88 cols), Google-style docstrings (pydocstyle/ruff D rules),
->    `from __future__ import annotations` at the top of every module — any violations?
+>    and `from __future__ import annotations` where the module's existing convention uses it (it
+>    is not universal — e.g. `__init__.py` omits it — so only flag a *removed* or inconsistent
+>    future import, not its mere absence) — any violations?
 > 2. Type hints: are function signatures fully annotated? Any missing return types?
 > 3. Pipeline DAG: are new step classes wired into the DAG with correct inputs/outputs and
 >    dependency edges? Any cycles or orphaned nodes?
@@ -468,6 +475,7 @@ fi
 For COMMENT (no own-PR detection needed — `--comment` is always allowed):
 
 ```bash
+# BODY = the same synthesized review markdown built in the APPROVE/REQUEST_CHANGES heredocs above
 gh pr review "$PR_NUMBER" --comment -b "$(printf '> **Verdict: COMMENT**\n\n%s' "$BODY")"
 ```
 

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,85 +1,502 @@
-# Review GitHub PR Comments
+# PR Code Review — Subagent Team
 
-Review and address GitHub Copilot or human review comments on pull requests.
+You are a senior scientific programmer reviewing a pull request for sleap-roots-analyze,
+a pure Python library for analyzing root-trait data (quality control, broad-sense heritability,
+ANOVA, PCA/UMAP, outlier detection, and visualization) from SLEAP Roots phenotyping output.
+You value testing, code quality, reproducibility, metadata preservation, statistical
+correctness, interpretability, and performance above all else.
 
-## Arguments
+## How This Skill Works
 
-$ARGUMENTS
+This skill launches **5 specialized subagents in parallel** to critically review the change.
+Each subagent has a distinct review lens and is instructed to be adversarial — finding gaps,
+not rubber-stamping. After all subagents return, synthesize findings into a unified review.
 
-If a PR number is provided as an argument, use it directly. Otherwise, detect from the current branch:
+It works in **two modes**:
 
-```bash
-gh pr view --json number --jq .number
-```
+- **PR mode** — an argument PR number is given, or the current branch has an open PR. The
+  review is posted to GitHub.
+- **Pre-PR mode** — no PR exists yet (e.g. invoked from `/pre-merge-check` Phase 3.5). The
+  change under review is the local branch diff and findings are reported locally (nothing is
+  posted).
 
-## Step 1: Fetch PR Comments
+## Step 1: Gather Change Context
 
-```bash
-# View PR with comments
-gh pr view <PR_NUMBER> --comments
-
-# Get inline code review comments with file paths and line numbers
-gh api repos/talmolab/sleap-roots-analyze/pulls/<PR_NUMBER>/comments --jq '.[] | {path: .path, line: .line, body: .body}'
-
-# Get review summaries
-gh api repos/talmolab/sleap-roots-analyze/pulls/<PR_NUMBER>/reviews --jq '.[].body'
-```
-
-## Step 2: Categorize Comments
-
-Organize comments by priority:
-
-### Critical (Must Fix)
-- Data consistency issues
-- Broken functionality
-- Security issues
-- Incorrect statistical calculations
-
-### Important (Should Fix)
-- API inconsistencies
-- Missing or incorrect tests
-- Type safety violations
-- Code maintainability issues
-- Misleading documentation
-
-### Nice to Have (Consider)
-- Code quality improvements
-- Style improvements
-- Performance optimizations (unless critical)
-- Additional features
-- Documentation enhancements
-
-## Step 3: Create Action Plan
-
-1. **List all comments** with their locations (file:line)
-2. **Prioritize** by severity (Critical > Important > Nice to Have)
-3. **Group related changes** (e.g., all import fixes together)
-4. **Identify already-fixed** issues from previous commits
-5. **Test after each group** of changes
-6. **Document decisions** if not implementing a suggestion
-
-## Step 4: Implement Fixes
-
-1. Fix Critical issues first, run tests, commit
-2. Fix Important issues, run tests, commit
-3. Consider Nice to Have items - implement or note for future
-
-## Step 5: Respond to Review
-
-After addressing comments:
+Detect the mode and the repo (owner/name stay dynamic — never hardcode the repository):
 
 ```bash
-# Post a comment summarizing changes
-gh pr comment <PR_NUMBER> --body "Addressed review comments:
-- Fixed [summary of critical fixes]
-- Updated [summary of important fixes]
-- Noted [items deferred to future work]
-"
+REPO_OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO_NAME=$(gh repo view --json name --jq '.name')
+
+# Resolve a PR number from the argument or the current branch (empty => pre-PR mode)
+PR_NUMBER="${1:-$(gh pr view --json number --jq '.number' 2>/dev/null)}"
 ```
 
-## Integration
+**PR mode** (`$PR_NUMBER` is set) — run in parallel to collect everything the subagents need:
 
-- Run `/lint` after fixes to verify code style
-- Run `/coverage` to check test coverage after adding tests
-- Run `/run-ci-locally` to verify full CI passes
-- Use `/pre-merge-check` for comprehensive pre-merge verification
+```bash
+gh pr view "$PR_NUMBER" --json title,body,baseRefName,headRefName,author,labels,files
+gh pr diff "$PR_NUMBER"
+gh pr checks "$PR_NUMBER"
+
+# Existing Copilot review comments (matches the bot and the Copilot user)
+gh api "repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUMBER/comments" \
+  --jq '.[] | select(.user.login | contains("opilot")) | "File: \(.path):\(.line // .original_line)\n\(.body)"'
+```
+
+**Pre-PR mode** (`$PR_NUMBER` empty) — the change is the local branch diff:
+
+```bash
+git fetch origin main --quiet
+git diff origin/main...HEAD          # the change under review (PR_DIFF)
+git log --oneline origin/main..HEAD  # commit-level intent (PR_BODY substitute)
+```
+
+Also read any OpenSpec proposal linked in the PR body or present on the branch (look for
+`openspec/changes/` paths) so the review is checked against the stated requirements.
+
+## Step 2: Launch Subagent Review Team
+
+Launch ALL 5 subagents in a single message (parallel execution). Embed the full diff, the PR
+description (or commit log in pre-PR mode), CI status, and any Copilot comments in each prompt.
+
+---
+
+### Subagent 1: Code Quality & Architecture
+
+```
+subagent_type: "general-purpose"
+description: "Review code quality and architecture"
+```
+
+**Prompt:**
+
+> You are reviewing a change for sleap-roots-analyze, a pure Python root-trait analysis library.
+> Your role: **Code Quality & Architecture Reviewer**.
+> Be adversarial. Read actual source files. Find real problems, not hypotheticals.
+>
+> Architecture overview:
+>
+> - Pure Python library consumed via a CLI (`sleap_roots_analyze.cli`) and Python API.
+> - Analysis built on pandas / numpy / scikit-learn / scipy / statsmodels.
+> - QC workflows run as a **NetworkX DAG pipeline** of step classes under
+>   `src/sleap_roots_analyze/pipeline/` (orchestrated by `pipeline_runner.py`).
+> - Trait/stat logic lives in modules like `statistics.py` (heritability, ANOVA), `pca.py`,
+>   `umap.py`, `outlier_detection.py`, `clustering.py`, `data_cleanup.py`, `data_utils.py`.
+> - Configuration is **omegaconf** YAML validated by `validate_qc_config()` /
+>   `validate_viz_config()`; analyses are scaffolded from golden templates in `configs/`.
+> - There is NO SLEAP `.slp`/`.h5` loading here — input is trait **CSV** data.
+>
+> **Check:**
+>
+> 1. Style: PEP 8 enforced by Black (88 cols), Google-style docstrings (pydocstyle/ruff D rules),
+>    `from __future__ import annotations` at the top of every module — any violations?
+> 2. Type hints: are function signatures fully annotated? Any missing return types?
+> 3. Pipeline DAG: are new step classes wired into the DAG with correct inputs/outputs and
+>    dependency edges? Any cycles or orphaned nodes?
+> 4. Magic numbers/strings: are statistical constants/thresholds named and co-located, or
+>    are they hardcoded inline?
+> 5. Pandas/numpy idioms: are operations vectorized? Any row-wise `apply`/Python loops that
+>    should be vectorized? Any chained-assignment / `SettingWithCopyWarning` risks?
+> 6. Suppression justification: any `# type: ignore`, `# noqa`, `np.errstate`,
+>    `pd.option_context`, or `warnings.filterwarnings` added? Each must have a comment explaining why.
+> 7. Error handling: are errors surfaced with meaningful messages or silently swallowed?
+> 8. Ripple effects: are there impacts in files NOT changed by the change? (read them)
+> 9. Dead code: does the change introduce unreachable branches, unused imports, or stale comments?
+> 10. Config schema: if new config fields are added, are they validated and documented in the
+>     golden templates?
+>
+> **Diff:**
+> {PR_DIFF}
+>
+> **Description / intent:**
+> {PR_BODY}
+>
+> Read any source files you need using the Read/Grep tools. Return:
+>
+> - BLOCKING issues (wrong types, broken DAG wiring, swallowed errors, unvalidated config)
+> - IMPORTANT issues (code smell, missing constants, unclear logic, unjustified suppressions)
+> - SUGGESTIONS (style, readability, pandas/numpy idiom improvements)
+> - Overall code quality score 1-10 with justification
+
+---
+
+### Subagent 2: Testing Strategy & TDD Discipline
+
+```
+subagent_type: "general-purpose"
+description: "Review testing strategy and TDD discipline"
+```
+
+**Prompt:**
+
+> You are reviewing a change for sleap-roots-analyze.
+> Your role: **Testing Strategy & TDD Discipline Reviewer**.
+> Be adversarial. Check every claim. Run mental red-green-refactor on the diff.
+>
+> **Testing infrastructure:**
+>
+> - **pytest** (`tests/`): unit tests in `test_*.py`; pipeline integration tests (e.g.
+>   `test_grouped_pipeline_*`, `test_dag.py`); fixtures in `tests/fixtures*.py` and
+>   `tests/conftest.py`; sample inputs under `tests/data/`.
+> - **Coverage**: pytest-cov via `--cov=src/sleap_roots_analyze`.
+> - **CI matrix**: tests run on **Ubuntu, Windows, and macOS** with **Python 3.11** — tests must
+>   pass on all three. Lint (Black + Ruff) runs on Ubuntu.
+>
+> **Check:**
+>
+> 1. Were tests written BEFORE implementation (TDD)? Evidence: test files in earlier commits?
+> 2. Is the RIGHT test level used? Pure stat/trait logic -> unit test in `test_<module>.py`;
+>    full pipeline -> a `test_*_pipeline_*.py` integration test.
+> 3. Are tests specific enough? ("returns NaN for an all-NaN trait column" not "works correctly")
+> 4. Missing tests — check each of these:
+>    - Empty / single-row inputs (zero samples, one genotype, one replicate)
+>    - All-NaN and partially-NaN trait columns
+>    - Small groups below statistical thresholds (n < 30 for Mahalanobis; < 3 replicates for H²)
+>    - Grouped vs ungrouped analysis paths
+>    - Metadata preservation through pipeline DAG stages
+>    - CSV output schema/column stability
+> 5. Will tests pass in CI on all three OSes? (no hardcoded paths, no platform-specific assumptions,
+>    deterministic seeds for stochastic steps like UMAP/Isolation Forest)
+> 6. Do existing tests break due to the change? (read `tests/` for impacted files)
+> 7. Are fixtures realistic? (do they use representative trait CSVs from `tests/data/`?)
+> 8. Is there a 1:1 mapping between OpenSpec spec scenarios and tests?
+>
+> **Diff:**
+> {PR_DIFF}
+>
+> **CI status:**
+> {CI_STATUS}
+>
+> Read existing test files using Glob/Read tools before concluding. Return:
+>
+> - BLOCKING: missing tests for new code paths, tests that won't run in CI, existing tests broken
+> - IMPORTANT: wrong test level, vague test descriptions, missing edge cases, non-deterministic tests
+> - SUGGESTIONS: additional coverage, test refactors
+> - TDD verdict: was red-green-refactor actually followed?
+
+---
+
+### Subagent 3: Statistical Rigor & Reproducibility
+
+```
+subagent_type: "general-purpose"
+description: "Review statistical rigor and reproducibility"
+```
+
+**Prompt:**
+
+> You are reviewing a change for sleap-roots-analyze, a library plant biologists use to compute
+> statistics and quality control on root phenotyping traits.
+> Your role: **Statistical Rigor & Reproducibility Reviewer**.
+> Be adversarial. Mistakes in statistics, thresholds, or metadata can invalidate research.
+>
+> **Core scientific values:**
+>
+> 1. **Statistical correctness** — heritability (H²), ANOVA, PCA, UMAP, and outlier detection
+>    (Mahalanobis distance, Isolation Forest, PCA reconstruction) must be computed correctly and
+>    use appropriate assumptions. Reference published methods where applicable.
+> 2. **Threshold validity** — Mahalanobis chi-squared reliability needs n ≥ 30 per group;
+>    broad-sense heritability needs ≥ 3 replicates per genotype. Multiple-comparison correction
+>    (FDR) must be applied where many traits are tested. Power/CI reporting must be sound.
+> 3. **Reproducibility** — analyses are pinned to a git SHA via committed configs; stochastic
+>    steps (UMAP, Isolation Forest, train/test splits) must set explicit random seeds.
+> 4. **Metadata preservation** — dataset identity, parameters, and config provenance must flow
+>    through the pipeline and appear in output so a CSV row traces back to its source + config.
+> 5. **Data format stability** — output CSV column names/ordering and metadata JSON fields must
+>    not change silently; downstream scripts depend on them.
+> 6. **Numerical stability** — NaN propagation must be deliberate; float comparisons must not use
+>    `==`; any warning suppression that hides numerical issues must be justified.
+>
+> **Check:**
+>
+> 1. Are statistical computations correct? Trace the algorithm (e.g. H² variance components,
+>    ANOVA model terms, Mahalanobis covariance inversion, PCA scaling) step by step.
+> 2. Are method references / assumptions documented? Is FDR applied to multi-trait testing?
+> 3. Are the n ≥ 30 (Mahalanobis) and ≥ 3 replicates (H²) guardrails respected, with WARNINGs
+>    when violated rather than silently producing unreliable numbers?
+> 4. Are random seeds set for every stochastic step so results are reproducible?
+> 5. Could this change alter previously published results (changed thresholds, defaults, or
+>    formulas)? If so, is it documented as a breaking change with a migration note?
+> 6. Is metadata (dataset, params, config SHA) preserved through pipeline stages into output?
+> 7. How is NaN handled — filtered, imputed, or propagated? Is the choice scientifically defensible
+>    and documented?
+> 8. Does the change modify output CSV columns/order or metadata JSON fields? If so, documented?
+>
+> **Diff:**
+> {PR_DIFF}
+>
+> **Description / intent:**
+> {PR_BODY}
+>
+> Return:
+>
+> - BLOCKING: incorrect statistics, violated reliability thresholds without warning, unseeded
+>   stochastic steps, silent output-format breakage, missing metadata
+> - IMPORTANT: missing references/assumptions, missing FDR, NaN-handling gaps
+> - SUGGESTIONS: additional validation, documentation, reference citations
+
+---
+
+### Subagent 4: Performance, Memory & Cross-Platform
+
+```
+subagent_type: "general-purpose"
+description: "Review performance, memory, and cross-platform safety"
+```
+
+**Prompt:**
+
+> You are reviewing a change for sleap-roots-analyze.
+> Your role: **Performance, Memory & Cross-Platform Reviewer**.
+> Be adversarial. Check every loop, every allocation, every path operation.
+>
+> The library processes trait tables that can reach thousands of samples × dozens-to-hundreds of
+> trait columns, plus PCA/UMAP/clustering over those matrices. Memory and performance matter, and
+> CI runs on Ubuntu, Windows, and macOS.
+>
+> **Check:**
+>
+> Performance:
+>
+> 1. Are pandas/numpy operations vectorized? Any `DataFrame.apply(axis=1)` or Python loops over
+>    rows/columns that should be vectorized?
+> 2. Redundant recomputation: is the same expensive result (e.g. a covariance matrix, a PCA fit)
+>    computed multiple times when it could be reused via the pipeline DAG?
+> 3. Are sklearn estimators fit once and reused rather than re-fit per call?
+>
+> Memory:
+>
+> 4. Does the code copy large DataFrames unnecessarily (`.copy()` in hot paths) where a view or
+>    in-place op would do?
+> 5. Are intermediate matrices (distance matrices, reconstructions) materialized at full size when
+>    they could be batched?
+>
+> Cross-Platform:
+>
+> 6. Are file paths built with `pathlib.Path` — never string concatenation or hardcoded `/`/`\`?
+> 7. Any platform-specific behavior (line endings, file encodings, temp dirs, case sensitivity,
+>    matplotlib backends) that would fail on Windows or macOS CI?
+> 8. Check CI status for platform-specific failures.
+>
+> Determinism:
+>
+> 9. `warnings.filterwarnings` and matplotlib global state are process-global. If the change adds
+>    or modifies them, could this leak into other code or tests?
+>
+> **Diff:**
+> {PR_DIFF}
+>
+> **CI status:**
+> {CI_STATUS}
+>
+> Return:
+>
+> - BLOCKING: OOM risks on large trait tables, row-wise loops where vectorization is required,
+>   path handling that breaks on Windows/macOS
+> - IMPORTANT: unnecessary copies, redundant fits, platform-specific assumptions, global-state leaks
+> - SUGGESTIONS: vectorization opportunities, memory optimizations, caching improvements
+
+---
+
+### Subagent 5: Behavioural Correctness & Edge Cases
+
+```
+subagent_type: "general-purpose"
+description: "Review behavioural correctness and edge cases"
+```
+
+**Prompt:**
+
+> You are reviewing a change for sleap-roots-analyze.
+> Your role: **Behavioural Correctness & Edge Case Reviewer**.
+> Be adversarial. Play adversarial user. Try to break the feature with pathological inputs.
+>
+> Focus on: does the implementation actually do what the spec/PR description claims?
+> The library must be robust to the messy reality of phenotyping data — missing trait values
+> (NaN), tiny genotype groups, single-replicate genotypes, all-identical columns, and configs
+> with unusual but valid field combinations.
+>
+> **Check:**
+>
+> 1. Read the stated behaviour (PR description / OpenSpec scenarios). Now read the diff. Does the
+>    code actually implement what it claims?
+> 2. Trace the full call chain for each new feature through the pipeline DAG (load CSV -> clean ->
+>    stats/PCA/UMAP/outliers -> output).
+> 3. What happens with pathological inputs?
+>    - Empty table (zero samples) or single sample?
+>    - All-NaN or constant (zero-variance) trait columns?
+>    - Groups below thresholds (n < 30 for Mahalanobis; < 3 replicates for H²)?
+>    - A genotype with one replicate; a group with one genotype?
+>    - Configs missing optional fields, or with `group_by` set to a non-existent column?
+> 4. Does the code return scientifically defensible results under partial failure — NaN/empty out,
+>    not zeros, silent drops, or crashes? Are guardrail WARNINGs emitted rather than swallowed?
+> 5. Pipeline error propagation: if one step fails or yields NaN, do downstream DAG steps handle
+>    it gracefully?
+> 6. Config validation: are invalid configs rejected by `validate_qc_config()` /
+>    `validate_viz_config()` with actionable messages before any computation runs?
+> 7. Idempotency/statelessness: are pipeline steps pure (same input + config -> same output)? Any
+>    hidden mutable/global state or in-place mutation of shared inputs?
+> 8. Does any existing Copilot comment raise an issue not yet addressed?
+>
+> **Diff:**
+> {PR_DIFF}
+>
+> **Description / intent:**
+> {PR_BODY}
+>
+> **Existing Copilot review comments:**
+> {COPILOT_COMMENTS}
+>
+> Read source files as needed using Read/Grep tools. Return:
+>
+> - BLOCKING: spec-implementation mismatches, crashes on empty/NaN input, silent data drops,
+>   unreliable stats emitted without warning
+> - IMPORTANT: edge cases not handled, NaN-propagation gaps, statelessness violations
+> - SUGGESTIONS: defensive guards, additional input validation, robustness improvements
+
+---
+
+## Step 3: Synthesize and Post Review
+
+After ALL subagents return:
+
+1. **Deduplicate** overlapping findings.
+2. **Prioritize**:
+   - **BLOCKING** — must fix before merge (incorrect statistics, broken tests, spec mismatch, data loss)
+   - **IMPORTANT** — should fix before merge (missing edge cases, NaN gaps, platform/reproducibility risks)
+   - **SUGGESTION** — optional improvements
+3. **Determine verdict**:
+   - `APPROVE` — no blocking issues, all important issues are minor
+   - `COMMENT` — no blocking issues but important items worth noting
+   - `REQUEST_CHANGES` — any blocking issues present
+
+### Pre-PR mode
+
+If there is no PR yet (invoked from `/pre-merge-check` Phase 3.5), **do not post**. Print the
+synthesized, severity-ranked review to the user so BLOCKING / IMPORTANT items can be fixed before
+the PR is opened.
+
+### PR mode — post the review to GitHub
+
+> **Note:** GitHub does not allow requesting changes or approving your own PRs. Detect own-PR
+> upfront and, if it's yours, skip `--approve`/`--request-changes` and post a `--comment` with a
+> verdict banner. This avoids `GraphQL: Review Can not approve your own pull request` errors.
+
+**Step 1: Detect own-PR** (run once before posting):
+
+```bash
+PR_AUTHOR=$(gh pr view "$PR_NUMBER" --json author --jq '.author.login')
+GH_USER=$(gh api user --jq '.login')
+IS_OWN_PR=false
+[ "$PR_AUTHOR" = "$GH_USER" ] && IS_OWN_PR=true
+```
+
+**Step 2: Post** using the appropriate method based on `$IS_OWN_PR`.
+
+For REQUEST_CHANGES:
+
+```bash
+BODY="$(cat <<'EOF'
+## Review Summary
+
+[2-3 sentence overall assessment]
+
+## Blocking Issues
+
+[Must fix before merge]
+
+## Important Issues
+
+[Should fix before merge]
+
+## Suggestions
+
+[Optional improvements]
+
+---
+*Review by Claude Code subagent team (Code Quality · Testing · Statistical Rigor · Performance/Memory · Behavioural Correctness)*
+EOF
+)"
+
+if [ "$IS_OWN_PR" = "true" ]; then
+  gh pr review "$PR_NUMBER" --comment -b "$(printf '> **Verdict: REQUEST_CHANGES** (posted as comment — cannot request changes on your own PR)\n\n%s' "$BODY")"
+else
+  gh pr review "$PR_NUMBER" --request-changes -b "$BODY"
+fi
+```
+
+For APPROVE:
+
+```bash
+BODY="$(cat <<'EOF'
+## Review Summary
+
+[2-3 sentence assessment]
+
+## Notes
+
+[Any suggestions or minor observations]
+
+---
+*Review by Claude Code subagent team (Code Quality · Testing · Statistical Rigor · Performance/Memory · Behavioural Correctness)*
+EOF
+)"
+
+if [ "$IS_OWN_PR" = "true" ]; then
+  gh pr review "$PR_NUMBER" --comment -b "$(printf '> **Verdict: APPROVE** (posted as comment — cannot approve your own PR)\n\n%s' "$BODY")"
+else
+  gh pr review "$PR_NUMBER" --approve -b "$BODY"
+fi
+```
+
+For COMMENT (no detection needed):
+
+```bash
+gh pr review "$PR_NUMBER" --comment -b "..."
+```
+
+After posting, show the user the full synthesized review and the GitHub link.
+
+---
+
+## Domain-Specific Review Patterns
+
+### Pattern 1: Statistical / Trait Computation Changes
+
+1. **Check validation** — are calculations validated against known data or published values?
+2. **Verify assumptions** — sample-size thresholds (n ≥ 30 Mahalanobis, ≥ 3 replicates H²), FDR
+   correction, random seeds for stochastic steps.
+3. **Review edge cases** — all-NaN columns, zero-variance traits, single-replicate genotypes.
+4. **Check reproducibility** — will this change previously published results? Is it documented?
+
+### Pattern 2: New Pipeline Steps
+
+1. **Check DAG wiring** — inputs/outputs and dependency edges correct; no cycles.
+2. **Verify metadata flow** — does the step preserve dataset/config provenance into output?
+3. **Review output format** — CSV columns consistent with sibling pipelines and stable.
+4. **Check documentation** — golden templates / README updated with the new field or step.
+
+### Pattern 3: Config Schema Changes
+
+1. **Validation** — new fields rejected/accepted correctly by `validate_qc_config()` /
+   `validate_viz_config()`.
+2. **Templates** — golden templates updated and documented with rationale.
+3. **Back-compat** — do existing committed configs still validate?
+
+### Pattern 4: Bug Fixes
+
+1. **Regression test** — does a test reproduce the original bug (and fail without the fix)?
+2. **Side effects** — could the fix change other traits/stats?
+3. **Coverage** — does the fix increase coverage on the affected path?
+4. **Scope** — is the fix minimal and focused?
+
+## Tips for Effective Reviews
+
+1. **Be specific** — reference `file.py:line` and suggest concrete alternatives.
+2. **Be kind** — assume positive intent, use constructive language.
+3. **Focus on substance** — don't nitpick style (Black/Ruff handle that).
+4. **Explain why** — help the author learn, don't just point out issues.
+5. **Approve quickly** — if it's good, say so.
+6. Evaluate each finding on its merits; note why if you decline a suggestion
+   (see superpowers:receiving-code-review).

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -22,13 +22,17 @@ It works in **two modes**:
 
 ## Step 1: Gather Change Context
 
-Detect the mode and the repo (owner/name stay dynamic — never hardcode the repository):
+Detect the mode and the repo (owner / name / base branch stay dynamic — never hardcode):
 
 ```bash
 REPO_OWNER=$(gh repo view --json owner --jq '.owner.login')
 REPO_NAME=$(gh repo view --json name --jq '.name')
+BASE_BRANCH=$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name')  # usually "main"
 
-# Resolve a PR number from the argument or the current branch (empty => pre-PR mode)
+# $1 is the PR number passed to /review-pr (if any); otherwise detect the current branch's
+# open PR. An empty result means no PR exists yet => pre-PR mode. NOTE: gh failures
+# (offline / unauthenticated) also yield empty, so an unexpected pre-PR classification can
+# signal a gh/auth problem rather than a missing PR — run `gh auth status` if surprised.
 PR_NUMBER="${1:-$(gh pr view --json number --jq '.number' 2>/dev/null)}"
 ```
 
@@ -47,9 +51,11 @@ gh api "repos/$REPO_OWNER/$REPO_NAME/pulls/$PR_NUMBER/comments" \
 **Pre-PR mode** (`$PR_NUMBER` empty) — the change is the local branch diff:
 
 ```bash
-git fetch origin main --quiet
-git diff origin/main...HEAD          # the change under review (PR_DIFF)
-git log --oneline origin/main..HEAD  # commit-level intent (PR_BODY substitute)
+git fetch origin "$BASE_BRANCH" --quiet
+# three-dot `diff` = changes since the merge-base (the change under review);
+# two-dot `log` = commits on HEAD not on the base branch. Keep them distinct.
+git diff "origin/$BASE_BRANCH...HEAD"          # the change under review (PR_DIFF)
+git log --oneline "origin/$BASE_BRANCH..HEAD"  # commit-level intent (PR_BODY substitute)
 ```
 
 Also read any OpenSpec proposal linked in the PR body or present on the branch (look for
@@ -141,7 +147,8 @@ description: "Review testing strategy and TDD discipline"
 >   `tests/conftest.py`; sample inputs under `tests/data/`.
 > - **Coverage**: pytest-cov via `--cov=src/sleap_roots_analyze`.
 > - **CI matrix**: tests run on **Ubuntu, Windows, and macOS** with **Python 3.11** — tests must
->   pass on all three. Lint (Black + Ruff) runs on Ubuntu.
+>   pass on all three. Lint (Black + Ruff) runs on Ubuntu. CI runs `pytest -m "not integration"`
+>   (issue #69), so `@pytest.mark.integration` tests are NOT executed/gated in CI.
 >
 > **Check:**
 >
@@ -197,8 +204,12 @@ description: "Review statistical rigor and reproducibility"
 >    (Mahalanobis distance, Isolation Forest, PCA reconstruction) must be computed correctly and
 >    use appropriate assumptions. Reference published methods where applicable.
 > 2. **Threshold validity** — Mahalanobis chi-squared reliability needs n ≥ 30 per group;
->    broad-sense heritability needs ≥ 3 replicates per genotype. Multiple-comparison correction
->    (FDR) must be applied where many traits are tested. Power/CI reporting must be sound.
+>    broad-sense heritability needs ≥ 3 replicates per genotype. These two are surfaced as
+>    **config-authoring-time advisory warnings** (`config_authoring.py`, via `/configure-run-all`),
+>    not runtime guards inside the stat functions. Multiple-comparison correction (FDR,
+>    Benjamini-Hochberg) is applied in the **cross-experiment correlation** path
+>    (`cross_experiment_analysis.py`) — per-trait ANOVA in `statistics.py` intentionally has no
+>    FDR, so do not demand it there. Power/CI reporting must be sound.
 > 3. **Reproducibility** — analyses are pinned to a git SHA via committed configs; stochastic
 >    steps (UMAP, Isolation Forest, train/test splits) must set explicit random seeds.
 > 4. **Metadata preservation** — dataset identity, parameters, and config provenance must flow
@@ -212,9 +223,13 @@ description: "Review statistical rigor and reproducibility"
 >
 > 1. Are statistical computations correct? Trace the algorithm (e.g. H² variance components,
 >    ANOVA model terms, Mahalanobis covariance inversion, PCA scaling) step by step.
-> 2. Are method references / assumptions documented? Is FDR applied to multi-trait testing?
-> 3. Are the n ≥ 30 (Mahalanobis) and ≥ 3 replicates (H²) guardrails respected, with WARNINGs
->    when violated rather than silently producing unreliable numbers?
+> 2. Are method references / assumptions documented? Is FDR applied where many cross-experiment
+>    correlations are tested? (Per-trait ANOVA has no FDR by design — flag only if the change
+>    introduces broad multiple testing without correction.)
+> 3. Are the small-sample guardrails surfaced at config-authoring time (n ≥ 30 Mahalanobis,
+>    ≥ 3 replicates H²)? Compute-time Mahalanobis reliability is instead assessed by the χ²
+>    Kolmogorov–Smirnov goodness-of-fit test (`validate_chi_squared_distribution`) — check that,
+>    not for a runtime n<30 warning inside the outlier function.
 > 4. Are random seeds set for every stochastic step so results are reproducible?
 > 5. Could this change alter previously published results (changed thresholds, defaults, or
 >    formulas)? If so, is it documented as a breaking change with a migration note?
@@ -450,10 +465,10 @@ else
 fi
 ```
 
-For COMMENT (no detection needed):
+For COMMENT (no own-PR detection needed — `--comment` is always allowed):
 
 ```bash
-gh pr review "$PR_NUMBER" --comment -b "..."
+gh pr review "$PR_NUMBER" --comment -b "$(printf '> **Verdict: COMMENT**\n\n%s' "$BODY")"
 ```
 
 After posting, show the user the full synthesized review and the GitHub link.

--- a/openspec/changes/adopt-canonical-review-pr/proposal.md
+++ b/openspec/changes/adopt-canonical-review-pr/proposal.md
@@ -1,0 +1,39 @@
+## Why
+
+The #126 standardization (#134) converged command *names* and added the missing generic
+commands, but deliberately left this repo's `review-pr` body untouched (it wasn't in the delta
+scope). That body is the **stale PR-comment fetcher** — it just pulls existing Copilot/human
+comments by PR number. The canonical best-of `review-pr` (in `sleap-roots` / `salk-bloom`) is a
+**multi-subagent adversarial review team** that actually reads the diff and source and produces
+a synthesized verdict.
+
+During the #134 self-review this gap surfaced concretely: the upgraded `pre-merge-check` Phase
+3.5 ("pre-PR self-review") couldn't reference `/review-pr` because a comment-fetcher can't
+review a diff, so it was routed to `/code-review` as a workaround. Adopting the canonical
+subagent-team `review-pr` removes the workaround and gives this repo the real best-of body.
+
+## What Changes
+
+- **REPLACE** `.claude/commands/review-pr.md` with the canonical **subagent review-team** body,
+  adapted from `sleap-roots` to this repo's domain: a root-trait **analysis** library
+  (pandas / numpy / scikit-learn / scipy / statsmodels) built on a NetworkX **DAG pipeline**
+  with omegaconf configs and a CLI — **not** SLEAP `.slp` loading. The five review lenses are
+  retargeted (statistical correctness for H²/ANOVA/PCA/UMAP/outlier detection; config-driven
+  reproducibility and metadata; NaN / small-group / replicate guardrails; pandas vectorization
+  and Windows/Ubuntu/macOS portability).
+- **GENERALIZE** the command to two modes: review an **existing PR** by number (posts the review
+  to GitHub), and — when **no PR exists yet** — review the **local branch diff** (`git diff
+  main...HEAD`) for the pre-PR self-review. Owner/name stay dynamic via `gh repo view`; own-PR
+  reviews post as a `--comment` with a verdict banner.
+- **REVERT** `pre-merge-check` Phase 3.5 to use `/review-pr` (local-diff mode) for the pre-PR
+  self-review, undoing the `/code-review` workaround. `/copilot-review` stays the Copilot fetch
+  in Phase 6; `/code-review` remains available as a lighter option.
+
+## Impact
+
+- Affected specs: `developer-tooling` — ADD "PR Code Review Subagent Team"; MODIFY "Pre-Merge
+  Verification" (Phase 3.5 scenario points back at `/review-pr`).
+- Affected code: `.claude/commands/review-pr.md` (rewrite), `.claude/commands/pre-merge-check.md`
+  (Phase 3.5 + integration list).
+- Documentation/tooling only — no `src/` or test changes. Verified by inspection + the existing
+  lint/format/openspec checks, and by dogfooding the new `/review-pr` on this PR.

--- a/openspec/changes/adopt-canonical-review-pr/proposal.md
+++ b/openspec/changes/adopt-canonical-review-pr/proposal.md
@@ -23,7 +23,8 @@ subagent-team `review-pr` removes the workaround and gives this repo the real be
   and Windows/Ubuntu/macOS portability).
 - **GENERALIZE** the command to two modes: review an **existing PR** by number (posts the review
   to GitHub), and — when **no PR exists yet** — review the **local branch diff** (`git diff
-  main...HEAD`) for the pre-PR self-review. Owner/name stay dynamic via `gh repo view`; own-PR
+  origin/main...HEAD`, against the resolved default branch) for the pre-PR self-review. Owner,
+  name, and base branch stay dynamic via `gh repo view`; own-PR
   reviews post as a `--comment` with a verdict banner.
 - **REVERT** `pre-merge-check` Phase 3.5 to use `/review-pr` (local-diff mode) for the pre-PR
   self-review, undoing the `/code-review` workaround. `/copilot-review` stays the Copilot fetch

--- a/openspec/changes/adopt-canonical-review-pr/specs/developer-tooling/spec.md
+++ b/openspec/changes/adopt-canonical-review-pr/specs/developer-tooling/spec.md
@@ -1,0 +1,70 @@
+## ADDED Requirements
+
+### Requirement: PR Code Review Subagent Team
+
+The `/review-pr` command SHALL conduct an adversarial code review by launching a team of
+specialized subagents in parallel, each with a distinct review lens, rather than only fetching
+existing review comments. The lenses SHALL cover: code quality & architecture; testing & TDD
+discipline; statistical rigor & reproducibility; performance, memory & cross-platform safety;
+and behavioural correctness & edge cases. After the subagents return, the command SHALL
+deduplicate and prioritize findings by severity (BLOCKING / IMPORTANT / SUGGESTION), determine a
+verdict (APPROVE / COMMENT / REQUEST_CHANGES), and — when a PR exists — post the synthesized
+review to GitHub. The repository owner/name SHALL be resolved dynamically via `gh repo view`
+(no hardcoded repository).
+
+#### Scenario: Review an existing PR
+
+- **WHEN** user invokes `/review-pr` with a PR number (or on a branch with an open PR)
+- **THEN** the PR diff, description, CI status, and existing Copilot comments are gathered
+- **AND** the specialized subagents review the change in parallel across their lenses
+- **AND** the synthesized, severity-ranked review with a verdict is posted to the PR
+
+#### Scenario: Pre-PR review of the local branch diff
+
+- **GIVEN** the user has implemented a change but not yet opened a PR
+- **WHEN** user invokes `/review-pr` and no PR exists for the branch
+- **THEN** the command reviews the local branch diff (`git diff main...HEAD`) with the same
+  subagent team and severity rubric
+- **AND** findings are reported locally so BLOCKING / IMPORTANT items can be fixed before the PR
+
+#### Scenario: Own-PR review posts as a comment
+
+- **WHEN** the PR author is the authenticated user
+- **THEN** the command does not attempt `--approve` / `--request-changes` (GitHub forbids self-review)
+- **AND** the verdict is posted via `--comment` with a verdict banner
+
+## MODIFIED Requirements
+
+### Requirement: Pre-Merge Verification
+
+The pre-merge check command SHALL perform comprehensive PR readiness verification before
+merging, including local CI checks, a pre-PR self-review of the local diff, OpenSpec validation,
+GitHub Copilot comment triage, and CI status verification. Copilot comments SHALL be fetched via the
+repo-agnostic `/copilot-review` command (no hardcoded repository). The command SHALL retain this
+repository's pipeline-specific phases (coverage reporting via `--cov`, CI status via
+`gh pr checks`, and final verification) and use this repository's `src/sleap_roots_analyze` paths.
+
+#### Scenario: Run pre-merge check on current PR
+
+- **GIVEN** user is on a feature branch with an open PR
+- **WHEN** user invokes `/pre-merge-check`
+- **THEN** local CI checks run (Black, Ruff, pytest with coverage)
+- **AND** GitHub Copilot review comments are fetched via `/copilot-review` and categorized by priority
+- **AND** GitHub Actions CI status is verified via `gh pr checks`
+- **AND** issues are reported with actionable fix guidance
+
+#### Scenario: Pre-PR self-review of the local diff
+
+- **GIVEN** user has finished implementing a change but has not yet opened the PR
+- **WHEN** the pre-merge check reaches the pre-PR self-review phase
+- **THEN** the local branch diff is critically reviewed via `/review-pr` (the subagent review
+  team in local-diff mode), applying the BLOCKING / IMPORTANT / SUGGESTION severity rubric
+- **AND** any BLOCKING / IMPORTANT findings are fixed before the PR is created
+- **AND** `/code-review` remains available as a lighter single-pass alternative
+
+#### Scenario: OpenSpec validation during pre-merge
+
+- **GIVEN** an OpenSpec change is in flight for the branch
+- **WHEN** the pre-merge check runs
+- **THEN** `openspec validate <change-id> --strict` is run and must pass
+- **AND** the associated OpenSpec tasks are confirmed checked off

--- a/openspec/changes/adopt-canonical-review-pr/specs/developer-tooling/spec.md
+++ b/openspec/changes/adopt-canonical-review-pr/specs/developer-tooling/spec.md
@@ -23,8 +23,8 @@ review to GitHub. The repository owner/name SHALL be resolved dynamically via `g
 
 - **GIVEN** the user has implemented a change but not yet opened a PR
 - **WHEN** user invokes `/review-pr` and no PR exists for the branch
-- **THEN** the command reviews the local branch diff (`git diff main...HEAD`) with the same
-  subagent team and severity rubric
+- **THEN** the command reviews the local branch diff (`git diff origin/main...HEAD`, against the
+  resolved default branch) with the same subagent team and severity rubric
 - **AND** findings are reported locally so BLOCKING / IMPORTANT items can be fixed before the PR
 
 #### Scenario: Own-PR review posts as a comment

--- a/openspec/changes/adopt-canonical-review-pr/tasks.md
+++ b/openspec/changes/adopt-canonical-review-pr/tasks.md
@@ -1,0 +1,32 @@
+## 1. Adopt the canonical subagent-team review-pr
+
+- [x] 1.1 Rewrite `.claude/commands/review-pr.md` from the `sleap-roots` subagent-team body,
+  retargeted to this repo's analysis domain (pandas/sklearn/scipy/statsmodels, NetworkX DAG
+  pipeline, omegaconf configs, CLI; no `.slp` loading).
+- [x] 1.2 Retarget the five review lenses: Code Quality & Architecture; Testing & TDD; Statistical
+  Rigor & Reproducibility; Performance/Memory & Cross-Platform; Behavioural Correctness & Edge Cases.
+- [x] 1.3 Add two modes — existing-PR (by number, posts review to GitHub) and pre-PR local-diff
+  (`git diff main...HEAD` when no PR exists). Keep owner/name dynamic via `gh repo view`; own-PR
+  posts as `--comment` with a verdict banner.
+- [x] 1.4 Use this repo's CI reality in the subagent prompts (lint on ubuntu; tests on
+  ubuntu/windows/macOS, Python 3.11; `tests/data/` fixtures; coverage via `--cov`).
+
+## 2. Restore pre-merge-check Phase 3.5
+
+- [x] 2.1 Revert `pre-merge-check` Phase 3.5 to run `/review-pr` (local-diff mode) for the pre-PR
+  self-review; update the integration list and Output block accordingly. `/copilot-review` stays
+  in Phase 6; `/code-review` remains a lighter alternative.
+
+## 3. Verify (tooling/docs — no pytest)
+
+- [x] 3.1 No stray source-repo names: `rg -n "sleap_roots\b|sleap-roots\b" .claude/commands/review-pr.md`
+  finds only intentional references; no `sleap-io`/`.slp`/SLEAP-loading content remains.
+- [x] 3.2 `uv run black --check src/sleap_roots_analyze tests` and `uv run ruff check
+  src/sleap_roots_analyze` still pass.
+- [x] 3.3 `openspec validate adopt-canonical-review-pr --strict` passes.
+
+## 4. Ship (dogfood the new command)
+
+- [ ] 4.1 Run `/pre-merge-check`; open the PR.
+- [ ] 4.2 Run the new `/review-pr` (subagent team) on the PR as the self-review.
+- [ ] 4.3 After merge, run `/openspec:archive adopt-canonical-review-pr`.

--- a/openspec/changes/adopt-canonical-review-pr/tasks.md
+++ b/openspec/changes/adopt-canonical-review-pr/tasks.md
@@ -6,7 +6,8 @@
 - [x] 1.2 Retarget the five review lenses: Code Quality & Architecture; Testing & TDD; Statistical
   Rigor & Reproducibility; Performance/Memory & Cross-Platform; Behavioural Correctness & Edge Cases.
 - [x] 1.3 Add two modes — existing-PR (by number, posts review to GitHub) and pre-PR local-diff
-  (`git diff main...HEAD` when no PR exists). Keep owner/name dynamic via `gh repo view`; own-PR
+  (`git diff origin/main...HEAD` against the resolved default branch when no PR exists). Keep
+  owner/name/base-branch dynamic via `gh repo view`; own-PR
   posts as `--comment` with a verdict banner.
 - [x] 1.4 Use this repo's CI reality in the subagent prompts (lint on ubuntu; tests on
   ubuntu/windows/macOS, Python 3.11; `tests/data/` fixtures; coverage via `--cov`).
@@ -27,6 +28,6 @@
 
 ## 4. Ship (dogfood the new command)
 
-- [ ] 4.1 Run `/pre-merge-check`; open the PR.
-- [ ] 4.2 Run the new `/review-pr` (subagent team) on the PR as the self-review.
+- [x] 4.1 Run `/pre-merge-check`; open the PR.
+- [x] 4.2 Run the new `/review-pr` (subagent team) on the PR as the self-review.
 - [ ] 4.3 After merge, run `/openspec:archive adopt-canonical-review-pr`.


### PR DESCRIPTION
## Summary

Follow-up to #134. The #126 standardization converged command *names* but deliberately left this repo's `review-pr` body untouched — it was the **stale PR-comment fetcher**. During the #134 self-review this forced a workaround: `pre-merge-check` Phase 3.5 had to use `/code-review` because a comment-fetcher can't review a diff. This PR adopts the **canonical best-of `review-pr`** and removes the workaround.

Tooling/docs only — no `src/` or test changes.

## Changes

- **Replace `review-pr.md`** with the canonical **5-subagent adversarial review team** (from `sleap-roots`), retargeted to this repo's analysis domain — pandas/sklearn/scipy/statsmodels, NetworkX DAG pipeline, omegaconf configs, CLI; **no `.slp`/sleap-io loading**. Lenses:
  - Code Quality & Architecture · Testing & TDD · **Statistical Rigor & Reproducibility** (H²/ANOVA/PCA/UMAP/outliers, n≥30 Mahalanobis & ≥3-replicate H² guardrails, FDR, seeds) · Performance/Memory & Cross-Platform (pandas vectorization, win/ubuntu/mac) · Behavioural Correctness & Edge Cases (NaN, zero-variance, tiny groups, config validation)
- **Two modes**: existing-PR (posts review to GitHub; own-PR posts as `--comment`) and **pre-PR local-diff** (`git diff origin/main...HEAD`) so Phase 3.5 can use it.
- **Restore `pre-merge-check` Phase 3.5** to `/review-pr` (local-diff mode); `/code-review` stays as a lighter alternative; `/copilot-review` stays the Copilot fetch in Phase 6.

## OpenSpec

Change `adopt-canonical-review-pr` under `developer-tooling`: ADD "PR Code Review Subagent Team" (3 scenarios) + MODIFY "Pre-Merge Verification" (Phase 3.5 → `/review-pr`). `openspec validate --strict` passes.

## Verification

- [x] No `.slp`/`sleap-io`/SLEAP-loading leftovers (only the explicit "NO SLEAP loading here" note)
- [x] `uv run black --check src/sleap_roots_analyze tests` + `uv run ruff check src/sleap_roots_analyze` pass
- [x] `openspec validate adopt-canonical-review-pr --strict` passes

Self-reviewed via the new `/review-pr` (subagent team) — see review comment below.

Refs #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)