### PR TITLE
feat: add HeritabilityResult serializable dataclass + adapter (#128)

### DIFF
--- a/openspec/changes/add-heritabilityresult-dataclass/proposal.md
+++ b/openspec/changes/add-heritabilityresult-dataclass/proposal.md
@@ -1,0 +1,65 @@
+# Add HeritabilityResult Serializable Dataclass Return Type (issue #128)
+
+## Why
+
+`calculate_heritability_estimates()` (`statistics.py`, exposed publicly via
+#116) returns a `Dict` keyed by trait name, each value a per-trait dict of
+broad-sense heritability plus variance components and a special
+`__calculation_metadata__` entry. Like the PCA dict, this nested, metadata-mixed
+shape needs a clean serializable view to cross a JSON boundary (bloom-mcp,
+caching, an API) and to anchor the wheat EDPIE golden tests.
+
+This is the Phase-1 anchor of the serializable-result-types epic (#130). It
+follows the exact convention established by `PCAResult` (#127): a frozen stdlib
+`@dataclass` holding only JSON-serializable science, a `from_*_dict()` adapter,
+`frozen=True` + `to_dict()`, and native-Python scalar casts.
+
+## What Changes
+
+- **`HeritabilityResult` and `TraitHeritability` frozen dataclasses** added to
+  the shared `result_types.py` module (created in #127). They expose only
+  serializable science — per-trait H², variance components, and counts — never
+  sklearn/statsmodels objects.
+- **`HeritabilityResult.from_heritability_dict(d, threshold)` adapter** mapping
+  the `calculate_heritability_estimates` return dict (the
+  `remove_low_h2=False` form, or the first element of the
+  `remove_low_h2=True` tuple):
+  - `method` is read from `d["__calculation_metadata__"]["method_used_for_all_traits"]`.
+  - The `__calculation_metadata__` key is skipped; trait entries carrying an
+    `"error"` (or lacking a `"heritability"` value) are collected into
+    `failed_traits` rather than `per_trait`.
+  - Each successful trait becomes a `TraitHeritability` with `passed_threshold =
+    h2 >= threshold`; all scalars cast to native `float`/`int`.
+- **`@property mean_h2`** (mean H² over successful traits) and
+  **`@property n_above_threshold`** (count with `passed_threshold`).
+- **Public exports.** `HeritabilityResult` and `TraitHeritability` added to the
+  package `__all__` with full type hints + Google-style docstrings (every field
+  documented in an `Attributes:` block), satisfying the
+  `test_public_api_docs.py` introspection contract.
+- **Additive / non-breaking.** `calculate_heritability_estimates` keeps its dict
+  / tuple returns unchanged (MINOR bump); the adapter does not mutate its input.
+- **Tests.** A native-type JSON round-trip (reproducibility CI gate) plus
+  adapter tests over a real `calculate_heritability_estimates` run on the
+  `heritability_data_known_h2` fixture (known H² ≈ 0.8 / 0.5 / 0.09): threshold
+  classification, `mean_h2` / `n_above_threshold`, `failed_traits` capture,
+  determinism, exports, and a dict-unchanged / non-mutating guard.
+
+## Out of Scope (deferred to the epic)
+
+- The wheat EDPIE Turface-19 golden numbers (mean H²=0.77; 8 traits ≥0.60) are
+  deferred to the epic's verification milestone (#120/#130), consistent with
+  #127. This change anchors numeric correctness on the synthetic
+  `heritability_data_known_h2` fixture (known variance components) instead.
+- The shared `docs/result-types.md` pattern doc remains an epic-close
+  deliverable.
+
+## Impact
+
+- Affected specs: the `serializable-result-types` capability gains heritability
+  requirements (same capability introduced by #127).
+- Affected code: `src/sleap_roots_analyze/result_types.py` (new dataclasses +
+  adapter); `src/sleap_roots_analyze/__init__.py` (`__all__` exports);
+  **new** `tests/test_heritability_result.py`.
+- No breaking changes; purely additive public API (MINOR version bump).
+- Stacked on #127 (`pcaresult-dataclass-127`), which introduces
+  `result_types.py`.

--- a/openspec/changes/add-heritabilityresult-dataclass/specs/serializable-result-types/spec.md
+++ b/openspec/changes/add-heritabilityresult-dataclass/specs/serializable-result-types/spec.md
@@ -1,0 +1,87 @@
+# serializable-result-types Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Serializable Heritability Result Type
+
+The package SHALL provide a frozen stdlib `@dataclass` `HeritabilityResult`
+(with a nested `TraitHeritability` dataclass) in `result_types.py` that captures
+only the JSON-serializable science of a `calculate_heritability_estimates()`
+run. Every scalar field SHALL be a native Python type (`int`, `float`, `str`,
+`bool`), so that `json.dumps(dataclasses.asdict(result))` succeeds without a
+custom serializer. `HeritabilityResult` SHALL provide a `to_dict()` method
+returning `dataclasses.asdict(self)`.
+
+#### Scenario: HeritabilityResult round-trips through JSON as native types
+
+- **WHEN** a `HeritabilityResult` built from a
+  `calculate_heritability_estimates()` dict is passed to
+  `json.dumps(dataclasses.asdict(result))`
+- **THEN** the call SHALL succeed without raising
+- **AND** parsing the string back with `json.loads` SHALL yield `threshold` as a
+  Python `float` and, for every entry in `per_trait`, `h2` as a Python `float`,
+  `passed_threshold` as a Python `bool`, and the count fields as Python `int`
+- **AND** the result SHALL contain no statsmodels model object
+
+#### Scenario: mean_h2 and n_above_threshold derive from successful traits
+
+- **WHEN** `result.mean_h2` and `result.n_above_threshold` are accessed
+- **THEN** `mean_h2` SHALL be the mean of `h2` over `per_trait` (a native
+  `float`, `0.0` when `per_trait` is empty)
+- **AND** `n_above_threshold` SHALL be the count of `per_trait` entries whose
+  `passed_threshold` is `True`
+
+### Requirement: HeritabilityResult Adapter From Legacy Dict
+
+The package SHALL provide
+`HeritabilityResult.from_heritability_dict(d, threshold)` that maps the
+`calculate_heritability_estimates()` return dict (the `remove_low_h2=False`
+form, or the first element of the `remove_low_h2=True` tuple) into a
+`HeritabilityResult`, without mutating `d`.
+
+#### Scenario: Adapter classifies traits by threshold
+
+- **WHEN** `HeritabilityResult.from_heritability_dict(d, threshold)` is called
+- **THEN** `method` SHALL equal
+  `d["__calculation_metadata__"]["method_used_for_all_traits"]`
+- **AND** the `__calculation_metadata__` entry SHALL NOT appear as a trait
+- **AND** each trait carrying a `"heritability"` value SHALL become a
+  `TraitHeritability` with `h2` cast to `float` and `passed_threshold` equal to
+  `h2 >= threshold`
+
+#### Scenario: Failed traits are separated from successful ones
+
+- **WHEN** the dict contains trait entries carrying an `"error"` (or lacking a
+  `"heritability"` value)
+- **THEN** those trait names SHALL be collected into `failed_traits`
+- **AND** SHALL NOT appear in `per_trait`
+
+### Requirement: HeritabilityResult Public Export
+
+The package SHALL export `HeritabilityResult` and `TraitHeritability` from the
+top-level `sleap_roots_analyze` namespace and list them in `__all__`.
+
+#### Scenario: Heritability result types importable from package root
+
+- **WHEN** a consumer runs
+  `from sleap_roots_analyze import HeritabilityResult, TraitHeritability`
+- **THEN** the import SHALL succeed
+- **AND** both names SHALL appear in `sleap_roots_analyze.__all__` with no
+  duplicate entries
+
+### Requirement: Non-Breaking Heritability Return Shape
+
+Adding `HeritabilityResult` SHALL NOT change the return shape of
+`calculate_heritability_estimates()`; the function SHALL keep returning its
+existing dict / tuple so all current callers continue to work unchanged.
+
+#### Scenario: Existing heritability return is preserved and not mutated
+
+- **WHEN** `calculate_heritability_estimates()` is called with
+  `remove_low_h2=False`
+- **THEN** it SHALL return the existing trait-keyed dict (including the
+  `__calculation_metadata__` entry)
+- **AND** calling `HeritabilityResult.from_heritability_dict(d, threshold)` SHALL
+  leave `d`'s keys and values unchanged
+- **AND** the `HeritabilityResult` view SHALL be opt-in, built only via
+  `HeritabilityResult.from_heritability_dict()`

--- a/openspec/changes/add-heritabilityresult-dataclass/tasks.md
+++ b/openspec/changes/add-heritabilityresult-dataclass/tasks.md
@@ -1,0 +1,44 @@
+# Tasks — Add HeritabilityResult Serializable Dataclass (issue #128)
+
+> Single `feat: ... (#128)` commit (CI green at HEAD); exports land with the
+> dataclass. Stacked on #127. OpenSpec archive post-merge.
+
+## 1. Failing tests first (red) — `tests/test_heritability_result.py`
+- [x] 1.1 `test_json_roundtrip_native_types`: run
+      `calculate_heritability_estimates` on `heritability_data_known_h2`, build
+      `HeritabilityResult.from_heritability_dict(d, threshold=0.3)`, assert
+      `json.dumps(asdict(...))` succeeds, then `json.loads` and assert
+      `threshold` is `float`, each `per_trait` `h2` is `float`,
+      `passed_threshold` is `bool`, counts are `int`.
+- [x] 1.2 `test_adapter_classifies_and_reads_method`: `method == "mixed_model"`;
+      `__calculation_metadata__` not present as a trait; known H² (~0.8/0.5/0.09)
+      mapped; `passed_threshold == (h2 >= threshold)`.
+- [x] 1.3 `test_mean_h2_and_n_above_threshold`: `mean_h2` ≈ mean of per-trait
+      H² (native float); `n_above_threshold` counts passing traits at a chosen
+      threshold (e.g. 0.3 → high+moderate pass, low fails).
+- [x] 1.4 `test_failed_traits_separated`: feed a dict with an error/`missing`
+      trait entry; it lands in `failed_traits`, not `per_trait`.
+- [x] 1.5 `test_deterministic`: same input → identical `asdict`/json.
+- [x] 1.6 `test_exports_and_all`: import from package root; both names in
+      `__all__`, no dupes.
+- [x] 1.7 `test_dict_unchanged_and_nonmutating`: keys preserved (incl.
+      `__calculation_metadata__`); adapter does not mutate `d`.
+
+## 2. Implement to green
+- [x] 2.1 Add `TraitHeritability` + frozen `HeritabilityResult` to
+      `result_types.py` (Google docstrings with `Attributes:` for every field).
+- [x] 2.2 Implement `from_heritability_dict(d, threshold)`: read `method`; skip
+      `__calculation_metadata__`; split success vs `failed_traits`; native casts;
+      no mutation of `d`.
+- [x] 2.3 Implement `@property mean_h2`, `@property n_above_threshold`, and
+      `to_dict()`.
+- [x] 2.4 Export `HeritabilityResult`, `TraitHeritability` from `__init__.py`
+      (`__all__`).
+
+## 3. Verify non-breaking
+- [x] 3.1 Existing `tests/test_statistics*.py` pass; return shape unchanged
+      (covered by task 1.7).
+
+## 4. Pre-merge
+- [x] 4.1 `black` + `ruff` + full `pytest` green; `openspec validate
+      add-heritabilityresult-dataclass --strict` passes.

--- a/openspec/changes/add-heritabilityresult-dataclass/tasks.md
+++ b/openspec/changes/add-heritabilityresult-dataclass/tasks.md
@@ -42,3 +42,19 @@
 ## 4. Pre-merge
 - [x] 4.1 `black` + `ruff` + full `pytest` green; `openspec validate
       add-heritabilityresult-dataclass --strict` passes.
+
+## 5. Review follow-ups (rebased on the updated #127)
+- [x] 5.1 Run-level `{"error": ...}` short-circuit: surface on a distinct `error`
+      field (string-valued top-level key), not as a fake `failed_traits=["error"]`.
+- [x] 5.2 Adapter field-mapping test value-asserts every `TraitHeritability` field
+      (var_genetic/var_residual/n_genotypes/n_observations/model_type), guarding a
+      swapped/wrong-key mapping; plus a per-trait-error-still-fails test.
+- [x] 5.3 Non-vacuous native-type test: assert `type(field) is float` on the
+      pre-serialization dataclass fields (np.float64 is a float subclass, so the
+      JSON round-trip launders leaks).
+- [x] 5.4 `to_json(allow_nan=False)` enforces the finite-floats JSON boundary;
+      finite round-trip + non-finite-h2 rejection tests (inherits #127 pattern).
+- [x] 5.5 Non-mutation guard deep-copies and asserts value equality, not keys only.
+- [x] 5.6 Provenance caveat documented (`threshold` applied as supplied); docstring
+      no longer entrenches "broad-sense" (source H² is genotype-mean/repeatability);
+      frozen-is-shallow note added.

--- a/src/sleap_roots_analyze/__init__.py
+++ b/src/sleap_roots_analyze/__init__.py
@@ -44,6 +44,8 @@ from sleap_roots_analyze.pca import (
 from sleap_roots_analyze.result_types import (
     FeatureContribution,
     PCAResult,
+    HeritabilityResult,
+    TraitHeritability,
 )
 
 from sleap_roots_analyze.umap import (
@@ -224,6 +226,8 @@ __all__ = [
     # Serializable result types (#130)
     "PCAResult",
     "FeatureContribution",
+    "HeritabilityResult",
+    "TraitHeritability",
     # UMAP functions
     "perform_umap_analysis",
     # Clustering functions

--- a/src/sleap_roots_analyze/result_types.py
+++ b/src/sleap_roots_analyze/result_types.py
@@ -32,7 +32,15 @@ from typing import Any, Optional
 
 import numpy as np
 
-__all__ = ["FeatureContribution", "PCAResult"]
+__all__ = [
+    "FeatureContribution",
+    "PCAResult",
+    "TraitHeritability",
+    "HeritabilityResult",
+]
+
+# Key the heritability dict reserves for calculation metadata (not a trait).
+_HERITABILITY_METADATA_KEY = "__calculation_metadata__"
 
 
 @dataclass(frozen=True)
@@ -191,4 +199,121 @@ class PCAResult:
             random_state=random_state,
             explained_variance_threshold=explained_variance_threshold,
             feature_contributions=feature_contributions,
+        )
+
+
+@dataclass(frozen=True)
+class TraitHeritability:
+    """A single trait's broad-sense heritability estimate.
+
+    Attributes:
+        trait: Trait (column) name.
+        h2: Broad-sense heritability estimate H² in ``[0, 1]``.
+        passed_threshold: Whether ``h2`` meets the result's threshold.
+        var_genetic: Genetic variance component (σ²_G).
+        var_residual: Residual/environmental variance component (σ²_E).
+        n_genotypes: Number of genotypes used for this trait.
+        n_observations: Number of observations used for this trait.
+        model_type: Model used for this trait (e.g. ``"mixed_model"``,
+            ``"anova_based"``, ``"no_variance"``).
+    """
+
+    trait: str
+    h2: float
+    passed_threshold: bool
+    var_genetic: float
+    var_residual: float
+    n_genotypes: int
+    n_observations: int
+    model_type: str
+
+
+@dataclass(frozen=True)
+class HeritabilityResult:
+    """JSON-serializable view of a heritability run (science only).
+
+    Built from the legacy ``calculate_heritability_estimates`` dict via
+    :meth:`from_heritability_dict`. Traits that failed estimation are listed in
+    ``failed_traits`` rather than ``per_trait``; no statsmodels model object is
+    retained.
+
+    Attributes:
+        method: Estimation method applied to all traits (e.g.
+            ``"mixed_model"``).
+        threshold: H² threshold used to classify ``passed_threshold``.
+        per_trait: Per-trait heritability estimates that succeeded.
+        failed_traits: Names of traits whose estimation errored or produced no
+            heritability value.
+    """
+
+    method: str
+    threshold: float
+    per_trait: list[TraitHeritability] = field(default_factory=list)
+    failed_traits: list[str] = field(default_factory=list)
+
+    @property
+    def mean_h2(self) -> float:
+        """Mean H² over successful traits (``0.0`` when there are none)."""
+        if not self.per_trait:
+            return 0.0
+        return float(sum(t.h2 for t in self.per_trait) / len(self.per_trait))
+
+    @property
+    def n_above_threshold(self) -> int:
+        """Number of successful traits whose H² meets the threshold."""
+        return sum(1 for t in self.per_trait if t.passed_threshold)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain ``dict`` view via :func:`dataclasses.asdict`."""
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_heritability_dict(cls, d: dict, threshold: float) -> "HeritabilityResult":
+        """Build a :class:`HeritabilityResult` from a heritability dict.
+
+        Accepts the ``calculate_heritability_estimates`` return dict (the
+        ``remove_low_h2=False`` form, or the first element of the
+        ``remove_low_h2=True`` tuple). Does not mutate ``d``.
+
+        Args:
+            d: Trait-keyed heritability dict, optionally including the
+                ``__calculation_metadata__`` entry.
+            threshold: H² threshold used to set each trait's
+                ``passed_threshold``.
+
+        Returns:
+            A frozen :class:`HeritabilityResult` holding only serializable
+            science.
+        """
+        metadata = d.get(_HERITABILITY_METADATA_KEY) or {}
+        method = str(metadata.get("method_used_for_all_traits", "unknown"))
+        threshold = float(threshold)
+
+        per_trait: list[TraitHeritability] = []
+        failed_traits: list[str] = []
+        for trait, entry in d.items():
+            if trait == _HERITABILITY_METADATA_KEY:
+                continue
+            if not isinstance(entry, dict) or "heritability" not in entry:
+                failed_traits.append(str(trait))
+                continue
+            h2 = float(entry["heritability"])
+            per_trait.append(
+                TraitHeritability(
+                    trait=str(trait),
+                    h2=h2,
+                    passed_threshold=h2 >= threshold,
+                    var_genetic=float(entry.get("var_genetic", 0.0)),
+                    var_residual=float(entry.get("var_residual", 0.0)),
+                    n_genotypes=int(entry.get("n_genotypes", 0)),
+                    n_observations=int(entry.get("n_observations", 0)),
+                    model_type=str(entry.get("model_type", "unknown")),
+                )
+            )
+
+        return cls(
+            method=method,
+            threshold=threshold,
+            per_trait=per_trait,
+            failed_traits=failed_traits,
         )

--- a/src/sleap_roots_analyze/result_types.py
+++ b/src/sleap_roots_analyze/result_types.py
@@ -204,11 +204,19 @@ class PCAResult:
 
 @dataclass(frozen=True)
 class TraitHeritability:
-    """A single trait's broad-sense heritability estimate.
+    """A single trait's heritability estimate.
+
+    The source ``calculate_heritability_estimates`` computes
+    ``H² = var_G / (var_G + var_E / mean_n_reps)`` — a genotype-mean
+    (repeatability) heritability, **not** the textbook broad-sense
+    ``var_G / (var_G + var_E)``. Because ``var_E`` is divided by the mean number
+    of replicates, ``h2`` runs higher than broad-sense H² but preserves the
+    genetic-variance ordering across traits.
 
     Attributes:
         trait: Trait (column) name.
-        h2: Broad-sense heritability estimate H² in ``[0, 1]``.
+        h2: Genotype-mean heritability estimate in ``[0, 1]`` (see above — not
+            textbook broad-sense).
         passed_threshold: Whether ``h2`` meets the result's threshold.
         var_genetic: Genetic variance component (σ²_G).
         var_residual: Residual/environmental variance component (σ²_E).
@@ -237,6 +245,11 @@ class HeritabilityResult:
     ``failed_traits`` rather than ``per_trait``; no statsmodels model object is
     retained.
 
+    ``frozen=True`` is shallow: the fields cannot be rebound, but the nested
+    ``per_trait`` / ``failed_traits`` lists are still mutable in place — treat the
+    result as read-only. Float fields must be finite for the JSON boundary; use
+    :meth:`to_json` to enforce it.
+
     Attributes:
         method: Estimation method applied to all traits (e.g.
             ``"mixed_model"``).
@@ -244,12 +257,17 @@ class HeritabilityResult:
         per_trait: Per-trait heritability estimates that succeeded.
         failed_traits: Names of traits whose estimation errored or produced no
             heritability value.
+        error: Run-level error message when the whole calculation short-circuited
+            (e.g. missing required columns) and produced no per-trait results;
+            ``None`` for a normal run. Distinct from ``failed_traits``, which holds
+            individual traits that failed within an otherwise-successful run.
     """
 
     method: str
     threshold: float
     per_trait: list[TraitHeritability] = field(default_factory=list)
     failed_traits: list[str] = field(default_factory=list)
+    error: Optional[str] = None
 
     @property
     def mean_h2(self) -> float:
@@ -267,6 +285,21 @@ class HeritabilityResult:
         """Return a plain ``dict`` view via :func:`dataclasses.asdict`."""
         return dataclasses.asdict(self)
 
+    def to_json(self, **kwargs: Any) -> str:
+        """Serialize to a strict-JSON string, enforcing the finite-floats contract.
+
+        Defaults to ``allow_nan=False`` so a non-finite value (e.g. a degenerate
+        ``h2``) raises a ``ValueError`` here rather than emitting the non-standard
+        ``NaN``/``Infinity`` tokens a strict consumer (bloom-mcp) rejects. Extra
+        keyword arguments are forwarded to :func:`json.dumps`.
+
+        Raises:
+            ValueError: If any float field is non-finite (under the default
+                ``allow_nan=False``).
+        """
+        kwargs.setdefault("allow_nan", False)
+        return json.dumps(self.to_dict(), **kwargs)
+
     @classmethod
     def from_heritability_dict(cls, d: dict, threshold: float) -> "HeritabilityResult":
         """Build a :class:`HeritabilityResult` from a heritability dict.
@@ -275,11 +308,21 @@ class HeritabilityResult:
         ``remove_low_h2=False`` form, or the first element of the
         ``remove_low_h2=True`` tuple). Does not mutate ``d``.
 
+        A run-level short-circuit — ``{"error": "..."}`` with no per-trait entries,
+        returned when the calculation aborts before processing any trait (e.g.
+        missing required columns) — is surfaced on ``error``, not mistaken for a
+        trait named ``"error"``. The string value distinguishes it from a per-trait
+        failure (whose value is always a dict).
+
+        Provenance caveat: ``threshold`` is applied *as supplied* — the source dict
+        does not carry it, so it is recorded on trust, not cross-checked. Pass the
+        threshold you intend the ``passed_threshold`` classification to reflect.
+
         Args:
             d: Trait-keyed heritability dict, optionally including the
                 ``__calculation_metadata__`` entry.
             threshold: H² threshold used to set each trait's
-                ``passed_threshold``.
+                ``passed_threshold`` (see provenance caveat above).
 
         Returns:
             A frozen :class:`HeritabilityResult` holding only serializable
@@ -288,6 +331,13 @@ class HeritabilityResult:
         metadata = d.get(_HERITABILITY_METADATA_KEY) or {}
         method = str(metadata.get("method_used_for_all_traits", "unknown"))
         threshold = float(threshold)
+
+        # Run-level short-circuit: a lone {"error": "<str>"} (no metadata, no
+        # per-trait entries). The string value distinguishes it from a per-trait
+        # failure (always a dict), so a trait legitimately named "error" is unaffected.
+        run_error = d.get("error")
+        if isinstance(run_error, str):
+            return cls(method=method, threshold=threshold, error=run_error)
 
         per_trait: list[TraitHeritability] = []
         failed_traits: list[str] = []

--- a/tests/test_heritability_result.py
+++ b/tests/test_heritability_result.py
@@ -29,6 +29,28 @@ def _run(df):
 class TestHeritabilityResultJSON:
     """The clean view must serialize to JSON as native Python types."""
 
+    def test_fields_are_native_types_pre_serialization(
+        self, heritability_data_known_h2
+    ):
+        """Float fields are native ``float`` on the dataclass, not laundered by JSON.
+
+        ``np.float64`` is a subclass of ``float``, so ``json.dumps`` silently casts
+        a leaked ``np.float64`` to native float before any assertion on the parsed
+        output. Assert on the dataclass fields themselves, where a leak survives.
+        """
+        df, _ = heritability_data_known_h2
+        result = HeritabilityResult.from_heritability_dict(_run(df), threshold=0.3)
+
+        assert type(result.threshold) is float
+        assert result.per_trait, "expected at least one successful trait"
+        for t in result.per_trait:
+            assert type(t.h2) is float
+            assert type(t.var_genetic) is float
+            assert type(t.var_residual) is float
+            assert type(t.passed_threshold) is bool
+            assert type(t.n_genotypes) is int
+            assert type(t.n_observations) is int
+
     def test_json_roundtrip_native_types(self, heritability_data_known_h2):
         """json.dumps(asdict(...)) round-trips to native Python types."""
         df, _ = heritability_data_known_h2
@@ -44,6 +66,24 @@ class TestHeritabilityResultJSON:
             assert type(t["passed_threshold"]) is bool
             assert type(t["n_genotypes"]) is int
             assert type(t["n_observations"]) is int
+
+    def test_to_json_roundtrips_finite_data(self, heritability_data_known_h2):
+        """On finite data, to_json emits strict JSON that parses back to to_dict."""
+        df, _ = heritability_data_known_h2
+        result = HeritabilityResult.from_heritability_dict(_run(df), threshold=0.3)
+        assert json.loads(result.to_json()) == json.loads(json.dumps(result.to_dict()))
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_to_json_rejects_non_finite_h2(self, heritability_data_known_h2, bad):
+        """A non-finite h2 raises at to_json instead of emitting invalid JSON."""
+        df, _ = heritability_data_known_h2
+        result = HeritabilityResult.from_heritability_dict(_run(df), threshold=0.3)
+        tainted = dataclasses.replace(
+            result,
+            per_trait=[dataclasses.replace(result.per_trait[0], h2=bad)],
+        )
+        with pytest.raises(ValueError, match="not JSON compliant"):
+            tainted.to_json()
 
     def test_to_dict_matches_asdict(self, heritability_data_known_h2):
         """``to_dict`` is a convenience over ``dataclasses.asdict``."""
@@ -65,6 +105,51 @@ class TestHeritabilityResultAdapter:
         traits = {t.trait for t in result.per_trait}
         assert "__calculation_metadata__" not in traits
         assert traits <= set(TRAIT_COLS)
+
+    def test_maps_all_trait_fields_from_real_entry(self, heritability_data_known_h2):
+        """Every TraitHeritability field is value-asserted against the source entry.
+
+        Guards against a swapped or wrong-key mapping (e.g. var_genetic↔var_residual)
+        that h2/passed_threshold-only checks would miss.
+        """
+        df, _ = heritability_data_known_h2
+        d = _run(df)
+        result = HeritabilityResult.from_heritability_dict(d, threshold=0.3)
+
+        for t in result.per_trait:
+            src = d[t.trait]
+            assert t.h2 == pytest.approx(float(src["heritability"]))
+            assert t.var_genetic == pytest.approx(float(src["var_genetic"]))
+            assert t.var_residual == pytest.approx(float(src["var_residual"]))
+            assert t.n_genotypes == int(src["n_genotypes"])
+            assert t.n_observations == int(src["n_observations"])
+            assert t.model_type == str(src["model_type"])
+            # var_genetic and var_residual are distinct keys, not swapped.
+            assert t.var_genetic != t.var_residual
+
+    def test_run_level_error_surfaced_not_a_fake_trait(self):
+        """A lone {"error": ...} run failure populates `error`, not failed_traits."""
+        msg = "Missing required columns: ['geno', 'rep']"
+        result = HeritabilityResult.from_heritability_dict(
+            {"error": msg}, threshold=0.3
+        )
+
+        assert result.error == msg
+        assert result.per_trait == []
+        assert result.failed_traits == []  # NOT ["error"]
+        assert "error" not in result.failed_traits
+        assert result.method == "unknown"
+
+    def test_per_trait_error_still_a_failed_trait(self, heritability_data_known_h2):
+        """A per-trait {"error": ...} entry remains a failed trait, not run-level."""
+        df, _ = heritability_data_known_h2
+        d = _run(df)
+        d["trait_bad"] = {"error": "Trait column 'trait_bad' not found"}
+
+        result = HeritabilityResult.from_heritability_dict(d, threshold=0.3)
+
+        assert result.error is None  # not a run-level failure
+        assert "trait_bad" in result.failed_traits
 
     def test_threshold_classification(self, heritability_data_known_h2):
         """passed_threshold is consistent and preserves H² ordering."""
@@ -159,11 +244,17 @@ class TestHeritabilityResultNonBreaking:
     """The legacy dict is preserved and not mutated by the adapter."""
 
     def test_dict_unchanged_and_nonmutating(self, heritability_data_known_h2):
-        """Legacy dict keeps its keys (incl. metadata) and is not mutated."""
+        """Legacy dict keeps its keys *and values* — the adapter never mutates it.
+
+        A keys-only check would pass an in-place value edit; deep-copy the dict and
+        assert full value equality after the adapter runs.
+        """
+        import copy
+
         df, _ = heritability_data_known_h2
         d = _run(df)
 
         assert "__calculation_metadata__" in d
-        before = set(d.keys())
+        before = copy.deepcopy(d)
         HeritabilityResult.from_heritability_dict(d, threshold=0.3)
-        assert set(d.keys()) == before
+        assert d == before

--- a/tests/test_heritability_result.py
+++ b/tests/test_heritability_result.py
@@ -1,0 +1,169 @@
+"""Tests for the serializable ``HeritabilityResult`` dataclass and adapter (#128).
+
+Covers the serializable-result-types contract for heritability: a native-type
+JSON round-trip (the reproducibility CI gate), threshold classification,
+``mean_h2`` / ``n_above_threshold`` derivations, separation of failed traits,
+determinism, public export, and the non-breaking / non-mutating guarantee.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from sleap_roots_analyze.result_types import HeritabilityResult, TraitHeritability
+from sleap_roots_analyze.statistics import calculate_heritability_estimates
+
+TRAIT_COLS = ["trait_high_h2", "trait_moderate_h2", "trait_low_h2"]
+
+
+def _run(df):
+    """Compute the legacy heritability dict for the known-H2 fixture."""
+    return calculate_heritability_estimates(
+        df, trait_cols=TRAIT_COLS, genotype_col="geno", replicate_col="rep"
+    )
+
+
+class TestHeritabilityResultJSON:
+    """The clean view must serialize to JSON as native Python types."""
+
+    def test_json_roundtrip_native_types(self, heritability_data_known_h2):
+        """json.dumps(asdict(...)) round-trips to native Python types."""
+        df, _ = heritability_data_known_h2
+        d = _run(df)
+        result = HeritabilityResult.from_heritability_dict(d, threshold=0.3)
+
+        parsed = json.loads(json.dumps(dataclasses.asdict(result)))
+
+        assert type(parsed["threshold"]) is float
+        assert parsed["per_trait"], "expected at least one successful trait"
+        for t in parsed["per_trait"]:
+            assert type(t["h2"]) is float
+            assert type(t["passed_threshold"]) is bool
+            assert type(t["n_genotypes"]) is int
+            assert type(t["n_observations"]) is int
+
+    def test_to_dict_matches_asdict(self, heritability_data_known_h2):
+        """``to_dict`` is a convenience over ``dataclasses.asdict``."""
+        df, _ = heritability_data_known_h2
+        result = HeritabilityResult.from_heritability_dict(_run(df), threshold=0.3)
+        assert result.to_dict() == dataclasses.asdict(result)
+
+
+class TestHeritabilityResultAdapter:
+    """``from_heritability_dict`` maps the legacy dict faithfully."""
+
+    def test_method_and_metadata_handling(self, heritability_data_known_h2):
+        """Method is read from metadata; the metadata key is not a trait."""
+        df, _ = heritability_data_known_h2
+        d = _run(df)
+        result = HeritabilityResult.from_heritability_dict(d, threshold=0.3)
+
+        assert result.method == "mixed_model"
+        traits = {t.trait for t in result.per_trait}
+        assert "__calculation_metadata__" not in traits
+        assert traits <= set(TRAIT_COLS)
+
+    def test_threshold_classification(self, heritability_data_known_h2):
+        """passed_threshold is consistent and preserves H² ordering."""
+        df, _ = heritability_data_known_h2
+        d = _run(df)
+        result = HeritabilityResult.from_heritability_dict(d, threshold=0.3)
+
+        by_trait = {t.trait: t for t in result.per_trait}
+        # The H² formula divides σ²_E by mean reps, so estimates run high but
+        # preserve the genetic-variance ordering high > moderate > low.
+        assert (
+            by_trait["trait_high_h2"].h2
+            > by_trait["trait_moderate_h2"].h2
+            > by_trait["trait_low_h2"].h2
+        )
+        for t in result.per_trait:
+            assert isinstance(t, TraitHeritability)
+            assert 0.0 <= t.h2 <= 1.0
+            assert t.passed_threshold == (t.h2 >= result.threshold)
+            assert t.passed_threshold is True  # all exceed 0.3
+
+    def test_mean_h2_and_n_above_threshold(self, heritability_data_known_h2):
+        """mean_h2 and n_above_threshold derive from successful traits."""
+        df, _ = heritability_data_known_h2
+        d = _run(df)
+        # Discriminating threshold: only the high-H² trait (~0.96) clears 0.9.
+        result = HeritabilityResult.from_heritability_dict(d, threshold=0.9)
+
+        mean = result.mean_h2
+        assert type(mean) is float
+        assert mean == pytest.approx(
+            sum(t.h2 for t in result.per_trait) / len(result.per_trait)
+        )
+        assert result.n_above_threshold == sum(
+            t.passed_threshold for t in result.per_trait
+        )
+        assert result.n_above_threshold == 1  # only trait_high_h2 clears 0.9
+
+    def test_failed_traits_separated(self, heritability_data_known_h2):
+        """Error trait entries land in failed_traits, not per_trait."""
+        df, _ = heritability_data_known_h2
+        d = _run(df)
+        # Inject an error trait the way the legacy function would.
+        d["trait_missing"] = {"error": "Trait column 'trait_missing' not found"}
+
+        result = HeritabilityResult.from_heritability_dict(d, threshold=0.3)
+
+        assert "trait_missing" in result.failed_traits
+        assert "trait_missing" not in {t.trait for t in result.per_trait}
+
+    def test_empty_per_trait_mean_is_zero(self):
+        """mean_h2 is 0.0 and counts are 0 when no trait succeeds."""
+        d = {
+            "__calculation_metadata__": {
+                "method_used_for_all_traits": "mixed_model",
+                "method_consistency": True,
+            },
+            "t1": {"error": "boom"},
+        }
+        result = HeritabilityResult.from_heritability_dict(d, threshold=0.3)
+        assert result.per_trait == []
+        assert result.mean_h2 == 0.0
+        assert result.n_above_threshold == 0
+
+
+class TestHeritabilityResultDeterminism:
+    """Same input → identical serialized result."""
+
+    def test_deterministic(self, heritability_data_known_h2):
+        """Same input yields an identical serialized result."""
+        df, _ = heritability_data_known_h2
+        r1 = HeritabilityResult.from_heritability_dict(_run(df), threshold=0.3)
+        r2 = HeritabilityResult.from_heritability_dict(_run(df), threshold=0.3)
+        assert dataclasses.asdict(r1) == dataclasses.asdict(r2)
+
+
+class TestHeritabilityResultExport:
+    """Public API surface."""
+
+    def test_importable_from_package_root(self):
+        """Both result types are importable and listed once in __all__."""
+        import sleap_roots_analyze as sra
+
+        assert sra.HeritabilityResult is HeritabilityResult
+        assert sra.TraitHeritability is TraitHeritability
+        for name in ("HeritabilityResult", "TraitHeritability"):
+            assert name in sra.__all__
+        assert len(sra.__all__) == len(set(sra.__all__))
+
+
+class TestHeritabilityResultNonBreaking:
+    """The legacy dict is preserved and not mutated by the adapter."""
+
+    def test_dict_unchanged_and_nonmutating(self, heritability_data_known_h2):
+        """Legacy dict keeps its keys (incl. metadata) and is not mutated."""
+        df, _ = heritability_data_known_h2
+        d = _run(df)
+
+        assert "__calculation_metadata__" in d
+        before = set(d.keys())
+        HeritabilityResult.from_heritability_dict(d, threshold=0.3)
+        assert set(d.keys()) == before


### PR DESCRIPTION
## Summary

Adds a frozen `HeritabilityResult` dataclass (with nested `TraitHeritability`) and a `from_heritability_dict(d, threshold)` adapter to the shared `result_types.py` module. This is the **Phase-1 anchor** of the serializable-result-types epic (#130), following the `PCAResult` (#127) convention.

`calculate_heritability_estimates()` returns a trait-keyed dict mixing per-trait estimates with a `__calculation_metadata__` entry — awkward to serialize or expose. `HeritabilityResult` is a clean JSON-native view: `json.dumps(dataclasses.asdict(result))` round-trips with no custom serializer.

Closes #128.

> **Stacked on #127** (`pcaresult-dataclass-127`, PR #149), which introduces `result_types.py`. Base will retarget to `main` once #127 merges.

## What's in the result

- Per-trait H², variance components (`var_genetic`/`var_residual`), and counts — all native-cast to JSON-safe types.
- `method` read from `__calculation_metadata__` (that entry is **not** treated as a trait); traits that errored go to `failed_traits`, not `per_trait`.
- `@property mean_h2` (mean over successful traits, `0.0` when empty) and `n_above_threshold`.
- `frozen=True` + `to_dict()`, matching the `PCAResult`/`EnrichmentResult` precedent.

## Backwards-compat

**Additive only (MINOR).** `calculate_heritability_estimates` still returns its exact dict/tuple; the adapter does not mutate its input. `HeritabilityResult`/`TraitHeritability` exported in `__all__`.

## Testing

- New `tests/test_heritability_result.py` (10 tests) over a real `calculate_heritability_estimates` run on the `heritability_data_known_h2` fixture (known variance components): native-type JSON round-trip, method/metadata handling, threshold classification + H² ordering, `mean_h2`/`n_above_threshold`, `failed_traits` separation, empty-case, determinism, export, and a dict-unchanged/non-mutating guard.
- `black`/`ruff` clean; `openspec validate add-heritabilityresult-dataclass --strict` passes; statistics + public-API contract suites green.

## Out of scope (deferred to the epic)

- Wheat-EDPIE Turface-19 golden numbers (mean H²=0.77; 8 traits ≥0.60) → epic verification milestone (#120/#130), as with #127. Numeric correctness is anchored here on the synthetic known-H² fixture.
- `docs/result-types.md` pattern doc → epic close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)