### PR TITLE
Audit __all__ exports for introspection-readiness (#117)

### DIFF
--- a/docs/public_api_audit_2026.md
+++ b/docs/public_api_audit_2026.md
@@ -1,0 +1,123 @@
+# Public API Introspection Audit (2026)
+
+**Issue:** [#117](https://github.com/talmolab/sleap-roots-analyze/issues/117) —
+*Audit `__all__` exports for introspection-readiness (type hints + docstrings)*
+
+**Blocker for:** bloom-mcp autopop generator (Phase 3 of the Metcalf 2026 project),
+which targets a ≥80% auto-generation rate for MCP tools.
+
+## Why
+
+bloom-mcp builds MCP tool descriptors by reading `sleap_roots_analyze.__all__` and,
+for each name, calling `inspect.signature()`, `typing.get_type_hints()`, and
+`__doc__` to derive parameters, types, defaults, and descriptions. Any public symbol
+with a missing annotation, an unresolvable type hint, or an unparsable docstring
+drops out of auto-generation and falls back to a hand-written wrapper. This audit
+brings every `__all__` entry up to a machine-introspectable bar and makes that bar a
+permanent, enforced contract.
+
+## Methodology
+
+The audit is implemented as a committed script,
+[`scripts/check_public_api_docs.py`](../scripts/check_public_api_docs.py), and is
+enforced on every test run via
+[`tests/test_public_api_docs.py`](../tests/test_public_api_docs.py). It iterates
+`sleap_roots_analyze.__all__` (112 entries: 110 functions + 2 classes) and applies
+the following criteria.
+
+For each public **function**:
+
+1. Every parameter (excluding `*args`/`**kwargs`) has a type annotation.
+2. The return value has a type annotation.
+3. `typing.get_type_hints()` resolves without raising.
+4. A docstring exists with a `Returns:` section, plus an `Args:` section when the
+   function takes parameters.
+5. Every parameter name appears in the docstring body.
+6. A `Raises:` section is present when the function body raises a non-trivial
+   exception (a `raise SomeError(...)` in its own body — bare re-raises and raises
+   inside nested functions are ignored).
+
+For each public **class** (`VizPipeline`, `VizPipelineConfig`):
+
+7. The class has a docstring.
+8. Every `__init__` parameter beyond `self` is annotated and named in the class or
+   `__init__` docstring.
+
+## Findings (before the change)
+
+18 of the 112 `__all__` entries failed at least one criterion. The 94 others already
+passed.
+
+### Unresolvable type hints (`get_type_hints()` → `NameError: 'Any'`)
+
+`visualization.py` used `Any` in annotations but never imported it. Because the
+module uses `from __future__ import annotations`, the annotations are stringized and
+the failure only surfaces when `get_type_hints()` evaluates them — exactly the
+bloom-mcp path. (Same class of bug fixed for `statistics.py` in #116.)
+
+| Function | Module |
+| --- | --- |
+| `create_trait_boxplots_by_genotype` | `visualization` |
+| `create_exploratory_summary_plots` | `visualization` |
+| `create_trait_by_genotype_boxplots` | `visualization` |
+
+### Missing return annotation / `Returns:` section
+
+| Function | Module | Gap |
+| --- | --- | --- |
+| `main` | `cli` | no return annotation **and** no `Returns:` |
+| `save_viz_config` | `pipeline.config.utils` | no `Returns:` |
+| `validate_viz_config` | `pipeline.config.utils` | no `Returns:` |
+| `create_publication_figure` | `visualization` | no `Returns:` |
+
+### Raises non-trivially but no `Raises:` section
+
+All raise `ValueError` for input validation (one also `RuntimeError`).
+
+| Function | Module |
+| --- | --- |
+| `calculate_figure_size` | `viz_utils` |
+| `calculate_barplot_size` | `viz_utils` |
+| `link_rhizovision_images_to_samples` | `data_utils` |
+| `link_cylinder_images_from_scan_path` | `data_utils` |
+| `perform_pca_analysis` | `pca` |
+| `calculate_optimal_clusters_hierarchical` | `clustering` (also `RuntimeError`) |
+| `detect_outliers_pca` | `outlier_detection` |
+| `create_pca_biplot` | `visualization` |
+| `identify_extreme_genotypes_by_pc` | `visualization` |
+| `create_pc_genotype_boxplots` | `visualization` |
+| `create_feature_contribution_heatmap` | `visualization` |
+
+## Changes made
+
+All changes are **type-hint and docstring only — no behavior change**. No public
+signatures or return values were altered.
+
+- **`visualization.py`** — added `from typing import Any`; added `Returns:` to
+  `create_publication_figure`; added `Raises:` to `create_pca_biplot`,
+  `identify_extreme_genotypes_by_pc`, `create_pc_genotype_boxplots`, and
+  `create_feature_contribution_heatmap`.
+- **`cli.py`** — added a `-> None` return annotation and a `Returns:` section to
+  `main`.
+- **`pipeline/config/utils.py`** — added `Returns:` sections to `save_viz_config`
+  and `validate_viz_config`.
+- **`viz_utils.py`** — added `Raises:` to `calculate_figure_size` and
+  `calculate_barplot_size`.
+- **`data_utils.py`** — added `Raises:` to `link_rhizovision_images_to_samples` and
+  `link_cylinder_images_from_scan_path`.
+- **`pca.py`** — added `Raises:` to `perform_pca_analysis`.
+- **`clustering.py`** — added `Raises:` to `calculate_optimal_clusters_hierarchical`.
+- **`outlier_detection.py`** — added `Raises:` to `detect_outliers_pca`.
+
+## Result (after the change)
+
+```
+Public API introspection audit: 112 __all__ entries
+  passing: 112
+  failing: 0
+```
+
+All 110 functions and 2 classes are introspection-ready. The contract is now
+enforced by `tests/test_public_api_docs.py`, so any new public symbol that regresses
+the bar will fail the test suite. The script can also be wired into CI directly via
+`python scripts/check_public_api_docs.py` (exit code 0 = clean).

--- a/openspec/changes/audit-public-api-introspection/proposal.md
+++ b/openspec/changes/audit-public-api-introspection/proposal.md
@@ -11,17 +11,27 @@ hand-written wrapper. The target auto-generation rate is **≥80%**, so each gap
 directly expands the manual fallback surface and delays Phase 3.
 
 A current audit of the 112 `__all__` entries (110 functions + 2 classes) finds
-**7 functions** that fail an introspection check:
+**18 functions** that fail an introspection check, in three categories:
 
-- `create_trait_boxplots_by_genotype`, `create_exploratory_summary_plots`,
-  `create_trait_by_genotype_boxplots` (in `visualization.py`) — `get_type_hints()`
-  raises `NameError: name 'Any' is not defined` because `Any` is used in
-  annotations but never imported (the module uses `from __future__ import
-  annotations`, so the failure surfaces at `get_type_hints()` time, exactly on the
-  bloom-mcp path). This is the same class of bug fixed for `statistics.py` in #116.
-- `cli.main` — no return annotation and no `Returns:` section.
-- `save_viz_config`, `validate_viz_config`, `create_publication_figure` — no
-  `Returns:` section.
+- **Unresolvable type hints (3)** — `create_trait_boxplots_by_genotype`,
+  `create_exploratory_summary_plots`, `create_trait_by_genotype_boxplots` (in
+  `visualization.py`): `get_type_hints()` raises `NameError: name 'Any' is not
+  defined` because `Any` is used in annotations but never imported (the module uses
+  `from __future__ import annotations`, so the failure surfaces at
+  `get_type_hints()` time, exactly on the bloom-mcp path). Same class of bug fixed
+  for `statistics.py` in #116.
+- **Missing return annotation / `Returns:` (4)** — `cli.main` (no return annotation
+  *and* no `Returns:`); `save_viz_config`, `validate_viz_config`,
+  `create_publication_figure` (no `Returns:`).
+- **Raises but undocumented (11)** — `calculate_figure_size`,
+  `calculate_barplot_size` (`viz_utils`); `link_rhizovision_images_to_samples`,
+  `link_cylinder_images_from_scan_path` (`data_utils`); `perform_pca_analysis`
+  (`pca`); `calculate_optimal_clusters_hierarchical` (`clustering`);
+  `detect_outliers_pca` (`outlier_detection`); `create_pca_biplot`,
+  `identify_extreme_genotypes_by_pc`, `create_pc_genotype_boxplots`,
+  `create_feature_contribution_heatmap` (`visualization`): each raises a non-trivial
+  exception (`ValueError`, and `RuntimeError` for the clustering one) with no
+  `Raises:` section.
 
 Beyond fixing these, the gap will silently reappear as new public functions are
 added unless the contract is **enforced**. This change adds a committed audit
@@ -40,11 +50,16 @@ Tracked by issue #117.
    exceptions. Public classes must carry a class docstring and annotate/document
    any non-trivial `__init__` parameters.
 
-2. **Fix the 7 failing functions** (type-hint + docstring only, no behavior change):
-   - Add `from typing import Any` to `visualization.py`.
-   - Add a return annotation + `Returns:` to `cli.main`.
-   - Add `Returns:` sections to `save_viz_config`, `validate_viz_config`,
-     `create_publication_figure`.
+2. **Fix the 18 failing functions** (type-hint + docstring only, no behavior
+   change):
+   - Add `from typing import Any` to `visualization.py` (fixes the 3 `get_type_hints`
+     failures).
+   - Add a return annotation + `Returns:` to `cli.main`; add `Returns:` sections to
+     `save_viz_config`, `validate_viz_config`, `create_publication_figure`.
+   - Add `Raises:` sections to the 11 functions that raise non-trivial exceptions
+     (in `viz_utils`, `data_utils`, `pca`, `clustering`, `outlier_detection`, and
+     `visualization`), each derived from the function's actual raised type and
+     condition.
 
 3. **Commit `scripts/check_public_api_docs.py`** — iterates `__all__`, applies the
    contract, prints a per-symbol report, and exits non-zero on any violation. It is
@@ -52,18 +67,29 @@ Tracked by issue #117.
    enforced in the existing test job.
 
 4. **Commit `docs/public_api_audit_2026.md`** — the audit report: methodology, the
-   pre-change findings (the 7 failures above), what was changed, and the
+   pre-change findings (the 18 failures above), what was changed, and the
    post-change result (0 violations across all 112 entries).
 
 ## Impact
 
 - Affected specs: **public-api-introspection** (new capability).
 - Affected code:
-  - `src/sleap_roots_analyze/visualization.py` (`Any` import)
+  - `src/sleap_roots_analyze/visualization.py` (`Any` import; `Returns:` for
+    `create_publication_figure`; `Raises:` for `create_pca_biplot`,
+    `identify_extreme_genotypes_by_pc`, `create_pc_genotype_boxplots`,
+    `create_feature_contribution_heatmap`)
   - `src/sleap_roots_analyze/cli.py` (`main` return annotation + docstring)
   - `src/sleap_roots_analyze/pipeline/config/utils.py` (`save_viz_config`,
     `validate_viz_config` docstrings)
-  - `create_publication_figure` docstring (in its defining module)
+  - `src/sleap_roots_analyze/viz_utils.py` (`Raises:` for `calculate_figure_size`,
+    `calculate_barplot_size`)
+  - `src/sleap_roots_analyze/data_utils.py` (`Raises:` for
+    `link_rhizovision_images_to_samples`, `link_cylinder_images_from_scan_path`)
+  - `src/sleap_roots_analyze/pca.py` (`Raises:` for `perform_pca_analysis`)
+  - `src/sleap_roots_analyze/clustering.py` (`Raises:` for
+    `calculate_optimal_clusters_hierarchical`)
+  - `src/sleap_roots_analyze/outlier_detection.py` (`Raises:` for
+    `detect_outliers_pca`)
   - `scripts/check_public_api_docs.py` (new)
   - `docs/public_api_audit_2026.md` (new)
   - a new test wiring the audit script into pytest

--- a/openspec/changes/audit-public-api-introspection/proposal.md
+++ b/openspec/changes/audit-public-api-introspection/proposal.md
@@ -1,0 +1,71 @@
+# Proposal: Audit `__all__` Exports for Introspection-Readiness
+
+## Why
+
+bloom-mcp's Phase 3 autopop generator builds MCP tool descriptors by reading
+`sleap_roots_analyze.__all__` and, for each name, calling `inspect.signature()` +
+`typing.get_type_hints()` + `__doc__` to derive parameters, types, defaults, and
+descriptions. Every public symbol with a missing annotation, an unresolvable type
+hint, or an unparsable docstring drops out of auto-generation and falls back to a
+hand-written wrapper. The target auto-generation rate is **≥80%**, so each gap
+directly expands the manual fallback surface and delays Phase 3.
+
+A current audit of the 112 `__all__` entries (110 functions + 2 classes) finds
+**7 functions** that fail an introspection check:
+
+- `create_trait_boxplots_by_genotype`, `create_exploratory_summary_plots`,
+  `create_trait_by_genotype_boxplots` (in `visualization.py`) — `get_type_hints()`
+  raises `NameError: name 'Any' is not defined` because `Any` is used in
+  annotations but never imported (the module uses `from __future__ import
+  annotations`, so the failure surfaces at `get_type_hints()` time, exactly on the
+  bloom-mcp path). This is the same class of bug fixed for `statistics.py` in #116.
+- `cli.main` — no return annotation and no `Returns:` section.
+- `save_viz_config`, `validate_viz_config`, `create_publication_figure` — no
+  `Returns:` section.
+
+Beyond fixing these, the gap will silently reappear as new public functions are
+added unless the contract is **enforced**. This change adds a committed audit
+script that fails on any violation, making introspection-readiness a permanent,
+testable contract.
+
+Tracked by issue #117.
+
+## What Changes
+
+1. **Define the introspection-readiness contract** as a new capability
+   (`public-api-introspection`): for every public function in `__all__` —
+   annotations on every parameter and the return; `get_type_hints()` resolves;
+   a Google-style docstring with `Args:` and `Returns:`; every parameter named in
+   the docstring; a `Raises:` section where the function raises non-trivial
+   exceptions. Public classes must carry a class docstring and annotate/document
+   any non-trivial `__init__` parameters.
+
+2. **Fix the 7 failing functions** (type-hint + docstring only, no behavior change):
+   - Add `from typing import Any` to `visualization.py`.
+   - Add a return annotation + `Returns:` to `cli.main`.
+   - Add `Returns:` sections to `save_viz_config`, `validate_viz_config`,
+     `create_publication_figure`.
+
+3. **Commit `scripts/check_public_api_docs.py`** — iterates `__all__`, applies the
+   contract, prints a per-symbol report, and exits non-zero on any violation. It is
+   runnable standalone (CI) and is exercised by a pytest test so the contract is
+   enforced in the existing test job.
+
+4. **Commit `docs/public_api_audit_2026.md`** — the audit report: methodology, the
+   pre-change findings (the 7 failures above), what was changed, and the
+   post-change result (0 violations across all 112 entries).
+
+## Impact
+
+- Affected specs: **public-api-introspection** (new capability).
+- Affected code:
+  - `src/sleap_roots_analyze/visualization.py` (`Any` import)
+  - `src/sleap_roots_analyze/cli.py` (`main` return annotation + docstring)
+  - `src/sleap_roots_analyze/pipeline/config/utils.py` (`save_viz_config`,
+    `validate_viz_config` docstrings)
+  - `create_publication_figure` docstring (in its defining module)
+  - `scripts/check_public_api_docs.py` (new)
+  - `docs/public_api_audit_2026.md` (new)
+  - a new test wiring the audit script into pytest
+- **No behavior change** — annotations, docstrings, a new check script, and a
+  report only. No public signatures or return values change.

--- a/openspec/changes/audit-public-api-introspection/specs/public-api-introspection/spec.md
+++ b/openspec/changes/audit-public-api-introspection/specs/public-api-introspection/spec.md
@@ -1,0 +1,90 @@
+# public-api-introspection Specification
+
+## ADDED Requirements
+
+### Requirement: Introspectable Public Function Signatures
+
+Every callable function listed in `sleap_roots_analyze.__all__` SHALL carry
+complete type information so downstream tooling can derive a parameter schema by
+introspection.
+
+#### Scenario: Every parameter and the return value is annotated
+
+- **WHEN** `inspect.signature()` is taken for each public function in `__all__`
+- **THEN** every parameter (excluding `*args`/`**kwargs`) SHALL have a non-empty
+  annotation
+- **AND** the function SHALL have a non-empty return annotation
+
+#### Scenario: Type hints resolve at runtime
+
+- **WHEN** `typing.get_type_hints()` is called on each public function
+- **THEN** it SHALL return without raising (no `NameError` from unimported names
+  such as `Any` under `from __future__ import annotations`)
+
+### Requirement: Parsable Public Function Docstrings
+
+Every public function in `__all__` SHALL have a Google-style docstring that names
+each parameter, so tooling can derive parameter descriptions.
+
+#### Scenario: Docstring has Args and Returns sections
+
+- **WHEN** the docstring of each public function is inspected
+- **THEN** it SHALL be non-empty
+- **AND** it SHALL contain a `Returns:` section
+- **AND** it SHALL contain an `Args:` section when the function takes at least one
+  parameter
+
+#### Scenario: Every parameter is documented
+
+- **WHEN** a public function declares parameters (excluding `self`/`cls` and
+  `*args`/`**kwargs`)
+- **THEN** each parameter name SHALL appear in the docstring body
+
+#### Scenario: Raising functions document their exceptions
+
+- **WHEN** a public function contains a `raise` of a non-trivial exception in its
+  own body
+- **THEN** its docstring SHALL contain a `Raises:` section
+
+### Requirement: Introspectable Public Classes
+
+Every class listed in `sleap_roots_analyze.__all__` SHALL be documented so tooling
+can describe it and its constructor.
+
+#### Scenario: Class has a docstring and documented constructor parameters
+
+- **WHEN** a public class in `__all__` is inspected
+- **THEN** the class SHALL have a non-empty docstring
+- **AND** where its `__init__` declares parameters beyond `self`, those parameters
+  SHALL be annotated and named in the class or `__init__` docstring
+
+### Requirement: Enforced Introspection Contract
+
+The project SHALL provide an automated check that fails when any `__all__` entry
+violates the introspection contract, so the contract holds as the API evolves.
+
+#### Scenario: Audit script reports and gates violations
+
+- **WHEN** `scripts/check_public_api_docs.py` is run
+- **THEN** it SHALL iterate every name in `sleap_roots_analyze.__all__`
+- **AND** it SHALL print a per-symbol pass/fail report
+- **AND** it SHALL exit with a non-zero status if any symbol violates the contract,
+  and zero when all entries pass
+
+#### Scenario: Contract is enforced in the test suite
+
+- **WHEN** the pytest suite runs
+- **THEN** a test SHALL execute the audit and fail if any `__all__` entry violates
+  the contract
+
+### Requirement: Public API Audit Report
+
+The project SHALL document the audit outcome in a committed report.
+
+#### Scenario: Audit report records findings and result
+
+- **WHEN** `docs/public_api_audit_2026.md` is viewed
+- **THEN** it SHALL describe the audit methodology and criteria
+- **AND** it SHALL list the symbols that failed before the change and what was
+  changed to fix them
+- **AND** it SHALL state the post-change result that all `__all__` entries pass

--- a/openspec/changes/audit-public-api-introspection/tasks.md
+++ b/openspec/changes/audit-public-api-introspection/tasks.md
@@ -11,10 +11,10 @@
   per-symbol report; `exit(1)` on any violation, `exit(0)` when clean. Expose a
   `run_audit() -> list[str]` returning violation strings so tests can call it.
 - [x] 1.2 Write `tests/test_public_api_docs.py` that imports `run_audit()` and
-  asserts it returns no violations. Confirm it FAILS now (script reports the 7
+  asserts it returns no violations. Confirm it FAILS now (script reports the 18
   known failures) — red state.
 
-## 2. Fix the 7 failing functions (no behavior change)
+## 2. Fix the 18 failing functions (no behavior change)
 
 - [x] 2.1 Add `from typing import Any` to `src/sleap_roots_analyze/visualization.py`
   (fixes `get_type_hints` `NameError` on `create_trait_boxplots_by_genotype`,
@@ -23,12 +23,21 @@
 - [x] 2.3 Add `Returns:` sections to `save_viz_config` and `validate_viz_config`
   (`pipeline/config/utils.py`).
 - [x] 2.4 Add a `Returns:` section to `create_publication_figure`.
-- [x] 2.5 Re-run the audit — expect 0 violations across all 112 entries (green).
+- [x] 2.5 Add `Raises:` sections to the 11 functions that raise non-trivial
+  exceptions, each derived from the actual raised type/condition:
+  `calculate_figure_size`, `calculate_barplot_size` (`viz_utils`);
+  `link_rhizovision_images_to_samples`, `link_cylinder_images_from_scan_path`
+  (`data_utils`); `perform_pca_analysis` (`pca`);
+  `calculate_optimal_clusters_hierarchical` (`clustering`, `ValueError` +
+  `RuntimeError`); `detect_outliers_pca` (`outlier_detection`); `create_pca_biplot`,
+  `identify_extreme_genotypes_by_pc`, `create_pc_genotype_boxplots`,
+  `create_feature_contribution_heatmap` (`visualization`).
+- [x] 2.6 Re-run the audit — expect 0 violations across all 112 entries (green).
 
 ## 3. Documentation
 
 - [x] 3.1 Write `docs/public_api_audit_2026.md`: methodology + criteria, the
-  pre-change failures (7 functions) and their fixes, and the post-change result
+  pre-change failures (18 functions) and their fixes, and the post-change result
   (0 violations / 112 entries).
 
 ## 4. Validation

--- a/openspec/changes/audit-public-api-introspection/tasks.md
+++ b/openspec/changes/audit-public-api-introspection/tasks.md
@@ -1,0 +1,40 @@
+# Tasks: Audit `__all__` Exports for Introspection-Readiness
+
+## 1. Audit script + test harness (write the check first)
+
+- [x] 1.1 Write `scripts/check_public_api_docs.py`: iterate
+  `sleap_roots_analyze.__all__`; for each callable function assert (a) every param
+  + return annotated, (b) `typing.get_type_hints()` resolves, (c) docstring with
+  `Args:`/`Returns:`, (d) every param named in the docstring, (e) `Raises:` present
+  when the function body contains a non-trivial `raise`; for each class assert a
+  class docstring and annotated/documented non-trivial `__init__` params. Print a
+  per-symbol report; `exit(1)` on any violation, `exit(0)` when clean. Expose a
+  `run_audit() -> list[str]` returning violation strings so tests can call it.
+- [x] 1.2 Write `tests/test_public_api_docs.py` that imports `run_audit()` and
+  asserts it returns no violations. Confirm it FAILS now (script reports the 7
+  known failures) — red state.
+
+## 2. Fix the 7 failing functions (no behavior change)
+
+- [x] 2.1 Add `from typing import Any` to `src/sleap_roots_analyze/visualization.py`
+  (fixes `get_type_hints` `NameError` on `create_trait_boxplots_by_genotype`,
+  `create_exploratory_summary_plots`, `create_trait_by_genotype_boxplots`).
+- [x] 2.2 Add a return annotation and a `Returns:` section to `cli.main`.
+- [x] 2.3 Add `Returns:` sections to `save_viz_config` and `validate_viz_config`
+  (`pipeline/config/utils.py`).
+- [x] 2.4 Add a `Returns:` section to `create_publication_figure`.
+- [x] 2.5 Re-run the audit — expect 0 violations across all 112 entries (green).
+
+## 3. Documentation
+
+- [x] 3.1 Write `docs/public_api_audit_2026.md`: methodology + criteria, the
+  pre-change failures (7 functions) and their fixes, and the post-change result
+  (0 violations / 112 entries).
+
+## 4. Validation
+
+- [x] 4.1 `uv run python scripts/check_public_api_docs.py` exits 0.
+- [x] 4.2 `uv run pytest tests/test_public_api_docs.py tests/test_public_api.py`
+  pass.
+- [x] 4.3 `uv run black --check` + `uv run ruff check` clean on changed files.
+- [x] 4.4 `openspec validate audit-public-api-introspection --strict` passes.

--- a/scripts/check_public_api_docs.py
+++ b/scripts/check_public_api_docs.py
@@ -139,6 +139,9 @@ def _check_function(name: str, func: object) -> list[str]:
     if "Returns:" not in doc:
         problems.append(f"{name}: docstring missing 'Returns:' section")
     for p in params:
+        # Conservative: matches the param name anywhere in the docstring, so a name
+        # mentioned only in Returns:/Raises: still passes. This avoids brittle
+        # Args:-block parsing; tighten to the Args: section if false negatives matter.
         if not re.search(rf"\b{re.escape(p.name)}\b", doc):
             problems.append(f"{name}: parameter '{p.name}' not documented")
     if _raises_nontrivially(func) and "Raises:" not in doc:

--- a/scripts/check_public_api_docs.py
+++ b/scripts/check_public_api_docs.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python
+"""Audit ``sleap_roots_analyze.__all__`` for introspection-readiness.
+
+bloom-mcp's autopop generator builds MCP tool descriptors by reading
+``sleap_roots_analyze.__all__`` and, for each name, calling ``inspect.signature()``,
+``typing.get_type_hints()``, and ``__doc__``. This script enforces the contract that
+makes that introspection succeed for every public symbol:
+
+For each public **function**:
+    1. Every parameter (excluding ``*args``/``**kwargs``) is annotated.
+    2. The return value is annotated.
+    3. ``typing.get_type_hints()`` resolves without raising.
+    4. A docstring exists with a ``Returns:`` section, plus an ``Args:`` section
+       when the function takes parameters.
+    5. Every parameter name appears in the docstring body.
+    6. A ``Raises:`` section is present when the function body raises a non-trivial
+       exception (a ``raise SomeError(...)`` in its own body, not a bare re-raise).
+
+For each public **class**:
+    7. The class has a docstring.
+    8. Every ``__init__`` parameter beyond ``self`` is annotated and named in the
+       class or ``__init__`` docstring.
+
+Run standalone (exits non-zero on any violation)::
+
+    uv run python scripts/check_public_api_docs.py
+
+Or import :func:`run_audit` (returns the list of violation strings) from a test.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import re
+import textwrap
+import typing
+
+import sleap_roots_analyze as sra
+
+_IGNORED_PARAMS = {"self", "cls"}
+_VAR_KINDS = (inspect.Parameter.VAR_POSITIONAL, inspect.Parameter.VAR_KEYWORD)
+
+
+def _real_params(sig: inspect.Signature) -> list[inspect.Parameter]:
+    """Return the documentable parameters of a signature.
+
+    Args:
+        sig: Signature to inspect.
+
+    Returns:
+        Parameters excluding ``self``/``cls`` and ``*args``/``**kwargs``.
+    """
+    return [
+        p
+        for p in sig.parameters.values()
+        if p.name not in _IGNORED_PARAMS and p.kind not in _VAR_KINDS
+    ]
+
+
+def _raises_nontrivially(func: object) -> bool:
+    """Report whether a function's own body raises a non-trivial exception.
+
+    A bare ``raise`` (re-raise) and ``raise`` statements inside nested functions or
+    lambdas are ignored, so only exceptions the function itself originates count.
+
+    Args:
+        func: Function object to inspect.
+
+    Returns:
+        True if the function body contains a ``raise <Exception>(...)``.
+    """
+    try:
+        source = textwrap.dedent(inspect.getsource(func))
+        tree = ast.parse(source)
+    except (OSError, TypeError, SyntaxError):
+        return False
+
+    # The parsed module's first statement is the function definition itself.
+    func_node = tree.body[0]
+    found = False
+
+    def visit(node: ast.AST, *, top: bool) -> None:
+        nonlocal found
+        # Do not descend into nested callables (their raises aren't this func's).
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.Lambda)):
+            if not top:
+                return
+        if isinstance(node, ast.Raise) and node.exc is not None:
+            found = True
+        for child in ast.iter_child_nodes(node):
+            visit(child, top=False)
+
+    visit(func_node, top=True)
+    return found
+
+
+def _check_function(name: str, func: object) -> list[str]:
+    """Check one public function against the introspection contract.
+
+    Args:
+        name: The ``__all__`` name being checked.
+        func: The function object.
+
+    Returns:
+        A list of violation messages (empty if the function passes).
+    """
+    problems: list[str] = []
+
+    try:
+        sig = inspect.signature(func)
+    except (ValueError, TypeError) as exc:
+        return [f"{name}: inspect.signature() failed ({exc})"]
+
+    params = _real_params(sig)
+
+    for p in params:
+        if p.annotation is inspect.Parameter.empty:
+            problems.append(f"{name}: parameter '{p.name}' has no type annotation")
+    if sig.return_annotation is inspect.Signature.empty:
+        problems.append(f"{name}: missing return annotation")
+
+    try:
+        typing.get_type_hints(func)
+    except Exception as exc:
+        # Intentionally broad: any failure to resolve hints (NameError, etc.)
+        # is a violation we want to report rather than propagate.
+        problems.append(
+            f"{name}: typing.get_type_hints() failed " f"({type(exc).__name__}: {exc})"
+        )
+
+    doc = inspect.getdoc(func) or ""
+    if not doc.strip():
+        problems.append(f"{name}: missing docstring")
+        return problems
+
+    if params and "Args:" not in doc:
+        problems.append(f"{name}: docstring missing 'Args:' section")
+    if "Returns:" not in doc:
+        problems.append(f"{name}: docstring missing 'Returns:' section")
+    for p in params:
+        if not re.search(rf"\b{re.escape(p.name)}\b", doc):
+            problems.append(f"{name}: parameter '{p.name}' not documented")
+    if _raises_nontrivially(func) and "Raises:" not in doc:
+        problems.append(f"{name}: raises but docstring has no 'Raises:' section")
+
+    return problems
+
+
+def _check_class(name: str, cls: type) -> list[str]:
+    """Check one public class against the introspection contract.
+
+    Args:
+        name: The ``__all__`` name being checked.
+        cls: The class object.
+
+    Returns:
+        A list of violation messages (empty if the class passes).
+    """
+    problems: list[str] = []
+
+    class_doc = inspect.getdoc(cls) or ""
+    if not class_doc.strip():
+        problems.append(f"{name}: class missing docstring")
+
+    init = cls.__init__
+    # An inherited ``object.__init__`` means no declared constructor params.
+    if init is object.__init__:
+        return problems
+
+    try:
+        sig = inspect.signature(init)
+    except (ValueError, TypeError):
+        return problems
+
+    params = _real_params(sig)
+    init_doc = inspect.getdoc(init) or ""
+    combined_doc = f"{class_doc}\n{init_doc}"
+    for p in params:
+        if p.annotation is inspect.Parameter.empty:
+            problems.append(
+                f"{name}.__init__: parameter '{p.name}' has no type annotation"
+            )
+        if not re.search(rf"\b{re.escape(p.name)}\b", combined_doc):
+            problems.append(f"{name}.__init__: parameter '{p.name}' not documented")
+
+    return problems
+
+
+def run_audit() -> list[str]:
+    """Audit every ``sleap_roots_analyze.__all__`` entry.
+
+    Returns:
+        A flat list of violation messages across all public symbols. An empty list
+        means the entire public API satisfies the introspection contract.
+    """
+    violations: list[str] = []
+    for name in sra.__all__:
+        obj = getattr(sra, name, None)
+        if obj is None:
+            violations.append(f"{name}: not found on sleap_roots_analyze")
+            continue
+        if inspect.isclass(obj):
+            violations.extend(_check_class(name, obj))
+        elif callable(obj):
+            violations.extend(_check_function(name, obj))
+        else:
+            violations.append(f"{name}: not callable and not a class ({type(obj)})")
+    return violations
+
+
+def main() -> int:
+    """Run the audit and print a per-symbol report.
+
+    Returns:
+        Process exit code: 0 if every public symbol passes, 1 otherwise.
+    """
+    violations = run_audit()
+    total = len(sra.__all__)
+    failing_names = {v.split(":", 1)[0].split(".", 1)[0] for v in violations}
+
+    print(f"Public API introspection audit: {total} __all__ entries")
+    print(f"  passing: {total - len(failing_names)}")
+    print(f"  failing: {len(failing_names)}")
+    if violations:
+        print("\nViolations:")
+        for v in violations:
+            print(f"  - {v}")
+        return 1
+    print("\nAll public API entries are introspection-ready.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/sleap_roots_analyze/cli.py
+++ b/src/sleap_roots_analyze/cli.py
@@ -915,8 +915,13 @@ def config_list():
     console.print(table)
 
 
-def main():
-    """Entry point for the CLI."""
+def main() -> None:
+    """Entry point for the CLI.
+
+    Returns:
+        None. Dispatches to the Click command group, which parses ``sys.argv`` and
+        runs the selected subcommand.
+    """
     cli()
 
 

--- a/src/sleap_roots_analyze/clustering.py
+++ b/src/sleap_roots_analyze/clustering.py
@@ -719,6 +719,11 @@ def calculate_optimal_clusters_hierarchical(
         - k_values: k values tested
         - method: Metric used for optimization
 
+    Raises:
+        ValueError: If fewer than 2 clusters can be tested, or ``method`` is not one
+            of "silhouette", "calinski", or "davies_bouldin".
+        RuntimeError: If the cluster-quality calculation fails.
+
     Examples:
         >>> optimal_result = calculate_optimal_clusters_hierarchical(
         ...     hier_result, max_clusters=10, method='silhouette'

--- a/src/sleap_roots_analyze/data_utils.py
+++ b/src/sleap_roots_analyze/data_utils.py
@@ -573,6 +573,9 @@ def link_rhizovision_images_to_samples(
 
     Returns:
         Dictionary mapping barcode to Rhizovision image paths
+
+    Raises:
+        ValueError: If ``barcode_col`` is not a column in ``df``.
     """
     if image_types is None:
         image_types = ["features.png", "seg.png"]
@@ -627,6 +630,10 @@ def link_cylinder_images_from_scan_path(
     Returns:
         Dictionary mapping barcode to image paths, compatible with
         create_genotype_image_grid() and other visualization functions.
+
+    Raises:
+        ValueError: If ``barcode_col`` or ``scan_path_col`` is not a column in
+            ``df``.
 
     Example:
         >>> from sleap_roots_analyze.data_utils import link_cylinder_images_from_scan_path

--- a/src/sleap_roots_analyze/outlier_detection.py
+++ b/src/sleap_roots_analyze/outlier_detection.py
@@ -647,6 +647,9 @@ def detect_outliers_pca(
         - explained_variance_per_feature: Variance explained for each original feature
         - explained_variance_ratio_per_feature: Fraction of each feature's variance explained
         - error: Error message if detection failed
+
+    Raises:
+        ValueError: If the processed data needed for reconstruction is unavailable.
     """
     # Convert to DataFrame to handle indices consistently
     if isinstance(data, np.ndarray):

--- a/src/sleap_roots_analyze/pca.py
+++ b/src/sleap_roots_analyze/pca.py
@@ -745,6 +745,12 @@ def perform_pca_analysis(
             - data_processed: Processed data (standardized or cleaned)
             - feature_names: List of feature names used
             - feature_metrics_df: DataFrame with per-feature metrics (if include_feature_metrics=True)
+
+    Raises:
+        ValueError: If the input array is not 2D, the DataFrame is empty, no valid
+            samples remain after dropping NaN values, no numeric columns (or none
+            with non-zero variance) are found, or fewer than 2 samples remain after
+            preprocessing.
     """
     # Convert numpy array to DataFrame if needed
     if not isinstance(data, pd.DataFrame):

--- a/src/sleap_roots_analyze/pipeline/config/utils.py
+++ b/src/sleap_roots_analyze/pipeline/config/utils.py
@@ -401,6 +401,10 @@ def save_viz_config(config: VizPipelineConfig, config_path: str | Path) -> None:
         config: VizPipelineConfig object to save.
         config_path: Path to save the YAML file.
 
+    Returns:
+        None. Writes the configuration to ``config_path`` as a side effect,
+        creating parent directories as needed.
+
     Example:
         >>> config = VizPipelineConfig(pipeline_name="viz_pipeline")
         >>> save_viz_config(config, "viz_config.yaml")
@@ -431,6 +435,9 @@ def validate_viz_config(config: VizPipelineConfig) -> None:
 
     Args:
         config: VizPipelineConfig object to validate.
+
+    Returns:
+        None. Returns normally when the configuration is valid; otherwise raises.
 
     Raises:
         ValueError: If configuration is invalid.

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -11,7 +11,7 @@ This module provides basic static visualization functions including:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -2039,6 +2039,9 @@ def create_pca_biplot(
 
     Returns:
         PCA biplot figure.
+
+    Raises:
+        ValueError: If the PCA sample count cannot be matched to ``df``.
     """
     fig, ax = plt.subplots(figsize=figsize)
 
@@ -2838,6 +2841,9 @@ def identify_extreme_genotypes_by_pc(
 
     Returns:
         DataFrame with extreme genotypes, their median PC scores, and rankings.
+
+    Raises:
+        ValueError: If ``genotype_col`` is not a column in ``df``.
     """
     if genotype_col not in df.columns:
         raise ValueError(f"Genotype column '{genotype_col}' not found in dataframe")
@@ -2936,6 +2942,9 @@ def create_pc_genotype_boxplots(
 
     Returns:
         Boxplot figure.
+
+    Raises:
+        ValueError: If ``genotype_col`` is not a column in ``df``.
     """
     if genotype_col not in df.columns:
         raise ValueError(f"Genotype column '{genotype_col}' not found in dataframe")
@@ -3107,6 +3116,10 @@ def create_feature_contribution_heatmap(
     Returns:
         Single figure if plot_type is "variance" or "loadings",
         tuple of (variance_fig, loadings_fig) if plot_type is "both".
+
+    Raises:
+        ValueError: If ``pca_results`` does not contain both "loadings" and
+            "eigenvalues" keys.
     """
     # Get necessary data from pca_results
     if "loadings" not in pca_results or "eigenvalues" not in pca_results:
@@ -3214,6 +3227,9 @@ def create_publication_figure(
         format: Output format ('pdf', 'eps', 'png', 'svg').
         transparent: Whether to use transparent background.
         bbox_inches: Bbox setting for matplotlib figures.
+
+    Returns:
+        None. Writes the figure to ``output_path`` as a side effect.
 
     Raises:
         ValueError: If figure type is not supported.

--- a/src/sleap_roots_analyze/viz_utils.py
+++ b/src/sleap_roots_analyze/viz_utils.py
@@ -57,6 +57,10 @@ def calculate_figure_size(
     Returns:
         Tuple of (width, height) in inches.
 
+    Raises:
+        ValueError: If ``layout`` is not one of "grid", "horizontal", "vertical",
+            or "single".
+
     Example:
         >>> from sleap_roots_analyze.pipeline.config import AdaptiveSizingConfig
         >>> config = AdaptiveSizingConfig()
@@ -205,6 +209,9 @@ def calculate_barplot_size(
 
     Returns:
         Tuple of (width, height) in inches.
+
+    Raises:
+        ValueError: If ``orientation`` is not "vertical" or "horizontal".
 
     Example:
         >>> from sleap_roots_analyze.pipeline.config import AdaptiveSizingConfig

--- a/tests/test_public_api_docs.py
+++ b/tests/test_public_api_docs.py
@@ -1,0 +1,31 @@
+"""Enforce the public-API introspection contract in the test suite.
+
+Wraps ``scripts/check_public_api_docs.py`` so every ``sleap_roots_analyze.__all__``
+entry is verified introspection-ready (complete type hints + parsable docstrings)
+on every test run. See issue #117 — this guards bloom-mcp's autopop generation path.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_public_api_docs.py"
+
+
+def _load_audit():
+    """Import the audit script as a module.
+
+    Returns:
+        The loaded ``check_public_api_docs`` module exposing ``run_audit``.
+    """
+    spec = importlib.util.spec_from_file_location("check_public_api_docs", _SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_all_public_api_entries_are_introspection_ready():
+    """Every __all__ entry passes the introspection contract (issue #117)."""
+    violations = _load_audit().run_audit()
+    assert violations == [], "Public API introspection violations:\n" + "\n".join(
+        f"  - {v}" for v in violations
+    )


### PR DESCRIPTION
Closes #117.

## Summary

Establishes an **introspection-readiness contract** for `sleap_roots_analyze.__all__` and brings every public symbol up to it. The motivation (issue #117) is bloom-mcp's Phase 3 autopop generator, which builds MCP tool descriptors by reading `sleap_roots_analyze.__all__` and, for each name, calling `inspect.signature()` + `typing.get_type_hints()` + `__doc__` to derive parameters, types, defaults, and descriptions. Any public symbol with a missing annotation, an unresolvable type hint, or an unparsable docstring drops out of auto-generation and expands the hand-written fallback surface — directly working against the ≥80% auto-generation target.

This PR fixes every introspection failure **and** makes the bar a permanent, enforced contract so it can't silently regress as the API grows.

**Result: 112/112 `__all__` entries (110 functions + 2 classes) are introspection-ready — was 18 failing.**

## Deliverables (issue #117 acceptance criteria)

- [x] **All `__all__` entries pass the audit** — `python scripts/check_public_api_docs.py` reports 112 passing / 0 failing.
- [x] **CI check committed** — `scripts/check_public_api_docs.py`, exits non-zero on any violation; also enforced on every test run via `tests/test_public_api_docs.py`.
- [x] **Audit report committed** — `docs/public_api_audit_2026.md` (methodology, findings, fixes, result).

Accompanied by the `audit-public-api-introspection` OpenSpec change (proposal, `public-api-introspection` spec, tasks).

## The contract

For each public **function** in `__all__`:
1. Every parameter (excluding `*args`/`**kwargs`) has a type annotation.
2. The return value has a type annotation.
3. `typing.get_type_hints()` resolves without raising.
4. A docstring exists with a `Returns:` section, plus an `Args:` section when the function takes parameters.
5. Every parameter name appears in the docstring body.
6. A `Raises:` section is present when the function body raises a non-trivial exception.

For each public **class** (`VizPipeline`, `VizPipelineConfig`): a class docstring, and every `__init__` parameter beyond `self` annotated and documented.

## Example usage

Run the audit standalone (e.g. as a CI step) — exit code 0 means the public API is introspection-ready:

```console
$ uv run python scripts/check_public_api_docs.py
Public API introspection audit: 112 __all__ entries
  passing: 112
  failing: 0

All public API entries are introspection-ready.
```

Or call it programmatically (this is how the pytest test consumes it):

```python
from check_public_api_docs import run_audit

violations = run_audit()   # list[str]; empty == contract satisfied
assert violations == []
```

When a public function regresses the bar, the report is specific and actionable:

```
  - my_new_function: missing return annotation
  - my_new_function: parameter 'threshold' not documented
  - my_new_function: raises but docstring has no 'Raises:' section
```

## Fixes applied (type hints + docstrings only — no behavior change)

The audit found 18 failing entries. No public signatures or return values were changed.

| Category | Functions | Fix |
|---|---|---|
| `get_type_hints()` → `NameError: 'Any'` | `create_trait_boxplots_by_genotype`, `create_exploratory_summary_plots`, `create_trait_by_genotype_boxplots` | add `from typing import Any` to `visualization.py` |
| Missing return annotation / `Returns:` | `cli.main`, `save_viz_config`, `validate_viz_config`, `create_publication_figure` | add `-> None` and/or a `Returns:` section |
| Raises but no `Raises:` section | 11 functions across `viz_utils`, `data_utils`, `pca`, `clustering`, `outlier_detection`, `visualization` (all `ValueError`; `calculate_optimal_clusters_hierarchical` also `RuntimeError`) | add accurate `Raises:` sections |

The `Any`-import failure is the same class of bug fixed for `statistics.py` in #116: because these modules use `from __future__ import annotations`, annotations are stringized and the unimported-name error only surfaces when `get_type_hints()` evaluates them — i.e. exactly on the bloom-mcp path, not at import time.

## API changes

- **No breaking changes.** Additive type annotations and docstring sections only; all existing call sites and return contracts are unchanged.
- `cli.main` gains a `-> None` return annotation (previously unannotated).
- New module `scripts/check_public_api_docs.py` exposes `run_audit() -> list[str]` for programmatic use.

## Validation

- `python scripts/check_public_api_docs.py` → 112 passing, 0 failing (exit 0)
- `uv run pytest -m "not integration"` → **2011 passed**, 0 failed (2 integration deselected, matching CI)
- `black --check` + `ruff check` clean on all changed files
- `openspec validate audit-public-api-introspection --strict` → valid

## Design notes / reasoning

- **Enforced in pytest, not only as a standalone CI step.** The contract is wrapped by `tests/test_public_api_docs.py` so it runs in the existing test job on all three OSes — no new CI wiring required, and a regression fails the suite immediately. The standalone `scripts/` entry point remains for direct CI use and local runs.
- **`Raises:` detection is deliberately conservative.** The script parses each function's own source via `ast` and only counts `raise SomeError(...)` statements in the top-level body — bare re-raises (`raise`) and raises inside nested functions/lambdas are ignored, avoiding false positives that would push noise into docstrings.
- **Classes are checked via their constructor.** bloom-mcp introspects a class through its `__init__` signature, so the class contract checks the class docstring plus annotated/documented `__init__` params, accepting documentation in either the class or `__init__` docstring.
- **`Raises:` text was derived from the code, not guessed.** Each new `Raises:` entry was written from the function's actual raised exception type and message conditions, so the docs match behavior rather than being boilerplate.
- **Out of scope:** pre-existing `black`/`ruff` violations remain in files this PR does not touch (`scripts/compare_pca_*.py`, `scripts/sanity_check.py`, `scripts/investigate_scanline_first_ind.py`, `tests/test_grouped_pipeline_robustness.py`). They predate this branch and would be a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
