### PR TITLE
Audit random_state/seed handling for determinism (#118)

### DIFF
--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -1,0 +1,80 @@
+# Reproducibility & Seeding Policy
+
+This document defines how `sleap-roots-analyze` guarantees reproducible results from
+its stochastic analyses, and the numerical tolerance to expect when comparing outputs
+(e.g. for golden-value tests). It backs issue #118 and is enforced by
+[`tests/test_reproducibility.py`](../tests/test_reproducibility.py).
+
+## Seeding policy
+
+Every public function whose result depends on a random number generator accepts a
+`random_state` parameter (default `42`) and forwards it to the underlying
+sklearn / umap estimator. Pass an explicit integer for reproducible output; pass
+`None` to opt into non-deterministic behavior.
+
+| Function | Module | Default `random_state` | Underlying RNG |
+| --- | --- | --- | --- |
+| `perform_pca_analysis` | `pca` | `42` | sklearn `PCA` (matters for the randomized SVD solver) |
+| `perform_umap_analysis` | `umap` | `42` | `umap.UMAP` |
+| `perform_kmeans_clustering` | `clustering` | `42` | sklearn `KMeans` |
+| `perform_gmm_clustering` | `clustering` | `42` | sklearn `GaussianMixture` |
+| `detect_outliers_isolation_forest` | `outlier_detection` | `42` | sklearn `IsolationForest` |
+| `detect_outliers_kmeans` | `outlier_detection` | `42` | via `perform_kmeans_clustering` |
+| `detect_outliers_gmm` | `outlier_detection` | `42` | via `perform_gmm_clustering` |
+| `detect_outliers_mahalanobis` | `outlier_detection` | `42` | via `perform_pca_analysis` |
+
+### Deterministic functions (no seed needed)
+
+`perform_hierarchical_clustering` uses scipy `linkage`, which is **deterministic**:
+the same input always produces the same linkage matrix. It intentionally does **not**
+take a `random_state` — adding one would misrepresent the API. Its determinism is
+still covered by the regression test.
+
+`create_phenotype_variation_plot` adds plotting jitter seeded with
+`np.random.seed(42)`, so its visual output is reproducible. The `create_umap_*` plot
+helpers consume a **precomputed** embedding and run no RNG of their own.
+
+## Determinism guarantee
+
+> Given the same `random_state`, the same input data, and the same environment
+> (library versions + BLAS backend), each stochastic function returns identical
+> output.
+
+This is verified on every test run: `tests/test_reproducibility.py` calls each
+function twice with `random_state=42` and asserts the reproducibility-bearing outputs
+match. Within a single machine the outputs are bit-for-bit identical (UMAP embeddings
+included).
+
+## Tolerance policy
+
+When comparing outputs across runs or machines, use these tolerances:
+
+- **Integer cluster labels and outlier indices:** compare for **exact** equality.
+- **Floating-point arrays** (UMAP embeddings, PCA transformed data / loadings /
+  eigenvalues, distances, cluster centers): compare with **`rtol=1e-6`** (and a small
+  `atol`, e.g. `1e-9`). This is the typical reliable tolerance for sklearn outputs.
+
+```python
+import numpy as np
+
+# integer labels — exact
+assert np.array_equal(a["cluster_labels"], b["cluster_labels"])
+
+# float arrays — within tolerance
+assert np.allclose(a["embedding"], b["embedding"], rtol=1e-6, atol=1e-9)
+```
+
+### Cross-platform / BLAS caveat
+
+Bit-for-bit equality is guaranteed **within a single environment**. Across operating
+systems or BLAS implementations (OpenBLAS vs MKL vs Accelerate), floating-point
+reductions can reorder and produce differences at roughly the `1e-6`–`1e-12` level.
+Therefore:
+
+- Do **not** assert exact float equality across machines — use `rtol=1e-6`.
+- Cluster labels can in principle flip if two samples are near a decision boundary;
+  for golden tests prefer comparing them up to a label permutation, or assert on
+  stable derived quantities (counts, sorted distances) when an exact match is needed.
+- We do **not** pin a BLAS backend. If a future golden test proves sensitive at the
+  `1e-6` level, pin the BLAS implementation in that test's environment (e.g. via the
+  `threadpoolctl` / `OPENBLAS_*` env) and document it alongside the test.

--- a/openspec/changes/audit-stochastic-determinism/proposal.md
+++ b/openspec/changes/audit-stochastic-determinism/proposal.md
@@ -1,0 +1,73 @@
+# Proposal: Audit `random_state`/Seed Handling for Determinism
+
+## Why
+
+bloom-mcp's Phase 2 golden-value tests will assert that past analyses — including
+the wheat EDPIE paper's PCA, clustering, and UMAP results — reproduce within
+tolerance on every run and CI machine. If any stochastic function returns different
+output across runs with the same seed, those golden tests fail non-deterministically
+and waste debugging time (e.g. a flaky `perform_umap_analysis` embedding).
+
+Tracked by issue #118.
+
+**Audit result (this change is mostly verification + lock-in):** every genuinely
+stochastic public function *already* accepts a `random_state` and propagates it to
+its underlying sklearn/umap call, and an empirical two-run check confirms identical
+output (UMAP embeddings are bit-identical with a fixed seed). The gaps are not in the
+implementation but in the *guarantees*: there is no regression test pinning this
+behavior, and no documented tolerance policy. This change adds both, so the
+determinism contract is enforced and the cross-platform expectations are written
+down before the intern's golden tests land.
+
+### Audit findings
+
+| Function | Module | `random_state` | Propagated | Deterministic (2-run) |
+| --- | --- | --- | --- | --- |
+| `perform_pca_analysis` | `pca` | ✅ (=42) | ✅ via `fit_pca`/`select_n_components` | ✅ |
+| `perform_umap_analysis` | `umap` | ✅ (=42) | ✅ to `umap.UMAP` | ✅ (exact) |
+| `perform_kmeans_clustering` | `clustering` | ✅ (=42) | ✅ to `KMeans` | ✅ |
+| `perform_gmm_clustering` | `clustering` | ✅ (=42) | ✅ to `GaussianMixture` | ✅ |
+| `perform_hierarchical_clustering` | `clustering` | ➖ none | n/a | ✅ (deterministic) |
+| `detect_outliers_isolation_forest` | `outlier_detection` | ✅ (=42) | ✅ to `IsolationForest` | ✅ |
+| `detect_outliers_kmeans` | `outlier_detection` | ✅ (=42) | ✅ via `perform_kmeans_clustering` | ✅ |
+| `detect_outliers_gmm` | `outlier_detection` | ✅ (=42) | ✅ via `perform_gmm_clustering` | ✅ |
+| `detect_outliers_mahalanobis` | `outlier_detection` | ✅ (=42) | ✅ via `perform_pca_analysis` | ✅ |
+
+`perform_hierarchical_clustering` uses scipy `linkage`, which is **deterministic** —
+the same input always yields the same linkage matrix. Adding a no-op `random_state`
+would misrepresent the API, so it is documented as seed-free and covered by the
+determinism test instead.
+
+No other public function computes a stochastic result without a seed: the
+`create_umap_*` plot helpers consume a precomputed embedding (they do not run UMAP),
+and `create_phenotype_variation_plot` already calls `np.random.seed(42)` before
+adding jitter.
+
+## What Changes
+
+1. **Add `tests/test_reproducibility.py`** — for each stochastic public function,
+   run it twice with the same `random_state` on a shared small synthetic dataset and
+   assert output equality: exact for integer labels/indices and discrete metadata,
+   `rtol=1e-6` for float arrays (embeddings, transformed data, distances). Include
+   `perform_hierarchical_clustering` (no seed) to lock in its determinism. Add a
+   smoke check that each function accepts `random_state=None` without error.
+
+2. **Add `docs/reproducibility.md`** — the seeding and tolerance policy: which
+   functions are stochastic and their default seed (`42`); the determinism guarantee
+   (same seed + same input + same environment → identical output); the
+   float-comparison tolerance (`rtol=1e-6`, integer labels exact) and the
+   cross-platform/BLAS caveat; and the note that hierarchical clustering is
+   deterministic and seed-free.
+
+3. **No production code change is required** — the audit confirmed every stochastic
+   function already exposes and propagates `random_state`. (If the determinism test
+   surfaces any propagation gap, the minimal fix is folded in under this change.)
+
+## Impact
+
+- Affected specs: **stochastic-determinism** (new capability).
+- Affected code:
+  - `tests/test_reproducibility.py` (new)
+  - `docs/reproducibility.md` (new)
+- **No behavior change** to any analysis function — this adds a regression test and
+  documentation that pin existing behavior.

--- a/openspec/changes/audit-stochastic-determinism/specs/stochastic-determinism/spec.md
+++ b/openspec/changes/audit-stochastic-determinism/specs/stochastic-determinism/spec.md
@@ -1,0 +1,60 @@
+# stochastic-determinism Specification
+
+## ADDED Requirements
+
+### Requirement: Seeded Stochastic Public Functions
+
+Every public function whose result depends on a random number generator SHALL accept
+a `random_state` parameter and propagate it to the underlying sklearn/umap estimator,
+so a fixed seed yields a reproducible result.
+
+#### Scenario: Stochastic functions expose and propagate a seed
+
+- **WHEN** any of `perform_pca_analysis`, `perform_umap_analysis`,
+  `perform_kmeans_clustering`, `perform_gmm_clustering`,
+  `detect_outliers_isolation_forest`, `detect_outliers_kmeans`,
+  `detect_outliers_gmm`, or `detect_outliers_mahalanobis` is called
+- **THEN** it SHALL accept a `random_state` argument
+- **AND** that value SHALL reach the underlying random-using estimator
+
+#### Scenario: Deterministic functions need no seed
+
+- **WHEN** `perform_hierarchical_clustering` is called twice with the same input
+- **THEN** it SHALL return an identical linkage matrix without requiring a
+  `random_state` argument
+
+### Requirement: Reproducible Outputs Under a Fixed Seed
+
+Stochastic public functions SHALL produce identical output, within a documented
+numerical tolerance, when called repeatedly with the same `random_state` and input.
+
+#### Scenario: Two runs with the same seed match
+
+- **WHEN** a stochastic public function is run twice with the same `random_state`
+  and the same input data
+- **THEN** integer cluster labels and outlier indices SHALL be exactly equal
+- **AND** floating-point arrays (embeddings, transformed data, distances) SHALL be
+  equal within `rtol=1e-6`
+
+#### Scenario: A regression test enforces determinism
+
+- **WHEN** the test suite runs
+- **THEN** `tests/test_reproducibility.py` SHALL execute each stochastic public
+  function twice and assert output equality, failing if any function becomes
+  non-deterministic under a fixed seed
+
+### Requirement: Documented Reproducibility Policy
+
+The project SHALL document its seeding and numerical-tolerance policy so consumers
+(including golden-value tests) know what reproducibility to expect.
+
+#### Scenario: Reproducibility policy is documented
+
+- **WHEN** `docs/reproducibility.md` is viewed
+- **THEN** it SHALL list the stochastic public functions and their default seed
+- **AND** it SHALL state the determinism guarantee (same seed + input + environment
+  → identical output)
+- **AND** it SHALL state the float-comparison tolerance (`rtol=1e-6`, integer labels
+  exact) and the cross-platform/BLAS caveat
+- **AND** it SHALL note that `perform_hierarchical_clustering` is deterministic and
+  requires no seed

--- a/openspec/changes/audit-stochastic-determinism/tasks.md
+++ b/openspec/changes/audit-stochastic-determinism/tasks.md
@@ -1,0 +1,29 @@
+# Tasks: Audit `random_state`/Seed Handling for Determinism
+
+## 1. Determinism regression test (write the check)
+
+- [x] 1.1 Add `tests/test_reproducibility.py` with a shared small synthetic dataset
+  fixture (clustered, NaN-free, a few dozen samples × handful of features).
+- [x] 1.2 For each seeded stochastic function (`perform_pca_analysis`,
+  `perform_umap_analysis`, `perform_kmeans_clustering`, `perform_gmm_clustering`,
+  `detect_outliers_isolation_forest`, `detect_outliers_kmeans`, `detect_outliers_gmm`,
+  `detect_outliers_mahalanobis`): run twice with `random_state=42` and assert key
+  outputs equal — exact for integer labels/indices, `rtol=1e-6` for float arrays.
+- [x] 1.3 Add a `perform_hierarchical_clustering` case: run twice (no seed) and assert
+  the linkage matrix is identical.
+- [x] 1.4 Add a smoke test that each seeded function accepts `random_state=None`
+  without raising.
+- [x] 1.5 Confirm the suite passes (audit found all functions already deterministic);
+  if any function is non-deterministic, fix propagation minimally and note it here.
+
+## 2. Documentation
+
+- [x] 2.1 Add `docs/reproducibility.md`: stochastic-function inventory + default seed,
+  the determinism guarantee, the `rtol=1e-6` / exact-labels tolerance policy, the
+  cross-platform/BLAS caveat, and the hierarchical-is-deterministic note.
+
+## 3. Validation
+
+- [x] 3.1 `uv run pytest tests/test_reproducibility.py` passes.
+- [x] 3.2 `uv run black --check` + `uv run ruff check` clean on changed files.
+- [x] 3.3 `openspec validate audit-stochastic-determinism --strict` passes.

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -1,0 +1,176 @@
+"""Determinism regression tests for stochastic public functions (issue #118).
+
+bloom-mcp's Phase 2 golden-value tests reproduce past analyses (wheat EDPIE PCA,
+clustering, UMAP) and rely on every stochastic function returning identical output
+for a fixed ``random_state``. These tests run each stochastic public function twice
+with the same seed and assert the reproducibility-bearing outputs match — exactly for
+integer labels/indices, within ``rtol`` for floating-point arrays.
+
+See ``docs/reproducibility.md`` for the seeding and tolerance policy.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import sleap_roots_analyze as sra
+from sleap_roots_analyze.clustering import perform_hierarchical_clustering
+
+# Tolerance for floating-point arrays. Within a single machine the outputs are
+# bit-identical; rtol=1e-6 leaves headroom for cross-platform BLAS differences
+# (see docs/reproducibility.md).
+RTOL = 1e-6
+ATOL = 1e-9
+
+SEED = 42
+N_FEATURES = 6
+
+
+@pytest.fixture(scope="module")
+def synthetic_df():
+    """Small clustered, NaN-free dataset shared across determinism checks.
+
+    Returns:
+        DataFrame of 60 samples x 6 features drawn from 3 well-separated clusters,
+        built from a fixed seed so the fixture itself is reproducible.
+    """
+    rng = np.random.RandomState(0)
+    centers = rng.randn(3, N_FEATURES) * 5
+    blocks = [centers[i] + rng.randn(20, N_FEATURES) for i in range(3)]
+    data = np.vstack(blocks)
+    return pd.DataFrame(data, columns=[f"f{i}" for i in range(N_FEATURES)])
+
+
+@pytest.fixture(scope="module")
+def feature_cols():
+    """Feature column names matching :func:`synthetic_df`.
+
+    Returns:
+        List of the six feature column names.
+    """
+    return [f"f{i}" for i in range(N_FEATURES)]
+
+
+def _assert_key_equal(result_a, result_b, key, mode):
+    """Assert two result dicts agree on one key.
+
+    Args:
+        result_a: First result dictionary.
+        result_b: Second result dictionary.
+        key: Key to compare.
+        mode: "exact" for array-equal (labels/indices) or "close" for ``rtol``.
+
+    Returns:
+        None. Raises AssertionError if the values differ.
+    """
+    a = np.asarray(result_a[key])
+    b = np.asarray(result_b[key])
+    if mode == "exact":
+        assert np.array_equal(a, b), f"{key} differs between runs (exact)"
+    else:
+        assert np.allclose(
+            a.astype(float), b.astype(float), rtol=RTOL, atol=ATOL, equal_nan=True
+        ), f"{key} differs between runs (rtol={RTOL})"
+
+
+# (label, callable, extra-kwargs-builder, [(key, mode), ...])
+# extra-kwargs-builder receives (df, feature_cols) and returns the non-seed kwargs.
+_CASES = [
+    (
+        "perform_pca_analysis",
+        sra.perform_pca_analysis,
+        lambda df, fc: {},
+        [
+            ("transformed_data", "close"),
+            ("loadings", "close"),
+            ("eigenvalues", "close"),
+        ],
+    ),
+    (
+        "perform_umap_analysis",
+        sra.perform_umap_analysis,
+        lambda df, fc: {"feature_cols": fc},
+        [("embedding", "close")],
+    ),
+    (
+        "perform_kmeans_clustering",
+        sra.perform_kmeans_clustering,
+        lambda df, fc: {"n_clusters": 3},
+        [
+            ("cluster_labels", "exact"),
+            ("cluster_centers", "close"),
+            ("inertia", "close"),
+        ],
+    ),
+    (
+        "perform_gmm_clustering",
+        sra.perform_gmm_clustering,
+        lambda df, fc: {"n_components": 3},
+        [("cluster_labels", "exact"), ("means", "close")],
+    ),
+    (
+        "detect_outliers_isolation_forest",
+        sra.detect_outliers_isolation_forest,
+        lambda df, fc: {},
+        [("outlier_indices", "exact"), ("anomaly_scores", "close")],
+    ),
+    (
+        "detect_outliers_kmeans",
+        sra.detect_outliers_kmeans,
+        lambda df, fc: {},
+        [("cluster_labels", "exact"), ("min_distances_to_centers", "close")],
+    ),
+    (
+        "detect_outliers_gmm",
+        sra.detect_outliers_gmm,
+        lambda df, fc: {},
+        [("cluster_labels", "exact"), ("probabilities", "close")],
+    ),
+    (
+        "detect_outliers_mahalanobis",
+        sra.detect_outliers_mahalanobis,
+        lambda df, fc: {},
+        [("outlier_indices", "exact"), ("mahalanobis_distances", "close")],
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "name, func, kwargs_for, keys", _CASES, ids=[c[0] for c in _CASES]
+)
+def test_same_seed_is_reproducible(
+    name, func, kwargs_for, keys, synthetic_df, feature_cols
+):
+    """Each seeded stochastic function returns identical output across two runs."""
+    kwargs = kwargs_for(synthetic_df, feature_cols)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result_a = func(synthetic_df, random_state=SEED, **kwargs)
+        result_b = func(synthetic_df, random_state=SEED, **kwargs)
+    for key, mode in keys:
+        _assert_key_equal(result_a, result_b, key, mode)
+
+
+def test_hierarchical_clustering_is_deterministic(synthetic_df):
+    """perform_hierarchical_clustering is deterministic and needs no seed."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result_a = perform_hierarchical_clustering(synthetic_df)
+        result_b = perform_hierarchical_clustering(synthetic_df)
+    _assert_key_equal(result_a, result_b, "linkage_matrix", "close")
+
+
+@pytest.mark.parametrize(
+    "name, func, kwargs_for, keys", _CASES, ids=[c[0] for c in _CASES]
+)
+def test_accepts_random_state_none(
+    name, func, kwargs_for, keys, synthetic_df, feature_cols
+):
+    """Each seeded function accepts random_state=None without raising."""
+    kwargs = kwargs_for(synthetic_df, feature_cols)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        result = func(synthetic_df, random_state=None, **kwargs)
+    assert isinstance(result, dict)


### PR DESCRIPTION
Closes #118.

## Summary

Locks in **deterministic reproducibility** of the stochastic public functions so bloom-mcp's Phase 2 golden-value tests (reproducing the wheat EDPIE paper's PCA, clustering, and UMAP results) are stable across runs and CI machines.

**Audit finding:** the implementation was already correct — every genuinely stochastic public function accepts a `random_state` (default `42`) and propagates it to its underlying sklearn/umap estimator, and an empirical two-run check confirms identical output (UMAP embeddings are bit-identical with a fixed seed). The gaps were in the *guarantees*, not the code: there was no regression test pinning this and no documented tolerance policy. This PR adds both. **No production code change was required.**

## Audit results

| Function | Module | `random_state` | Propagated | Deterministic (2-run) |
|---|---|---|---|---|
| `perform_pca_analysis` | `pca` | ✅ (=42) | ✅ via `fit_pca` | ✅ |
| `perform_umap_analysis` | `umap` | ✅ (=42) | ✅ to `umap.UMAP` | ✅ (exact) |
| `perform_kmeans_clustering` | `clustering` | ✅ (=42) | ✅ to `KMeans` | ✅ |
| `perform_gmm_clustering` | `clustering` | ✅ (=42) | ✅ to `GaussianMixture` | ✅ |
| `perform_hierarchical_clustering` | `clustering` | ➖ none | n/a | ✅ (deterministic) |
| `detect_outliers_isolation_forest` | `outlier_detection` | ✅ (=42) | ✅ to `IsolationForest` | ✅ |
| `detect_outliers_kmeans` | `outlier_detection` | ✅ (=42) | ✅ via `perform_kmeans_clustering` | ✅ |
| `detect_outliers_gmm` | `outlier_detection` | ✅ (=42) | ✅ via `perform_gmm_clustering` | ✅ |
| `detect_outliers_mahalanobis` | `outlier_detection` | ✅ (=42) | ✅ via `perform_pca_analysis` | ✅ |

`perform_hierarchical_clustering` uses scipy `linkage`, which is **deterministic** — same input → same linkage matrix. It intentionally takes no `random_state` (a no-op param would misrepresent the API); its determinism is covered by the test instead. No other public function computes a stochastic result without a seed (`create_umap_*` plot helpers consume a precomputed embedding; `create_phenotype_variation_plot` already seeds its jitter).

## Deliverables (issue #118 acceptance)

- [x] Every stochastic public function takes `random_state` and propagates it — verified by audit.
- [x] `tests/test_reproducibility.py` runs each twice and asserts equality.
- [x] Tolerance policy documented in `docs/reproducibility.md`.

## What's added

- **`tests/test_reproducibility.py`** — for each stochastic function: run twice with `random_state=42`, assert **exact** equality for integer labels/outlier indices and **`rtol=1e-6`** for float arrays (embeddings, transformed data, loadings, distances, centers). Plus a `perform_hierarchical_clustering` determinism case and a `random_state=None` smoke test. (17 tests)
- **`docs/reproducibility.md`** — seeding inventory + defaults, the determinism guarantee, the `rtol=1e-6` / exact-labels tolerance policy, and the cross-platform/BLAS caveat (no BLAS pinned; widen comparisons or pin per-test if a golden test proves sensitive).
- OpenSpec change `audit-stochastic-determinism` (proposal, `stochastic-determinism` spec, tasks).

## Design notes

- **Tolerance split:** integer cluster labels / outlier indices are compared exactly; floats use `rtol=1e-6` to leave headroom for cross-platform BLAS reordering. Documented so golden tests adopt the same policy.
- **Hierarchical stays seed-free** rather than gaining a misleading no-op `random_state` — the honest representation of a deterministic algorithm.
- **`random_state` left typed as `int = 42`** (not widened to `Optional[int]`): the functions already forward `None` correctly to sklearn, the smoke test proves it, and golden tests pass a fixed seed — so no signature churn was warranted.

## Validation

- `uv run pytest tests/test_reproducibility.py` → **17 passed**
- `uv run pytest -m "not integration"` → **2027 passed**, 0 failed (2 integration deselected)
- `black --check` + `ruff check` clean on changed files
- `openspec validate audit-stochastic-determinism --strict` → valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)