### PR TITLE
feat: add PCAResult serializable dataclass + adapter (#127)

### DIFF
--- a/openspec/changes/add-pcaresult-dataclass/proposal.md
+++ b/openspec/changes/add-pcaresult-dataclass/proposal.md
@@ -1,0 +1,88 @@
+# Add PCAResult Serializable Dataclass Return Type (issue #127)
+
+## Why
+
+`perform_pca_analysis()` (`pca.py`) returns a `Dict` that mixes four
+serializability classes in one bag: clean scalars/lists
+(`n_components_selected`, `feature_names`), `np.ndarray` fields
+(`loadings`, `transformed_data`, `explained_variance_ratio`, `eigenvalues`),
+`pd.DataFrame` fields (`feature_contributions`, `feature_metrics_df`), and
+non-serializable sklearn objects (`pca`, `scaler`). This makes the function
+impossible to expose over any JSON boundary — bloom-mcp (Metcalf 2026), an API,
+or a cached artifact — without bespoke conversion.
+
+The package already has JSON-safe stdlib `@dataclass` result types in
+`summary/cross_platform_summary.py` (`TraitReductionStats`, `PowerStats`,
+`CorrelationStats`, `TopCorrelation`, …) and the `EnrichmentResult` pattern
+(flat, JSON-native, `to_dict()`). This change extends that pattern to PCA as the
+**detailed exemplar** for the serializable-result-types epic (#130), with #128
+(`HeritabilityResult`) and #129 (`ClusterResult`) following the identical
+convention.
+
+## What Changes
+
+- **New module `src/sleap_roots_analyze/result_types.py`** — the shared home for
+  the epic's serializable result types (PCA now; heritability/cluster later). It
+  imports nothing from `pca.py`, keeping dependencies one-way.
+- **`PCAResult` and `FeatureContribution` stdlib dataclasses** exposing **only
+  serializable science** — sklearn `pca`/`scaler` objects stay out of the clean
+  view (still available via the legacy dict for in-process callers).
+  `frozen=True` and a `to_dict()` convenience (`asdict(self)`), matching the
+  `CrossPlatformPCResult`/`EnrichmentResult` precedent. Every scalar is cast to
+  a native Python `int`/`float`/`bool` (numpy scalars like `np.int64` are **not**
+  reliably JSON-serializable), so `json.dumps(dataclasses.asdict(result))`
+  round-trips with no custom serializer.
+- **`PCAResult.from_pca_dict(d, *, random_state=None, explained_variance_threshold=None)`
+  adapter** mapping the existing `perform_pca_analysis` return dict into the
+  dataclass:
+  - `scores` is built from `d["transformed_data"]` (the dict has no `scores`
+    key); arrays are copied via `.tolist()`.
+  - `feature_contributions` is built from the DataFrame **index** (the source is
+    sorted by `total_contribution` descending, indexed by feature name), so the
+    name↔value correspondence and ordering are preserved — not a positional zip
+    against `feature_names`.
+  - `standardized` is `d["scaler"] is not None` (equivalent to the requested
+    `standardize` flag given the function's guarantees).
+  - `cumulative_variance_ratio` is carried from `d["cumulative_variance_ratio"]`
+    (per-component cumsum), not discarded.
+  - `random_state` / `explained_variance_threshold` are stamped from the adapter
+    arguments (they are not present in the dict) for reproducibility provenance.
+  - The per-PC `PC{k}_variance_contrib` columns and the redundant
+    `feature_metrics_df` are intentionally omitted from the clean view.
+- **`@property cumulative_variance`** returning the summed retained
+  explained-variance ratio as a native `float`.
+- **Public exports.** `PCAResult` and `FeatureContribution` added to the package
+  `__all__` (in `__init__.py`) with full type hints + Google-style docstrings
+  whose `Attributes:` block documents every field — this exemplar sets the
+  convention #128/#129 copy.
+- **Additive / non-breaking.** `perform_pca_analysis` keeps returning its dict
+  unchanged (MINOR bump); `from_pca_dict` does not mutate its input. No existing
+  key, shape, or caller (`result["loadings"]`, the wheat EDPIE paper, the
+  pipeline) changes.
+- **Tests.** A `json.dumps(asdict(...))` round-trip that asserts **native Python
+  types after `json.loads`** (feeds the reproducibility CI gate), plus adapter
+  tests over real `perform_pca_analysis` runs: array shapes equal `n_components`,
+  the `standardized` flag for both `standardize` branches, determinism for a
+  fixed `random_state` (epic #118), `n_components=1` shape preservation,
+  `feature_contributions` ordering/name fidelity, no sklearn object in the view,
+  and a dict-unchanged/non-mutating guard.
+
+## Out of Scope (deferred to the epic)
+
+- The epic-wide `docs/result-types.md` pattern doc (#130 acceptance) is deferred
+  to the epic-closing child so it can describe the convention across all three
+  result types rather than PCA alone; #127 seeds the runnable exemplar in code.
+- Golden numeric validation of `PCAResult` fields against the wheat EDPIE
+  reference values is deferred to the epic's verification milestone (#120/#130);
+  #127 covers structure, types, serialization, provenance, and determinism only.
+
+## Impact
+
+- Affected specs: **new** `serializable-result-types` capability (the durable
+  home for the epic's pattern; #128/#129 will add requirements here).
+- Affected code: **new** `src/sleap_roots_analyze/result_types.py` (dataclasses +
+  adapter); `src/sleap_roots_analyze/__init__.py` (`__all__` exports);
+  **new** `tests/test_pca_result.py`. The two new `__all__` entries must satisfy
+  the existing `tests/test_public_api_docs.py` introspection contract (type
+  hints + Google docstrings); there is no hardcoded count to update.
+- No breaking changes; purely additive public API (MINOR version bump).

--- a/openspec/changes/add-pcaresult-dataclass/specs/serializable-result-types/spec.md
+++ b/openspec/changes/add-pcaresult-dataclass/specs/serializable-result-types/spec.md
@@ -1,0 +1,126 @@
+# serializable-result-types Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Serializable PCA Result Type
+
+The package SHALL provide a frozen stdlib `@dataclass` `PCAResult` (with a nested
+`FeatureContribution` dataclass) in `result_types.py` that captures only the
+JSON-serializable science of a `perform_pca_analysis()` run, excluding sklearn
+`PCA`/`StandardScaler` objects. Every scalar field SHALL be a native Python type
+(`int`, `float`, `str`, `bool`) — not a numpy scalar — and every array field a
+list thereof, so that `json.dumps(dataclasses.asdict(result))` succeeds without a
+custom serializer. `PCAResult` SHALL provide a `to_dict()` method returning
+`dataclasses.asdict(self)`.
+
+#### Scenario: PCAResult round-trips through JSON as native types
+
+- **WHEN** a `PCAResult` is built from a `perform_pca_analysis()` return dict and
+  passed to `json.dumps(dataclasses.asdict(result))`
+- **THEN** the call SHALL succeed without raising
+- **AND** parsing the string back with `json.loads` SHALL yield `n_components` as
+  a Python `int`, `standardized` as a Python `bool`, and every element of
+  `explained_variance_ratio`, `eigenvalues`, `cumulative_variance_ratio`,
+  `loadings`, and `scores` as a Python `float` (no `np.int64`/`np.float64`)
+- **AND** the round-tripped numeric values SHALL equal the input values within
+  floating-point tolerance
+
+#### Scenario: No sklearn object is present in the clean view
+
+- **WHEN** `dataclasses.asdict(result)` is inspected
+- **THEN** it SHALL contain no sklearn `PCA` or `StandardScaler` object
+- **AND** SHALL contain no `pca`, `scaler`, or `feature_metrics_df` key
+
+#### Scenario: cumulative_variance property sums retained components
+
+- **WHEN** `result.cumulative_variance` is accessed
+- **THEN** it SHALL return a native Python `float` equal to the sum of
+  `explained_variance_ratio` over the retained components
+
+### Requirement: PCAResult Adapter From Legacy Dict
+
+The package SHALL provide
+`PCAResult.from_pca_dict(d, *, random_state=None, explained_variance_threshold=None)`
+that maps the canonical `perform_pca_analysis()` return dict into a `PCAResult`.
+The adapter SHALL assume the canonical key set (`n_components_selected`,
+`feature_names`, `loadings`, `eigenvalues`, `explained_variance_ratio`,
+`cumulative_variance_ratio`, `transformed_data`, `scaler`,
+`feature_contributions`); behavior on a partial dict is unspecified. The adapter
+SHALL NOT mutate `d`.
+
+#### Scenario: Adapter maps the core fields from a real run
+
+- **WHEN** `PCAResult.from_pca_dict(d)` is called on the dict returned by
+  `perform_pca_analysis()`
+- **THEN** `n_components` SHALL equal `int(d["n_components_selected"])`
+- **AND** `explained_variance_ratio`, `eigenvalues`, and
+  `cumulative_variance_ratio` SHALL each be a `list[float]` of length
+  `n_components`
+- **AND** `scores` SHALL be built from `d["transformed_data"]` as a nested
+  `list[list[float]]` of shape `(n_samples, n_components)`
+- **AND** `loadings` SHALL be a nested `list[list[float]]` of shape
+  `(n_features, n_components)`
+
+#### Scenario: Nested shapes are preserved at n_components == 1
+
+- **WHEN** a run retains a single component and `from_pca_dict` is applied
+- **THEN** `loadings` SHALL be `(n_features, 1)` and `scores` SHALL be
+  `(n_samples, 1)` — each inner row a one-element list, not a flattened scalar
+
+#### Scenario: standardized flag reflects whether standardization was applied
+
+- **WHEN** `from_pca_dict` is applied to a run with `standardize=True`
+- **THEN** `standardized` SHALL be `True` (the dict carries a fitted `scaler`)
+- **WHEN** `from_pca_dict` is applied to a run with `standardize=False`
+- **THEN** `standardized` SHALL be `False` (`d["scaler"]` is `None`)
+
+#### Scenario: feature_contributions preserve order and name↔value correspondence
+
+- **WHEN** `from_pca_dict` converts the `feature_contributions` DataFrame
+- **THEN** the resulting list SHALL be ordered by `total_contribution`
+  descending, matching the source DataFrame row order
+- **AND** each `FeatureContribution.feature` SHALL be the DataFrame **index**
+  label for its row (not a positional pairing with `feature_names`)
+- **AND** its `total_contribution` and `fractional_contribution` SHALL be native
+  `float` values equal to that row's values
+
+#### Scenario: Provenance arguments are stamped into the result
+
+- **WHEN** `from_pca_dict(d, random_state=42, explained_variance_threshold=0.95)`
+  is called
+- **THEN** `result.random_state` SHALL be `42` and
+  `result.explained_variance_threshold` SHALL be `0.95`
+- **WHEN** the provenance arguments are omitted
+- **THEN** both fields SHALL be `None`
+
+### Requirement: PCAResult Public Export
+
+The package SHALL export `PCAResult` and `FeatureContribution` from the top-level
+`sleap_roots_analyze` namespace and list them in `__all__`.
+
+#### Scenario: Result types importable from package root
+
+- **WHEN** a consumer runs
+  `from sleap_roots_analyze import PCAResult, FeatureContribution`
+- **THEN** the import SHALL succeed
+- **AND** both names SHALL appear in `sleap_roots_analyze.__all__` with no
+  duplicate entries
+
+### Requirement: Non-Breaking PCA Return Shape
+
+Adding `PCAResult` SHALL NOT change the return shape of
+`perform_pca_analysis()`; the function SHALL keep returning its existing dict so
+all current callers (`result["loadings"]`, the wheat EDPIE paper, the pipeline)
+continue to work unchanged.
+
+#### Scenario: Existing dict return is preserved and not mutated
+
+- **WHEN** `perform_pca_analysis()` is called
+- **THEN** it SHALL return a `dict` containing the existing keys (including
+  `loadings`, `transformed_data`, `explained_variance_ratio`, `eigenvalues`,
+  `cumulative_variance_ratio`, `feature_names`, `feature_contributions`,
+  `scaler`, `pca`, `n_components_selected`)
+- **AND** calling `PCAResult.from_pca_dict(d)` SHALL leave `d`'s keys and values
+  unchanged
+- **AND** the `PCAResult` view SHALL be opt-in, built only via
+  `PCAResult.from_pca_dict()`

--- a/openspec/changes/add-pcaresult-dataclass/tasks.md
+++ b/openspec/changes/add-pcaresult-dataclass/tasks.md
@@ -1,0 +1,77 @@
+# Tasks — Add PCAResult Serializable Dataclass (issue #127)
+
+> Commit strategy: a single `feat: add PCAResult serializable dataclass (#127)`
+> commit (the repo does not commit red tests separately; CI must be green at
+> HEAD). The export edit and the introspection-guard bump MUST land in the same
+> commit as the dataclass definitions. OpenSpec archive happens post-merge as a
+> separate `chore:` commit.
+
+## 1. Failing tests first (red) — `tests/test_pca_result.py`
+- [x] 1.1 `test_pcaresult_json_roundtrip_native_types`: run `perform_pca_analysis`
+      on a small synthetic frame, build `PCAResult.from_pca_dict(d)`, assert
+      `json.dumps(dataclasses.asdict(result))` does not raise, then `json.loads`
+      it and assert `n_components` is `int`, `standardized` is `bool`, and every
+      element of `explained_variance_ratio`/`eigenvalues`/
+      `cumulative_variance_ratio`/`loadings`/`scores` is native `float`. Assert
+      `"pca"`, `"scaler"`, `"feature_metrics_df"` are absent from `asdict`.
+- [x] 1.2 `test_adapter_maps_core_fields`: assert `n_components ==
+      int(d["n_components_selected"])`; `explained_variance_ratio`/`eigenvalues`/
+      `cumulative_variance_ratio` are `list[float]` of length `n_components`;
+      `scores` is sourced from `d["transformed_data"]` with shape
+      `(n_samples, n_components)`; `loadings` shape `(n_features, n_components)`.
+      Use a fixture where retained `n_components < n_features` so the shape
+      checks are non-trivial.
+- [x] 1.3 `test_feature_contributions_order_and_names`: assert the list is
+      ordered by `total_contribution` descending and each
+      `FeatureContribution.feature` is the DataFrame index label with values
+      equal to `feature_contributions.loc[feature]` (catches a positional-zip
+      mis-alignment against `feature_names`).
+- [x] 1.4 `test_standardized_flag` parametrized over `standardize in (True,
+      False)`: `result.standardized is standardize`, and `json.dumps(asdict)`
+      succeeds in both branches.
+- [x] 1.5 `test_pcaresult_deterministic`: same `random_state` → identical
+      `asdict(r1) == asdict(r2)` and identical `json.dumps` output (epic #118).
+- [x] 1.6 `test_n_components_one_shapes`: a run retaining a single component
+      keeps `loadings` `(n_features, 1)` and `scores` `(n_samples, 1)` nested
+      (no flatten/squeeze).
+- [x] 1.7 `test_cumulative_variance_property`: `pytest.approx(sum(evr))`, value
+      in `(0, 1]`, native `float`.
+- [x] 1.8 `test_provenance_args`: `from_pca_dict(d, random_state=42,
+      explained_variance_threshold=0.95)` stamps both fields; omitting them
+      yields `None`.
+- [x] 1.9 `test_exports_and_all`: `from sleap_roots_analyze import PCAResult,
+      FeatureContribution` succeeds; both in `__all__`, no dupes.
+- [x] 1.10 `test_perform_pca_analysis_dict_unchanged`: returned dict still
+      contains the canonical keys; `from_pca_dict(d)` does not mutate `d`.
+
+## 2. Implement to green
+- [x] 2.1 Create `src/sleap_roots_analyze/result_types.py` with `from __future__
+      import annotations`, module docstring, and the `FeatureContribution` +
+      frozen `PCAResult` dataclasses. Google-style class docstrings with an
+      `Attributes:` block documenting **every** field (type, meaning, and
+      shape/units, e.g. `loadings: (n_features, n_components) nested list`).
+      Required fields first, then `random_state`/`explained_variance_threshold`
+      (`= None`), then `feature_contributions = field(default_factory=list)`.
+- [x] 2.2 Implement `PCAResult.from_pca_dict()`: `scores` from
+      `transformed_data`; `cumulative_variance_ratio` from the dict; explicit
+      `int()`/`float()` scalar casts; `feature_contributions` built from the
+      DataFrame index (preserving sort order); `standardized` from `scaler is not
+      None`; provenance args stamped; no mutation of `d`.
+- [x] 2.3 Implement `@property cumulative_variance` (native `float`) and
+      `to_dict()` returning `dataclasses.asdict(self)`.
+- [x] 2.4 Export `PCAResult`, `FeatureContribution` from `__init__.py` (import +
+      add to `__all__`). Note: `pca.py` has no `__all__`; exports live only in
+      `__init__.py`.
+- [x] 2.5 Ensure the two new names satisfy the `__all__` introspection contract
+      (`tests/test_public_api_docs.py` checks every `__all__` entry for complete
+      type hints + parsable Google docstrings): no hardcoded count to bump, but
+      `PCAResult`/`FeatureContribution` must have resolvable annotations and
+      Google-style docstrings so the contract test stays green.
+
+## 3. Verify non-breaking
+- [x] 3.1 Confirm `perform_pca_analysis()` return dict is unchanged and existing
+      `tests/test_pca*.py` pass (covered concretely by task 1.10).
+
+## 4. Pre-merge
+- [x] 4.1 `black` + `ruff` + full `pytest` + coverage green; `openspec validate
+      add-pcaresult-dataclass --strict` passes.

--- a/src/sleap_roots_analyze/__init__.py
+++ b/src/sleap_roots_analyze/__init__.py
@@ -41,6 +41,11 @@ from sleap_roots_analyze.pca import (
     run_pca_and_export_artifacts,
 )
 
+from sleap_roots_analyze.result_types import (
+    FeatureContribution,
+    PCAResult,
+)
+
 from sleap_roots_analyze.umap import (
     perform_umap_analysis,
 )
@@ -209,6 +214,9 @@ __all__ = [
     "calculate_pca_metrics",
     "build_feature_metrics_df",
     "run_pca_and_export_artifacts",
+    # Serializable result types (#130)
+    "PCAResult",
+    "FeatureContribution",
     # UMAP functions
     "perform_umap_analysis",
     # Clustering functions

--- a/src/sleap_roots_analyze/result_types.py
+++ b/src/sleap_roots_analyze/result_types.py
@@ -1,0 +1,154 @@
+"""Serializable stdlib dataclass result types for analytical functions.
+
+This module is the shared home for the serializable-result-types epic (#130):
+flat ``@dataclass`` views that hold **only JSON-serializable science** — native
+Python scalars and lists, never ``numpy`` arrays, ``pandas`` frames, or sklearn
+objects. Because every field is JSON-native, ``json.dumps(asdict(result))``
+round-trips with no custom serializer, which is what lets these results cross a
+JSON boundary (bloom-mcp, a cached artifact, an API) and anchor the
+reproducibility CI gate.
+
+The first type is :class:`PCAResult` (issue #127, the detailed exemplar);
+``HeritabilityResult`` (#128) and ``ClusterResult`` (#129) follow the same
+convention here. This module imports nothing from the analytical modules
+(``pca.py`` etc.) so dependencies stay one-way.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+import numpy as np
+
+__all__ = ["FeatureContribution", "PCAResult"]
+
+
+@dataclass(frozen=True)
+class FeatureContribution:
+    """A single feature's contribution to the retained PCA components.
+
+    Attributes:
+        feature: Feature (column) name the contribution belongs to.
+        total_contribution: Sum over retained components of
+            ``loading**2 * eigenvalue`` for this feature (variance contributed).
+        fractional_contribution: ``total_contribution`` normalized to sum to 1
+            across all features.
+    """
+
+    feature: str
+    total_contribution: float
+    fractional_contribution: float
+
+
+@dataclass(frozen=True)
+class PCAResult:
+    """JSON-serializable view of a PCA run (science only, no sklearn objects).
+
+    Built from the legacy ``perform_pca_analysis`` dict via
+    :meth:`from_pca_dict`. Component-indexed fields cover only the retained
+    components; the fitted ``PCA``/``StandardScaler`` objects are intentionally
+    excluded (still available via the legacy dict for in-process callers).
+
+    Attributes:
+        n_components: Number of retained principal components.
+        feature_names: Feature (column) names in their original order; row order
+            of ``loadings``.
+        explained_variance_ratio: Per-component fraction of total variance
+            explained, length ``n_components``.
+        eigenvalues: Per-component eigenvalues, length ``n_components``.
+        cumulative_variance_ratio: Per-component cumulative sum of
+            ``explained_variance_ratio``, length ``n_components``.
+        loadings: ``(n_features, n_components)`` nested list of component
+            loadings.
+        scores: ``(n_samples, n_components)`` nested list of transformed sample
+            coordinates.
+        standardized: Whether the data was standardized (a ``StandardScaler``
+            was fitted) before PCA.
+        random_state: Random state used for the run, stamped for reproducibility
+            provenance; ``None`` if not supplied to the adapter.
+        explained_variance_threshold: Cumulative-variance threshold used for
+            component selection, stamped for provenance; ``None`` if not
+            supplied to the adapter.
+        feature_contributions: Per-feature contributions, ordered by
+            ``total_contribution`` descending.
+    """
+
+    n_components: int
+    feature_names: list[str]
+    explained_variance_ratio: list[float]
+    eigenvalues: list[float]
+    cumulative_variance_ratio: list[float]
+    loadings: list[list[float]]
+    scores: list[list[float]]
+    standardized: bool
+    random_state: Optional[int] = None
+    explained_variance_threshold: Optional[float] = None
+    feature_contributions: list[FeatureContribution] = field(default_factory=list)
+
+    @property
+    def cumulative_variance(self) -> float:
+        """Total fraction of variance explained by the retained components."""
+        return float(sum(self.explained_variance_ratio))
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain ``dict`` view via :func:`dataclasses.asdict`."""
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_pca_dict(
+        cls,
+        d: dict,
+        *,
+        random_state: Optional[int] = None,
+        explained_variance_threshold: Optional[float] = None,
+    ) -> "PCAResult":
+        """Build a :class:`PCAResult` from a ``perform_pca_analysis`` dict.
+
+        Assumes the canonical key set returned by ``perform_pca_analysis``
+        (``n_components_selected``, ``feature_names``, ``loadings``,
+        ``eigenvalues``, ``explained_variance_ratio``,
+        ``cumulative_variance_ratio``, ``transformed_data``, ``scaler``,
+        ``feature_contributions``). Does not mutate ``d``.
+
+        Args:
+            d: The dict returned by ``perform_pca_analysis``.
+            random_state: Random state to stamp into the result for provenance.
+            explained_variance_threshold: Threshold to stamp into the result for
+                provenance.
+
+        Returns:
+            A frozen :class:`PCAResult` holding only JSON-serializable science.
+        """
+        n = int(d["n_components_selected"])
+
+        fc_df = d.get("feature_contributions")
+        feature_contributions: list[FeatureContribution] = []
+        if fc_df is not None:
+            for idx, row in fc_df.iterrows():
+                feature_contributions.append(
+                    FeatureContribution(
+                        feature=str(idx),
+                        total_contribution=float(row["total_contribution"]),
+                        fractional_contribution=float(row["fractional_contribution"]),
+                    )
+                )
+
+        return cls(
+            n_components=n,
+            feature_names=[str(name) for name in d["feature_names"]],
+            explained_variance_ratio=np.asarray(d["explained_variance_ratio"])[
+                :n
+            ].tolist(),
+            eigenvalues=np.asarray(d["eigenvalues"])[:n].tolist(),
+            cumulative_variance_ratio=np.asarray(d["cumulative_variance_ratio"])[
+                :n
+            ].tolist(),
+            loadings=np.asarray(d["loadings"])[:, :n].tolist(),
+            scores=np.asarray(d["transformed_data"])[:, :n].tolist(),
+            standardized=d.get("scaler") is not None,
+            random_state=random_state,
+            explained_variance_threshold=explained_variance_threshold,
+            feature_contributions=feature_contributions,
+        )

--- a/src/sleap_roots_analyze/result_types.py
+++ b/src/sleap_roots_analyze/result_types.py
@@ -8,6 +8,15 @@ round-trips with no custom serializer, which is what lets these results cross a
 JSON boundary (bloom-mcp, a cached artifact, an API) and anchor the
 reproducibility CI gate.
 
+**Finite-floats contract.** The JSON boundary is *strict* JSON: floats must be
+finite. ``json.dumps`` will happily emit the non-standard ``NaN``/``Infinity``
+tokens (which a strict consumer such as bloom-mcp rejects), so each result type
+exposes a ``to_json`` method that serializes with ``allow_nan=False`` — a
+degenerate science value (e.g. an all-zero-loadings PCA producing a ``NaN``
+fractional contribution, a non-finite ``h2``/``bic``) raises a ``ValueError`` at
+serialization rather than silently producing invalid JSON. Callers crossing the
+boundary should use ``to_json`` (or pass ``allow_nan=False`` themselves).
+
 The first type is :class:`PCAResult` (issue #127, the detailed exemplar);
 ``HeritabilityResult`` (#128) and ``ClusterResult`` (#129) follow the same
 convention here. This module imports nothing from the analytical modules
@@ -17,6 +26,7 @@ convention here. This module imports nothing from the analytical modules
 from __future__ import annotations
 
 import dataclasses
+import json
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
@@ -49,7 +59,15 @@ class PCAResult:
     Built from the legacy ``perform_pca_analysis`` dict via
     :meth:`from_pca_dict`. Component-indexed fields cover only the retained
     components; the fitted ``PCA``/``StandardScaler`` objects are intentionally
-    excluded (still available via the legacy dict for in-process callers).
+    excluded (still available via the legacy dict for in-process callers), as are
+    the secondary per-feature variance breakdowns
+    (``explained_variance_ratio_per_feature``, ``feature_variances``) — this view
+    keeps only the primary component-level science.
+
+    ``frozen=True`` is shallow: the dataclass fields cannot be rebound, but the
+    nested ``list`` fields (``loadings``, ``scores``, ``feature_contributions``)
+    are still mutable in place. Treat the result as read-only. Float fields must be
+    finite to satisfy the JSON boundary — use :meth:`to_json` to enforce it.
 
     Attributes:
         n_components: Number of retained principal components.
@@ -96,6 +114,21 @@ class PCAResult:
         """Return a plain ``dict`` view via :func:`dataclasses.asdict`."""
         return dataclasses.asdict(self)
 
+    def to_json(self, **kwargs: Any) -> str:
+        """Serialize to a strict-JSON string, enforcing the finite-floats contract.
+
+        Defaults to ``allow_nan=False`` so a non-finite value (``NaN``/``Infinity``
+        from a degenerate run) raises a ``ValueError`` here rather than emitting the
+        non-standard tokens that a strict JSON consumer (e.g. bloom-mcp) rejects.
+        Extra keyword arguments are forwarded to :func:`json.dumps`.
+
+        Raises:
+            ValueError: If any float field is non-finite (under the default
+                ``allow_nan=False``).
+        """
+        kwargs.setdefault("allow_nan", False)
+        return json.dumps(self.to_dict(), **kwargs)
+
     @classmethod
     def from_pca_dict(
         cls,
@@ -112,11 +145,18 @@ class PCAResult:
         ``cumulative_variance_ratio``, ``transformed_data``, ``scaler``,
         ``feature_contributions``). Does not mutate ``d``.
 
+        Provenance caveat: ``random_state`` and ``explained_variance_threshold``
+        are *stamped as supplied* — the source dict does not carry them, so they
+        are recorded on trust, not cross-checked. Pass the **same** values that
+        produced ``d`` (e.g. the ``random_state`` handed to ``perform_pca_analysis``);
+        a mismatched seed creates a false-but-authoritative reproducibility record.
+
         Args:
             d: The dict returned by ``perform_pca_analysis``.
             random_state: Random state to stamp into the result for provenance.
+                Must match the seed used to produce ``d`` (see caveat above).
             explained_variance_threshold: Threshold to stamp into the result for
-                provenance.
+                provenance. Must match the threshold used to produce ``d``.
 
         Returns:
             A frozen :class:`PCAResult` holding only JSON-serializable science.

--- a/tests/test_pca_result.py
+++ b/tests/test_pca_result.py
@@ -13,6 +13,7 @@ import dataclasses
 import json
 
 import numpy as np
+import pandas as pd
 import pytest
 
 from sleap_roots_analyze.pca import perform_pca_analysis
@@ -21,6 +22,31 @@ from sleap_roots_analyze.result_types import FeatureContribution, PCAResult
 
 class TestPCAResultJSONRoundTrip:
     """The clean view must serialize to JSON as native Python types."""
+
+    def test_fields_are_native_types_pre_serialization(self, pca_3d_data):
+        """Float fields are native ``float`` on the dataclass, not laundered by JSON.
+
+        ``np.float64`` is a subclass of ``float``, so ``json.dumps`` silently
+        converts a leaked ``np.float64`` into a native float before any assertion on
+        the parsed output — making post-round-trip float checks vacuous. Assert on
+        the dataclass fields themselves, where a leak would survive as ``np.float64``.
+        """
+        df, _ = pca_3d_data
+        result = PCAResult.from_pca_dict(perform_pca_analysis(df, standardize=True))
+
+        assert type(result.n_components) is int
+        assert type(result.standardized) is bool
+        for v in (
+            *result.explained_variance_ratio,
+            *result.eigenvalues,
+            *result.cumulative_variance_ratio,
+            *(v for row in result.loadings for v in row),
+            *(v for row in result.scores for v in row),
+        ):
+            assert type(v) is float
+        for c in result.feature_contributions:
+            assert type(c.total_contribution) is float
+            assert type(c.fractional_contribution) is float
 
     def test_roundtrip_native_types(self, pca_3d_data):
         """json.dumps(asdict(...)) succeeds and round-trips to native types."""
@@ -147,6 +173,44 @@ class TestPCAResultAdapter:
         assert bare.explained_variance_threshold is None
 
 
+class TestPCAResultJSONBoundaryContract:
+    """`to_json` enforces strict, finite-floats-only JSON (the bloom-mcp contract)."""
+
+    def test_to_json_roundtrips_finite_data(self, pca_3d_data):
+        """On finite data, to_json emits strict JSON that parses back to to_dict."""
+        df, _ = pca_3d_data
+        result = PCAResult.from_pca_dict(perform_pca_analysis(df, standardize=True))
+
+        # allow_nan=False is the default; parsing back must equal the dict view.
+        parsed = json.loads(result.to_json())
+        assert parsed == json.loads(json.dumps(result.to_dict()))
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_to_json_rejects_non_finite_floats(self, pca_3d_data, bad):
+        """A non-finite field raises at to_json instead of emitting invalid JSON.
+
+        Reachable in practice via degenerate PCA (e.g. all-zero loadings →
+        ``NaN`` fractional contribution). The plain ``json.dumps`` default would
+        silently emit ``NaN``/``Infinity``, which a strict consumer rejects.
+        """
+        df, _ = pca_3d_data
+        result = PCAResult.from_pca_dict(perform_pca_analysis(df, standardize=True))
+        # frozen dataclass: inject the non-finite value via replace.
+        tainted = dataclasses.replace(result, eigenvalues=[bad])
+
+        with pytest.raises(ValueError, match="not JSON compliant"):
+            tainted.to_json()
+
+        # And the unguarded default would have laundered it into invalid JSON.
+        assert json.dumps(tainted.to_dict()) != ""  # plain dumps does NOT raise
+
+    def test_to_json_forwards_kwargs(self, pca_3d_data):
+        """Extra kwargs reach json.dumps (e.g. indent) without breaking the contract."""
+        df, _ = pca_3d_data
+        result = PCAResult.from_pca_dict(perform_pca_analysis(df, standardize=True))
+        assert "\n" in result.to_json(indent=2)
+
+
 class TestPCAResultProperties:
     """Derived properties."""
 
@@ -192,7 +256,11 @@ class TestPCAResultNonBreaking:
     """The legacy dict return is preserved and not mutated by the adapter."""
 
     def test_dict_keys_unchanged_and_nonmutating(self, pca_3d_data):
-        """Legacy dict keeps its keys and is not mutated by the adapter."""
+        """Legacy dict keeps its keys *and values* — the adapter never mutates it.
+
+        A keys-only check would pass an in-place value/array edit; snapshot the
+        actual values (arrays, frame, scalars) and assert deep equality afterwards.
+        """
         df, _ = pca_3d_data
         d = perform_pca_analysis(df, standardize=True)
 
@@ -210,6 +278,27 @@ class TestPCAResultNonBreaking:
         }
         assert expected_keys.issubset(d.keys())
 
-        before = set(d.keys())
+        # Deep snapshot of every value, using type-appropriate equality afterwards.
+        array_keys = [
+            "loadings",
+            "transformed_data",
+            "explained_variance_ratio",
+            "eigenvalues",
+            "cumulative_variance_ratio",
+        ]
+        before_keys = set(d.keys())
+        before_arrays = {k: np.asarray(d[k]).copy() for k in array_keys}
+        before_fc = d["feature_contributions"].copy(deep=True)
+        before_names = list(d["feature_names"])
+        before_n = d["n_components_selected"]
+        scaler_id, pca_id = id(d["scaler"]), id(d["pca"])
+
         PCAResult.from_pca_dict(d)
-        assert set(d.keys()) == before
+
+        assert set(d.keys()) == before_keys
+        for k in array_keys:
+            np.testing.assert_array_equal(np.asarray(d[k]), before_arrays[k])
+        pd.testing.assert_frame_equal(d["feature_contributions"], before_fc)
+        assert list(d["feature_names"]) == before_names
+        assert d["n_components_selected"] == before_n
+        assert id(d["scaler"]) == scaler_id and id(d["pca"]) == pca_id

--- a/tests/test_pca_result.py
+++ b/tests/test_pca_result.py
@@ -1,0 +1,215 @@
+"""Tests for the serializable ``PCAResult`` dataclass and its adapter (#127).
+
+These cover the serializable-result-types contract: a JSON round-trip that
+yields native Python types (the reproducibility CI gate), faithful mapping from
+the legacy ``perform_pca_analysis`` dict, ordering/name fidelity of feature
+contributions, determinism, provenance stamping, public export, and the
+non-breaking / non-mutating guarantee.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import numpy as np
+import pytest
+
+from sleap_roots_analyze.pca import perform_pca_analysis
+from sleap_roots_analyze.result_types import FeatureContribution, PCAResult
+
+
+class TestPCAResultJSONRoundTrip:
+    """The clean view must serialize to JSON as native Python types."""
+
+    def test_roundtrip_native_types(self, pca_3d_data):
+        """json.dumps(asdict(...)) succeeds and round-trips to native types."""
+        df, _ = pca_3d_data
+        d = perform_pca_analysis(df, standardize=True)
+        result = PCAResult.from_pca_dict(d)
+
+        dumped = json.dumps(dataclasses.asdict(result))
+        parsed = json.loads(dumped)
+
+        assert type(parsed["n_components"]) is int
+        assert type(parsed["standardized"]) is bool
+        for key in (
+            "explained_variance_ratio",
+            "eigenvalues",
+            "cumulative_variance_ratio",
+        ):
+            assert all(type(v) is float for v in parsed[key]), key
+        for matrix_key in ("loadings", "scores"):
+            assert all(
+                type(v) is float for row in parsed[matrix_key] for v in row
+            ), matrix_key
+
+    def test_no_sklearn_objects_in_view(self, pca_3d_data):
+        """The clean view drops sklearn objects and redundant frames."""
+        df, _ = pca_3d_data
+        d = perform_pca_analysis(df, standardize=True)
+        result = PCAResult.from_pca_dict(d)
+
+        view = dataclasses.asdict(result)
+        for forbidden in ("pca", "scaler", "feature_metrics_df"):
+            assert forbidden not in view
+
+    def test_to_dict_matches_asdict(self, pca_3d_data):
+        """``to_dict`` is a convenience over ``dataclasses.asdict``."""
+        df, _ = pca_3d_data
+        result = PCAResult.from_pca_dict(perform_pca_analysis(df))
+        assert result.to_dict() == dataclasses.asdict(result)
+
+
+class TestPCAResultAdapter:
+    """``from_pca_dict`` maps the legacy dict faithfully."""
+
+    def test_core_field_shapes(self, pca_3d_data):
+        """Arrays are truncated/copied to (n_components) and 2-D nested."""
+        df, _ = pca_3d_data  # 3 features
+        # Force 2 retained components so the shape checks are non-trivial.
+        d = perform_pca_analysis(df, standardize=True, n_components=2)
+        result = PCAResult.from_pca_dict(d)
+
+        n = result.n_components
+        assert n == int(d["n_components_selected"])
+        assert n < df.shape[1]  # truncation is non-trivial
+
+        assert len(result.explained_variance_ratio) == n
+        assert len(result.eigenvalues) == n
+        assert len(result.cumulative_variance_ratio) == n
+
+        # scores come from transformed_data, shape (n_samples, n_components)
+        assert len(result.scores) == df.shape[0]
+        assert all(len(row) == n for row in result.scores)
+        np.testing.assert_allclose(
+            np.asarray(result.scores), d["transformed_data"][:, :n]
+        )
+
+        # loadings shape (n_features, n_components)
+        assert len(result.loadings) == len(result.feature_names)
+        assert all(len(row) == n for row in result.loadings)
+
+    def test_feature_contributions_order_and_names(self, pca_3d_data):
+        """Contributions keep DataFrame order and name↔value correspondence."""
+        df, _ = pca_3d_data
+        d = perform_pca_analysis(df, standardize=True)
+        result = PCAResult.from_pca_dict(d)
+
+        fc_df = d["feature_contributions"]
+        # Order: descending by total_contribution, matching the source frame.
+        totals = [c.total_contribution for c in result.feature_contributions]
+        assert totals == sorted(totals, reverse=True)
+        assert [c.feature for c in result.feature_contributions] == list(fc_df.index)
+        for c in result.feature_contributions:
+            assert isinstance(c, FeatureContribution)
+            assert c.total_contribution == pytest.approx(
+                fc_df.loc[c.feature, "total_contribution"]
+            )
+            assert c.fractional_contribution == pytest.approx(
+                fc_df.loc[c.feature, "fractional_contribution"]
+            )
+
+    @pytest.mark.parametrize("standardize", [True, False])
+    def test_standardized_flag(self, pca_3d_data, standardize):
+        """``standardized`` reflects whether a scaler was fitted."""
+        df, _ = pca_3d_data
+        d = perform_pca_analysis(df, standardize=standardize)
+        result = PCAResult.from_pca_dict(d)
+
+        assert result.standardized is standardize
+        # serializes cleanly in both branches
+        json.dumps(dataclasses.asdict(result))
+
+    def test_n_components_one_keeps_nested_shape(self, pca_variance_threshold_data):
+        """A single retained component stays 2-D nested, not flattened."""
+        df = pca_variance_threshold_data["one_component"]
+        d = perform_pca_analysis(df, standardize=True)
+        result = PCAResult.from_pca_dict(d)
+
+        assert result.n_components == 1
+        assert all(len(row) == 1 for row in result.loadings)
+        assert all(len(row) == 1 for row in result.scores)
+
+    def test_provenance_args_stamped(self, pca_3d_data):
+        """random_state / threshold are stamped from adapter args."""
+        df, _ = pca_3d_data
+        d = perform_pca_analysis(df, random_state=42)
+
+        stamped = PCAResult.from_pca_dict(
+            d, random_state=42, explained_variance_threshold=0.95
+        )
+        assert stamped.random_state == 42
+        assert stamped.explained_variance_threshold == 0.95
+
+        bare = PCAResult.from_pca_dict(d)
+        assert bare.random_state is None
+        assert bare.explained_variance_threshold is None
+
+
+class TestPCAResultProperties:
+    """Derived properties."""
+
+    def test_cumulative_variance(self, pca_3d_data):
+        """``cumulative_variance`` sums retained ratios as a native float."""
+        df, _ = pca_3d_data
+        result = PCAResult.from_pca_dict(perform_pca_analysis(df))
+
+        cv = result.cumulative_variance
+        assert type(cv) is float
+        assert cv == pytest.approx(sum(result.explained_variance_ratio))
+        assert 0.0 < cv <= 1.0 + 1e-9
+
+
+class TestPCAResultDeterminism:
+    """Same seed → identical serialized result (epic #118)."""
+
+    def test_same_random_state_identical(self, pca_3d_data):
+        """Identical seeds produce byte-identical serialized results."""
+        df, _ = pca_3d_data
+        r1 = PCAResult.from_pca_dict(perform_pca_analysis(df, random_state=42))
+        r2 = PCAResult.from_pca_dict(perform_pca_analysis(df, random_state=42))
+
+        assert dataclasses.asdict(r1) == dataclasses.asdict(r2)
+        assert json.dumps(dataclasses.asdict(r1)) == json.dumps(dataclasses.asdict(r2))
+
+
+class TestPCAResultExport:
+    """Public API surface."""
+
+    def test_importable_from_package_root(self):
+        """Both result types are importable and listed once in __all__."""
+        import sleap_roots_analyze as sra
+
+        assert sra.PCAResult is PCAResult
+        assert sra.FeatureContribution is FeatureContribution
+        for name in ("PCAResult", "FeatureContribution"):
+            assert name in sra.__all__
+        assert len(sra.__all__) == len(set(sra.__all__))
+
+
+class TestPCAResultNonBreaking:
+    """The legacy dict return is preserved and not mutated by the adapter."""
+
+    def test_dict_keys_unchanged_and_nonmutating(self, pca_3d_data):
+        """Legacy dict keeps its keys and is not mutated by the adapter."""
+        df, _ = pca_3d_data
+        d = perform_pca_analysis(df, standardize=True)
+
+        expected_keys = {
+            "loadings",
+            "transformed_data",
+            "explained_variance_ratio",
+            "eigenvalues",
+            "cumulative_variance_ratio",
+            "feature_names",
+            "feature_contributions",
+            "scaler",
+            "pca",
+            "n_components_selected",
+        }
+        assert expected_keys.issubset(d.keys())
+
+        before = set(d.keys())
+        PCAResult.from_pca_dict(d)
+        assert set(d.keys()) == before


### PR DESCRIPTION
## Summary

Adds a stdlib `PCAResult` dataclass (with nested `FeatureContribution`) and a `from_pca_dict()` adapter in a new shared `result_types.py` module. This is the **detailed exemplar** for the serializable-result-types epic (#130); #128 (`HeritabilityResult`) and #129 (`ClusterResult`) will follow the same convention in this module.

`perform_pca_analysis()` returns a dict mixing numpy arrays, pandas frames, and sklearn objects — it can't cross a JSON boundary (bloom-mcp, caching, an API) without bespoke conversion. `PCAResult` is a clean, JSON-native view: `json.dumps(dataclasses.asdict(result))` round-trips with no custom serializer.

Closes #127.

## What's in the result

- Science only — **no sklearn `PCA`/`StandardScaler`** in the view.
- `scores` mapped from the dict's `transformed_data`; every scalar cast to native `int`/`float` (numpy scalars like `np.int64` are **not** reliably JSON-serializable).
- `feature_contributions` preserve the source DataFrame's `total_contribution`-descending order and name-from-index correspondence.
- Carries per-component `cumulative_variance_ratio`; `@property cumulative_variance` for the scalar total.
- `from_pca_dict(d, *, random_state=None, explained_variance_threshold=None)` stamps reproducibility provenance (these aren't in the dict).
- `frozen=True` + `to_dict()`, matching the `EnrichmentResult`/`CrossPlatformPCResult` precedent.

## Backwards-compat

**Additive only (MINOR).** `perform_pca_analysis` still returns its exact dict; the adapter does not mutate its input. `PCAResult`/`FeatureContribution` exported in `__all__`.

## Testing

- New `tests/test_pca_result.py` (13 tests): native-type JSON round-trip (the reproducibility CI gate), no-sklearn-object guard, adapter shape mapping, `feature_contributions` ordering/name fidelity, both `standardize` branches, `n_components=1` nested-shape preservation, provenance stamping, determinism (epic #118), public export, and a dict-unchanged/non-mutating guard.
- Full suite green (2087 passed); `black`/`ruff` clean; `openspec validate add-pcaresult-dataclass --strict` passes.

## Out of scope (deferred to the epic)

- `docs/result-types.md` pattern doc (written once at epic close, across all three types).
- Wheat-EDPIE golden numeric assertions (epic verification milestone #120/#130).

The OpenSpec proposal was honed via a 5-agent adversarial review before implementation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)