### PR TITLE
feat: add ClusterResult serializable dataclasses + adapters (#129)

### DIFF
--- a/docs/result-types.md
+++ b/docs/result-types.md
@@ -1,0 +1,82 @@
+# Serializable result types
+
+Most analytical functions in `sleap_roots_analyze` return a `dict` (or tuple) that
+mixes JSON-hostile members — `numpy.ndarray`, sklearn objects (`PCA`,
+`StandardScaler`, `UMAP`), `pandas.DataFrame`. Those results cannot cross a JSON
+boundary without bespoke conversion, which blocks exposing the functions as MCP tools
+(bloom-mcp), caching results as artifacts, and schema-checkable outputs (FAIR:
+interoperable + reusable).
+
+The **result types** in [`result_types.py`](../src/sleap_roots_analyze/result_types.py)
+solve this: flat stdlib `@dataclass` views that hold **only JSON-serializable science**.
+This is the same house pattern already used in
+[`summary/cross_platform_summary.py`](../src/sleap_roots_analyze/summary/cross_platform_summary.py)
+(`TraitReductionStats`, `PowerStats`, …), extended to the analytical functions under the
+serializable-result-types epic (#130).
+
+## The pattern
+
+A result type is a `@dataclass(frozen=True)` that satisfies these rules:
+
+1. **stdlib `dataclasses`, not Pydantic.** The package stays dependency-light and
+   MCP-agnostic; bloom-mcp wraps these plain dicts in its own Pydantic models at its
+   boundary.
+2. **Every field is JSON-native** — Python scalars, `str`, `bool`, and (nested) `list`s
+   of those. Never `numpy` arrays, `pandas` frames, or sklearn objects. The conversion
+   to native types happens once, in the adapter (`np.asarray(...).tolist()`,
+   `float(...)`, `int(...)`).
+3. **Science only.** Fitted sklearn objects (`PCA`, `StandardScaler`) stay out of the
+   clean view — they remain available via the legacy dict for in-process callers.
+4. **Derivations are `@property`, not stored fields**, so the serialized state has no
+   redundant/derivable members (e.g. `PCAResult.cumulative_variance`,
+   `HeritabilityResult.mean_h2`).
+5. **A `from_*_dict()` classmethod adapter** builds the dataclass from the legacy dict
+   and must **not mutate** the input dict.
+
+Because every field is JSON-native, the invariant that anchors the reproducibility CI
+gate holds with no custom serializer:
+
+```python
+import json, dataclasses
+from sleap_roots_analyze import PCAResult
+
+result = PCAResult.from_pca_dict(perform_pca_analysis(df), random_state=42)
+restored = json.loads(json.dumps(dataclasses.asdict(result)))   # round-trips, no encoder
+```
+
+## The types
+
+| Type | Built from | Adapter |
+| --- | --- | --- |
+| `PCAResult` (+ `FeatureContribution`) | `perform_pca_analysis` dict | `PCAResult.from_pca_dict(d, *, random_state=None, explained_variance_threshold=None)` |
+| `HeritabilityResult` (+ `TraitHeritability`) | `calculate_heritability_estimates` dict | `HeritabilityResult.from_heritability_dict(d, threshold)` |
+| `KMeansResult` / `GMMResult` (subclasses of `ClusterResult`) | `perform_kmeans_clustering` / `perform_gmm_clustering` dict | `ClusterResult.from_kmeans_dict(d, *, random_state)` / `from_gmm_dict(...)` |
+
+All are exported from the top-level `sleap_roots_analyze` namespace and `__all__`.
+
+## Backwards compatibility
+
+**Additive only.** Existing callers (`result["loadings"]`, the wheat EDPIE paper, the
+pipeline) keep working:
+
+1. Add the dataclass + `from_*_dict()` adapter; the analytical functions keep returning
+   the legacy dict → MINOR bump. The dataclass is an *additional* typed view, opt-in via
+   the adapter.
+2. Later (separate, deprecation-windowed) the functions may return the dataclass with a
+   `__getitem__` shim → MAJOR bump.
+
+## Adding a new result type (test-first)
+
+Follow the epic's pairing loop:
+
+1. Write the `json.dumps(dataclasses.asdict(...))` **round-trip test first** (plus a
+   golden / determinism test where the function feeds the #120 reproduction suite), and
+   watch it fail.
+2. Add the `@dataclass(frozen=True)` to `result_types.py` with JSON-native fields,
+   `@property` derivations, a non-mutating `from_*_dict()` adapter, and Google-style
+   docstrings.
+3. Export it from `result_types.__all__` and the top-level `__init__`.
+4. Add a unit test module `tests/test_<name>_result.py` covering the adapter and the
+   round-trip; where the function is re-run in the #120 golden suite
+   (`tests/test_pipeline_reproduction.py`), assert the golden numbers against the typed
+   view too.

--- a/docs/result-types.md
+++ b/docs/result-types.md
@@ -44,6 +44,24 @@ result = PCAResult.from_pca_dict(perform_pca_analysis(df), random_state=42)
 restored = json.loads(json.dumps(dataclasses.asdict(result)))   # round-trips, no encoder
 ```
 
+Each type also provides convenience helpers:
+
+- **`to_dict()`** — the plain `dict` view (`dataclasses.asdict(self)`), for callers that
+  don't want to import `dataclasses`.
+- **`to_json(**kwargs)`** — a strict-JSON string with `allow_nan=False` by default, so a
+  non-finite value (a degenerate `bic`/`aic`/`h2`, an all-zero-loadings PCA `NaN`
+  fractional contribution) raises a `ValueError` at serialization rather than emitting the
+  non-standard `NaN`/`Infinity` tokens a strict consumer (bloom-mcp) rejects. This enforces
+  the **finite-floats contract** of the JSON boundary; extra kwargs forward to `json.dumps`.
+
+```python
+result.to_json(indent=2)   # strict JSON; raises on NaN/Inf instead of emitting invalid JSON
+```
+
+For clustering, the `ClusterResult.algorithm` discriminator a consumer branches on is
+exported as the constants `ALGORITHM_KMEANS` / `ALGORITHM_GMM` (in `result_types`) — use
+those rather than re-spelling the string literals.
+
 ## The types
 
 | Type | Built from | Adapter |

--- a/openspec/changes/add-clusterresult-dataclass/proposal.md
+++ b/openspec/changes/add-clusterresult-dataclass/proposal.md
@@ -1,0 +1,67 @@
+# Add ClusterResult Serializable Dataclass Return Types (issue #129)
+
+## Why
+
+`perform_kmeans_clustering` / `perform_gmm_clustering` (`clustering.py`) return
+`Dict`s containing `np.ndarray` fields (`cluster_labels`, `cluster_centers` /
+`means`, `weights`, …) plus scalar quality metrics. Like PCA and heritability,
+this can't cross a JSON boundary (bloom-mcp, caching, an API) without bespoke
+conversion. Clustering is also **stochastic**, so the seed must be recorded in
+the result to make golden tests reproducible (ties to #118).
+
+The epic review flagged that KMeans and GMM returns differ substantially, so a
+single flat type does not fit both. This change models that with a **shared
+frozen base `ClusterResult` plus two subclasses** (`KMeansResult`,
+`GMMResult`), following the `result_types.py` convention established by
+`PCAResult` (#127) and `HeritabilityResult` (#128).
+
+## What Changes
+
+- **Frozen base `ClusterResult`** in `result_types.py` holding the science
+  common to both algorithms: `algorithm` (`"kmeans"` | `"gmm"`), `n_clusters`,
+  `cluster_labels`, `cluster_sizes`, the three quality metrics
+  (`silhouette_score`, `davies_bouldin_score`, `calinski_harabasz_score`),
+  `feature_names`, and the stamped `random_state`.
+- **`KMeansResult(ClusterResult)`** adds `cluster_centers` (`(k, n_features)`)
+  and `inertia`.
+- **`GMMResult(ClusterResult)`** adds `cluster_centers` (the GMM `means`,
+  `(k, n_features)`), `weights` (`(k,)`), `bic`, `aic`, `converged`, `n_iter`,
+  and `covariance_type`.
+- **Adapters** `ClusterResult.from_kmeans_dict(d, *, random_state)` →
+  `KMeansResult` and `ClusterResult.from_gmm_dict(d, *, random_state)` →
+  `GMMResult`. Each maps the legacy dict's arrays to JSON-native lists with
+  explicit native scalar casts, maps GMM `n_components`→`n_clusters` and
+  `means`→`cluster_centers`, and stamps `random_state` (the dicts don't carry
+  it). Neither adapter mutates `d`.
+- **`to_dict()`** on the base (via `dataclasses.asdict`), so each concrete
+  subclass serializes flat with no custom serializer. The `algorithm` field is
+  the discriminator a JSON consumer reads.
+- **Public exports.** `ClusterResult`, `KMeansResult`, `GMMResult` added to the
+  package `__all__` with full type hints + Google-style docstrings (every field
+  in an `Attributes:` block), satisfying the `test_public_api_docs.py`
+  introspection contract.
+- **Additive / non-breaking.** Both clustering functions keep returning their
+  dicts unchanged (MINOR bump).
+- **Tests.** Native-type JSON round-trips for both subclasses (reproducibility
+  CI gate), adapter field mapping (incl. GMM `means`→`cluster_centers`),
+  `random_state` stamping, a **determinism test** (same seed → identical
+  `cluster_labels` via the typed view, #118), exports, and dict-unchanged /
+  non-mutating guards.
+
+## Out of Scope (deferred to the epic)
+
+- The shared `docs/result-types.md` pattern doc remains an epic-close
+  deliverable.
+- Per-sample soft assignments (GMM `probabilities`, `(N, K)`) and per-sample
+  distance arrays (`distances_to_centers`) are intentionally omitted from the
+  clean summary view; they remain available via the legacy dict.
+
+## Impact
+
+- Affected specs: the `serializable-result-types` capability gains clustering
+  requirements (same capability as #127/#128).
+- Affected code: `src/sleap_roots_analyze/result_types.py` (base + two
+  subclasses + adapters); `src/sleap_roots_analyze/__init__.py` (`__all__`);
+  **new** `tests/test_cluster_result.py`.
+- No breaking changes; purely additive public API (MINOR version bump).
+- Stacked on #128 (`heritabilityresult-dataclass-128`), which is stacked on #127.

--- a/openspec/changes/add-clusterresult-dataclass/specs/serializable-result-types/spec.md
+++ b/openspec/changes/add-clusterresult-dataclass/specs/serializable-result-types/spec.md
@@ -1,0 +1,92 @@
+# serializable-result-types Specification (delta)
+
+## ADDED Requirements
+
+### Requirement: Serializable Clustering Result Types
+
+The package SHALL provide a frozen stdlib `@dataclass` base `ClusterResult` and
+two frozen subclasses `KMeansResult` and `GMMResult` in `result_types.py`, each
+capturing only the JSON-serializable science of a clustering run (no sklearn
+estimator objects). Every scalar field SHALL be a native Python type, and every
+array field a list thereof, so that `json.dumps(dataclasses.asdict(result))`
+succeeds without a custom serializer. The base SHALL provide a `to_dict()`
+method returning `dataclasses.asdict(self)`, and an `algorithm` field
+(`"kmeans"` | `"gmm"`) that discriminates the concrete type.
+
+#### Scenario: KMeansResult round-trips through JSON as native types
+
+- **WHEN** a `KMeansResult` built from a `perform_kmeans_clustering()` dict is
+  passed to `json.dumps(dataclasses.asdict(result))`
+- **THEN** the call SHALL succeed without raising
+- **AND** parsing it back SHALL yield `algorithm == "kmeans"`, `cluster_labels`
+  as a list of `int`, `cluster_centers` as nested `list[list[float]]`,
+  `inertia` and the quality metrics as `float`, and `random_state` as `int`
+
+#### Scenario: GMMResult round-trips through JSON as native types
+
+- **WHEN** a `GMMResult` built from a `perform_gmm_clustering()` dict is passed
+  to `json.dumps(dataclasses.asdict(result))`
+- **THEN** the call SHALL succeed without raising
+- **AND** parsing it back SHALL yield `algorithm == "gmm"`, `cluster_centers`
+  (the GMM means) as nested `list[list[float]]`, `weights` as a list of
+  `float`, `bic`/`aic` as `float`, `converged` as `bool`, and `n_iter` as `int`
+
+### Requirement: Clustering Adapters From Legacy Dicts
+
+The package SHALL provide `ClusterResult.from_kmeans_dict(d, *, random_state)`
+returning a `KMeansResult`, and `ClusterResult.from_gmm_dict(d, *,
+random_state)` returning a `GMMResult`. Each SHALL map the legacy clustering
+dict into the typed view, stamp the supplied `random_state`, and not mutate `d`.
+
+#### Scenario: KMeans adapter maps the legacy dict
+
+- **WHEN** `ClusterResult.from_kmeans_dict(d, random_state=42)` is called on a
+  `perform_kmeans_clustering()` dict
+- **THEN** `n_clusters` SHALL equal `int(d["n_clusters"])`
+- **AND** `cluster_centers` SHALL be `d["cluster_centers"]` as nested
+  `list[list[float]]`
+- **AND** `cluster_labels` SHALL be a list of `int` and `random_state` SHALL be
+  `42`
+
+#### Scenario: GMM adapter maps n_components and means
+
+- **WHEN** `ClusterResult.from_gmm_dict(d, random_state=42)` is called on a
+  `perform_gmm_clustering()` dict
+- **THEN** `n_clusters` SHALL equal `int(d["n_components"])`
+- **AND** `cluster_centers` SHALL be built from `d["means"]`
+- **AND** `weights`, `bic`, `aic`, `converged`, `n_iter`, and `covariance_type`
+  SHALL be carried from the dict with native casts
+
+#### Scenario: Same seed yields identical cluster labels via the typed view
+
+- **WHEN** `perform_kmeans_clustering` is run twice with the same
+  `random_state` and each result is passed through `from_kmeans_dict`
+- **THEN** the two results' `cluster_labels` SHALL be identical
+
+### Requirement: Clustering Result Public Export
+
+The package SHALL export `ClusterResult`, `KMeansResult`, and `GMMResult` from
+the top-level `sleap_roots_analyze` namespace and list them in `__all__`.
+
+#### Scenario: Clustering result types importable from package root
+
+- **WHEN** a consumer runs
+  `from sleap_roots_analyze import ClusterResult, KMeansResult, GMMResult`
+- **THEN** the import SHALL succeed
+- **AND** all three names SHALL appear in `sleap_roots_analyze.__all__` with no
+  duplicate entries
+
+### Requirement: Non-Breaking Clustering Return Shapes
+
+Adding the clustering result types SHALL NOT change the return shapes of
+`perform_kmeans_clustering` / `perform_gmm_clustering`; both SHALL keep
+returning their existing dicts so all current callers continue to work.
+
+#### Scenario: Existing clustering returns are preserved and not mutated
+
+- **WHEN** `perform_kmeans_clustering()` or `perform_gmm_clustering()` is called
+- **THEN** it SHALL return its existing dict (including `cluster_labels`,
+  `cluster_centers`/`means`, and the quality-metric keys)
+- **AND** calling the corresponding adapter SHALL leave the dict's keys and
+  values unchanged
+- **AND** the typed view SHALL be opt-in, built only via the adapters

--- a/openspec/changes/add-clusterresult-dataclass/tasks.md
+++ b/openspec/changes/add-clusterresult-dataclass/tasks.md
@@ -1,0 +1,48 @@
+# Tasks — Add ClusterResult Serializable Dataclasses (issue #129)
+
+> Single `feat: ... (#129)` commit (CI green at HEAD); exports land with the
+> dataclasses. Stacked on #128 → #127. OpenSpec archive post-merge.
+
+## 1. Failing tests first (red) — `tests/test_cluster_result.py`
+- [x] 1.1 `test_kmeans_json_roundtrip_native_types`: build
+      `ClusterResult.from_kmeans_dict(kmeans_cluster_result, random_state=42)`,
+      assert `json.dumps(asdict(...))` succeeds, then `json.loads` and assert
+      `algorithm == "kmeans"`, `cluster_labels` are `int`, `cluster_centers`
+      nested `float`, `inertia`/metrics `float`, `random_state` `int`.
+- [x] 1.2 `test_gmm_json_roundtrip_native_types`: same for
+      `from_gmm_dict(gmm_cluster_result, random_state=42)`; assert
+      `algorithm == "gmm"`, `cluster_centers` from means, `weights` floats,
+      `bic`/`aic` float, `converged` bool, `n_iter` int.
+- [x] 1.3 `test_kmeans_adapter_maps_fields`: `n_clusters == int(d["n_clusters"])`;
+      `cluster_centers` shape `(k, n_features)`; `cluster_sizes` ints summing to
+      n_samples; `random_state == 42`.
+- [x] 1.4 `test_gmm_adapter_maps_n_components_and_means`: `n_clusters ==
+      int(d["n_components"])`; `cluster_centers` equals `d["means"]`;
+      `covariance_type` carried.
+- [x] 1.5 `test_determinism_same_seed_identical_labels`: run
+      `perform_kmeans_clustering(simple_cluster_data, n_clusters=3,
+      random_state=42)` twice, build typed views, assert identical
+      `cluster_labels` (#118).
+- [x] 1.6 `test_exports_and_all`: import `ClusterResult`, `KMeansResult`,
+      `GMMResult` from package root; all in `__all__`, no dupes.
+- [x] 1.7 `test_dicts_unchanged_and_nonmutating`: kmeans/gmm dict keys preserved;
+      adapters do not mutate input.
+
+## 2. Implement to green
+- [x] 2.1 Add frozen base `ClusterResult` (common fields + `algorithm` +
+      `to_dict()`), then frozen `KMeansResult` / `GMMResult` subclasses to
+      `result_types.py` (Google docstrings with `Attributes:` per field).
+- [x] 2.2 Implement `ClusterResult.from_kmeans_dict(d, *, random_state)` and
+      `ClusterResult.from_gmm_dict(d, *, random_state)`: native list/scalar
+      casts; GMM `n_components`→`n_clusters`, `means`→`cluster_centers`; stamp
+      `random_state`; no mutation of `d`.
+- [x] 2.3 Export `ClusterResult`, `KMeansResult`, `GMMResult` from `__init__.py`
+      (`__all__`).
+
+## 3. Verify non-breaking
+- [x] 3.1 Existing `tests/test_clustering.py` pass; return shapes unchanged
+      (covered by task 1.7).
+
+## 4. Pre-merge
+- [x] 4.1 `black` + `ruff` + full `pytest` green; `openspec validate
+      add-clusterresult-dataclass --strict` passes.

--- a/openspec/changes/add-clusterresult-dataclass/tasks.md
+++ b/openspec/changes/add-clusterresult-dataclass/tasks.md
@@ -46,3 +46,21 @@
 ## 4. Pre-merge
 - [x] 4.1 `black` + `ruff` + full `pytest` green; `openspec validate
       add-clusterresult-dataclass --strict` passes.
+
+## 5. Review follow-ups (rebased on the updated #127/#128)
+- [x] 5.1 Retain GMM per-component `covariances` (the fitted cluster shapes) as a
+      nested list; document the deliberate omission of per-sample
+      `probabilities`/`log_likelihoods` and the per-`k` `bic_scores`/`aic_scores`
+      selection sweep. Add covariance-retention + shape tests.
+- [x] 5.2 GMM determinism test (same seed → identical serialized view, the
+      init-sensitive case); value-assert `bic`/`aic`/`converged`/`n_iter`/`weights`
+      against the source (guarding a bic↔aic swap).
+- [x] 5.3 Move the PCAResult golden test out of `test_pipeline_reproduction.py`
+      into `test_pca_result.py` (it validates #127's type, not a cluster type).
+- [x] 5.4 Promote the `algorithm` discriminators to exported module constants
+      `ALGORITHM_KMEANS`/`ALGORITHM_GMM` (no inline literals); document `to_dict()`
+      + `to_json()` in `docs/result-types.md`.
+- [x] 5.5 Cross-cutting (shared module): `to_json(allow_nan=False)` finite-floats
+      contract on `ClusterResult`; non-vacuous `type(field) is float` pre-serialization
+      assertions; non-mutation guards deep-compare values; frozen-is-shallow +
+      provenance (`random_state` as supplied) docstring notes.

--- a/src/sleap_roots_analyze/__init__.py
+++ b/src/sleap_roots_analyze/__init__.py
@@ -46,6 +46,9 @@ from sleap_roots_analyze.result_types import (
     PCAResult,
     HeritabilityResult,
     TraitHeritability,
+    ClusterResult,
+    KMeansResult,
+    GMMResult,
 )
 
 from sleap_roots_analyze.umap import (
@@ -228,6 +231,9 @@ __all__ = [
     "FeatureContribution",
     "HeritabilityResult",
     "TraitHeritability",
+    "ClusterResult",
+    "KMeansResult",
+    "GMMResult",
     # UMAP functions
     "perform_umap_analysis",
     # Clustering functions

--- a/src/sleap_roots_analyze/result_types.py
+++ b/src/sleap_roots_analyze/result_types.py
@@ -37,6 +37,9 @@ __all__ = [
     "PCAResult",
     "TraitHeritability",
     "HeritabilityResult",
+    "ClusterResult",
+    "KMeansResult",
+    "GMMResult",
 ]
 
 # Key the heritability dict reserves for calculation metadata (not a trait).
@@ -367,3 +370,162 @@ class HeritabilityResult:
             per_trait=per_trait,
             failed_traits=failed_traits,
         )
+
+
+@dataclass(frozen=True)
+class ClusterResult:
+    """JSON-serializable base view of a clustering run (science only).
+
+    KMeans and GMM return substantially different results, so the algorithm-
+    specific science lives on the :class:`KMeansResult` / :class:`GMMResult`
+    subclasses; this base holds only the fields common to both. The
+    ``algorithm`` field discriminates the concrete type for a JSON consumer.
+    Build via :meth:`from_kmeans_dict` / :meth:`from_gmm_dict`.
+
+    Attributes:
+        algorithm: Clustering algorithm, ``"kmeans"`` or ``"gmm"``.
+        n_clusters: Number of clusters (KMeans ``n_clusters`` / GMM
+            ``n_components``).
+        cluster_labels: Hard cluster assignment per sample.
+        cluster_sizes: Number of samples assigned to each cluster.
+        silhouette_score: Silhouette quality metric in ``[-1, 1]``.
+        davies_bouldin_score: Davies-Bouldin quality metric (lower is better).
+        calinski_harabasz_score: Calinski-Harabasz quality metric (higher is
+            better).
+        feature_names: Feature (column) names used for clustering.
+        random_state: Random seed used for the run, stamped for reproducibility.
+    """
+
+    algorithm: str
+    n_clusters: int
+    cluster_labels: list[int]
+    cluster_sizes: list[int]
+    silhouette_score: float
+    davies_bouldin_score: float
+    calinski_harabasz_score: float
+    feature_names: list[str]
+    random_state: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain ``dict`` view via :func:`dataclasses.asdict`."""
+        return dataclasses.asdict(self)
+
+    @classmethod
+    def from_kmeans_dict(cls, d: dict, *, random_state: int) -> "KMeansResult":
+        """Build a :class:`KMeansResult` from a ``perform_kmeans_clustering`` dict.
+
+        Stamps ``random_state`` (the dict does not carry it). Does not mutate
+        ``d``.
+
+        Args:
+            d: The dict returned by ``perform_kmeans_clustering``.
+            random_state: Seed to stamp into the result for reproducibility.
+
+        Returns:
+            A frozen :class:`KMeansResult` holding only serializable science.
+        """
+        return KMeansResult(
+            algorithm="kmeans",
+            n_clusters=int(d["n_clusters"]),
+            cluster_labels=[int(x) for x in np.asarray(d["cluster_labels"])],
+            cluster_sizes=[int(x) for x in d["cluster_sizes"]],
+            silhouette_score=float(d["silhouette_score"]),
+            davies_bouldin_score=float(d["davies_bouldin_score"]),
+            calinski_harabasz_score=float(d["calinski_harabasz_score"]),
+            feature_names=[str(name) for name in d["feature_names"]],
+            random_state=int(random_state),
+            cluster_centers=np.asarray(d["cluster_centers"]).tolist(),
+            inertia=float(d["inertia"]),
+        )
+
+    @classmethod
+    def from_gmm_dict(cls, d: dict, *, random_state: int) -> "GMMResult":
+        """Build a :class:`GMMResult` from a ``perform_gmm_clustering`` dict.
+
+        Maps ``n_components`` to ``n_clusters`` and the GMM ``means`` to
+        ``cluster_centers``, and stamps ``random_state`` (the dict does not
+        carry it). Does not mutate ``d``.
+
+        Args:
+            d: The dict returned by ``perform_gmm_clustering``.
+            random_state: Seed to stamp into the result for reproducibility.
+
+        Returns:
+            A frozen :class:`GMMResult` holding only serializable science.
+        """
+        return GMMResult(
+            algorithm="gmm",
+            n_clusters=int(d["n_components"]),
+            cluster_labels=[int(x) for x in np.asarray(d["cluster_labels"])],
+            cluster_sizes=[int(x) for x in d["cluster_sizes"]],
+            silhouette_score=float(d["silhouette_score"]),
+            davies_bouldin_score=float(d["davies_bouldin_score"]),
+            calinski_harabasz_score=float(d["calinski_harabasz_score"]),
+            feature_names=[str(name) for name in d["feature_names"]],
+            random_state=int(random_state),
+            cluster_centers=np.asarray(d["means"]).tolist(),
+            weights=[float(w) for w in np.asarray(d["weights"])],
+            bic=float(d["bic"]),
+            aic=float(d["aic"]),
+            converged=bool(d["converged"]),
+            n_iter=int(d["n_iter"]),
+            covariance_type=str(d["covariance_type"]),
+        )
+
+
+@dataclass(frozen=True)
+class KMeansResult(ClusterResult):
+    """JSON-serializable view of a K-Means run.
+
+    Attributes:
+        algorithm: Always ``"kmeans"`` for this type.
+        n_clusters: Number of clusters.
+        cluster_labels: Hard cluster assignment per sample.
+        cluster_sizes: Number of samples assigned to each cluster.
+        silhouette_score: Silhouette quality metric in ``[-1, 1]``.
+        davies_bouldin_score: Davies-Bouldin quality metric (lower is better).
+        calinski_harabasz_score: Calinski-Harabasz quality metric (higher is
+            better).
+        feature_names: Feature (column) names used for clustering.
+        random_state: Random seed stamped for reproducibility.
+        cluster_centers: ``(n_clusters, n_features)`` nested list of centroids.
+        inertia: Within-cluster sum of squares.
+    """
+
+    cluster_centers: list[list[float]] = field(default_factory=list)
+    inertia: float = 0.0
+
+
+@dataclass(frozen=True)
+class GMMResult(ClusterResult):
+    """JSON-serializable view of a Gaussian Mixture Model run.
+
+    Attributes:
+        algorithm: Always ``"gmm"`` for this type.
+        n_clusters: Number of mixture components.
+        cluster_labels: Hard cluster assignment (argmax of probabilities) per
+            sample.
+        cluster_sizes: Number of samples assigned to each component.
+        silhouette_score: Silhouette quality metric in ``[-1, 1]``.
+        davies_bouldin_score: Davies-Bouldin quality metric (lower is better).
+        calinski_harabasz_score: Calinski-Harabasz quality metric (higher is
+            better).
+        feature_names: Feature (column) names used for clustering.
+        random_state: Random seed stamped for reproducibility.
+        cluster_centers: ``(n_clusters, n_features)`` nested list of component
+            means.
+        weights: Mixture weight per component.
+        bic: Bayesian Information Criterion of the selected model.
+        aic: Akaike Information Criterion of the selected model.
+        converged: Whether the EM algorithm converged.
+        n_iter: Number of EM iterations performed.
+        covariance_type: Covariance parameterization used (e.g. ``"full"``).
+    """
+
+    cluster_centers: list[list[float]] = field(default_factory=list)
+    weights: list[float] = field(default_factory=list)
+    bic: float = 0.0
+    aic: float = 0.0
+    converged: bool = False
+    n_iter: int = 0
+    covariance_type: str = "full"

--- a/src/sleap_roots_analyze/result_types.py
+++ b/src/sleap_roots_analyze/result_types.py
@@ -40,10 +40,18 @@ __all__ = [
     "ClusterResult",
     "KMeansResult",
     "GMMResult",
+    "ALGORITHM_KMEANS",
+    "ALGORITHM_GMM",
 ]
 
 # Key the heritability dict reserves for calculation metadata (not a trait).
 _HERITABILITY_METADATA_KEY = "__calculation_metadata__"
+
+# Clustering ``algorithm`` discriminator values — the JSON tag a consumer branches
+# on to pick KMeansResult vs GMMResult. Named constants (not inline literals) so the
+# producer and any consumer share one spelling.
+ALGORITHM_KMEANS = "kmeans"
+ALGORITHM_GMM = "gmm"
 
 
 @dataclass(frozen=True)
@@ -379,11 +387,18 @@ class ClusterResult:
     KMeans and GMM return substantially different results, so the algorithm-
     specific science lives on the :class:`KMeansResult` / :class:`GMMResult`
     subclasses; this base holds only the fields common to both. The
-    ``algorithm`` field discriminates the concrete type for a JSON consumer.
+    ``algorithm`` field discriminates the concrete type for a JSON consumer
+    (compare against :data:`ALGORITHM_KMEANS` / :data:`ALGORITHM_GMM`).
     Build via :meth:`from_kmeans_dict` / :meth:`from_gmm_dict`.
 
+    ``frozen=True`` is shallow: the fields cannot be rebound, but the nested list
+    fields (``cluster_labels``, ``cluster_centers``, ...) are still mutable in
+    place — treat the result as read-only. Float fields must be finite for the JSON
+    boundary; use :meth:`to_json` to enforce it.
+
     Attributes:
-        algorithm: Clustering algorithm, ``"kmeans"`` or ``"gmm"``.
+        algorithm: Clustering algorithm, :data:`ALGORITHM_KMEANS` (``"kmeans"``) or
+            :data:`ALGORITHM_GMM` (``"gmm"``).
         n_clusters: Number of clusters (KMeans ``n_clusters`` / GMM
             ``n_components``).
         cluster_labels: Hard cluster assignment per sample.
@@ -410,22 +425,40 @@ class ClusterResult:
         """Return a plain ``dict`` view via :func:`dataclasses.asdict`."""
         return dataclasses.asdict(self)
 
+    def to_json(self, **kwargs: Any) -> str:
+        """Serialize to a strict-JSON string, enforcing the finite-floats contract.
+
+        Defaults to ``allow_nan=False`` so a non-finite value (e.g. a degenerate GMM
+        ``bic``/``aic``) raises a ``ValueError`` here rather than emitting the
+        non-standard ``NaN``/``Infinity`` tokens a strict consumer (bloom-mcp)
+        rejects. Extra keyword arguments are forwarded to :func:`json.dumps`.
+
+        Raises:
+            ValueError: If any float field is non-finite (under the default
+                ``allow_nan=False``).
+        """
+        kwargs.setdefault("allow_nan", False)
+        return json.dumps(self.to_dict(), **kwargs)
+
     @classmethod
     def from_kmeans_dict(cls, d: dict, *, random_state: int) -> "KMeansResult":
         """Build a :class:`KMeansResult` from a ``perform_kmeans_clustering`` dict.
 
-        Stamps ``random_state`` (the dict does not carry it). Does not mutate
-        ``d``.
+        Provenance caveat: ``random_state`` is stamped *as supplied* — the dict does
+        not carry it, so it is recorded on trust, not cross-checked. Pass the same
+        seed handed to ``perform_kmeans_clustering``; a mismatch creates a
+        false-but-authoritative reproducibility record. Does not mutate ``d``.
 
         Args:
             d: The dict returned by ``perform_kmeans_clustering``.
-            random_state: Seed to stamp into the result for reproducibility.
+            random_state: Seed to stamp into the result for reproducibility (must
+                match the seed used to produce ``d``).
 
         Returns:
             A frozen :class:`KMeansResult` holding only serializable science.
         """
         return KMeansResult(
-            algorithm="kmeans",
+            algorithm=ALGORITHM_KMEANS,
             n_clusters=int(d["n_clusters"]),
             cluster_labels=[int(x) for x in np.asarray(d["cluster_labels"])],
             cluster_sizes=[int(x) for x in d["cluster_sizes"]],
@@ -443,18 +476,28 @@ class ClusterResult:
         """Build a :class:`GMMResult` from a ``perform_gmm_clustering`` dict.
 
         Maps ``n_components`` to ``n_clusters`` and the GMM ``means`` to
-        ``cluster_centers``, and stamps ``random_state`` (the dict does not
-        carry it). Does not mutate ``d``.
+        ``cluster_centers``, and retains the per-component ``covariances`` (the
+        fitted cluster shapes). Stamps ``random_state``.
+
+        Provenance caveat: ``random_state`` is stamped *as supplied* — the dict does
+        not carry it, so it is recorded on trust, not cross-checked. Pass the same
+        seed handed to ``perform_gmm_clustering``. Does not mutate ``d``.
+
+        Intentionally omitted (not part of the selected-model science this view
+        captures): per-sample ``probabilities`` and ``log_likelihoods`` (scale with
+        the sample count), and the per-``k`` ``bic_scores``/``aic_scores`` selection
+        sweep (the selected model's ``bic``/``aic`` are kept).
 
         Args:
             d: The dict returned by ``perform_gmm_clustering``.
-            random_state: Seed to stamp into the result for reproducibility.
+            random_state: Seed to stamp into the result for reproducibility (must
+                match the seed used to produce ``d``).
 
         Returns:
             A frozen :class:`GMMResult` holding only serializable science.
         """
         return GMMResult(
-            algorithm="gmm",
+            algorithm=ALGORITHM_GMM,
             n_clusters=int(d["n_components"]),
             cluster_labels=[int(x) for x in np.asarray(d["cluster_labels"])],
             cluster_sizes=[int(x) for x in d["cluster_sizes"]],
@@ -464,6 +507,7 @@ class ClusterResult:
             feature_names=[str(name) for name in d["feature_names"]],
             random_state=int(random_state),
             cluster_centers=np.asarray(d["means"]).tolist(),
+            covariances=np.asarray(d["covariances"]).tolist(),
             weights=[float(w) for w in np.asarray(d["weights"])],
             bic=float(d["bic"]),
             aic=float(d["aic"]),
@@ -478,7 +522,7 @@ class KMeansResult(ClusterResult):
     """JSON-serializable view of a K-Means run.
 
     Attributes:
-        algorithm: Always ``"kmeans"`` for this type.
+        algorithm: Always :data:`ALGORITHM_KMEANS` (``"kmeans"``) for this type.
         n_clusters: Number of clusters.
         cluster_labels: Hard cluster assignment per sample.
         cluster_sizes: Number of samples assigned to each cluster.
@@ -501,7 +545,7 @@ class GMMResult(ClusterResult):
     """JSON-serializable view of a Gaussian Mixture Model run.
 
     Attributes:
-        algorithm: Always ``"gmm"`` for this type.
+        algorithm: Always :data:`ALGORITHM_GMM` (``"gmm"``) for this type.
         n_clusters: Number of mixture components.
         cluster_labels: Hard cluster assignment (argmax of probabilities) per
             sample.
@@ -514,15 +558,26 @@ class GMMResult(ClusterResult):
         random_state: Random seed stamped for reproducibility.
         cluster_centers: ``(n_clusters, n_features)`` nested list of component
             means.
+        covariances: Per-component covariances (the fitted cluster shapes), as a
+            nested list. Shape depends on ``covariance_type``: ``"full"`` →
+            ``(n_clusters, n_features, n_features)``, ``"tied"`` →
+            ``(n_features, n_features)``, ``"diag"`` → ``(n_clusters, n_features)``,
+            ``"spherical"`` → ``(n_clusters,)``.
         weights: Mixture weight per component.
         bic: Bayesian Information Criterion of the selected model.
         aic: Akaike Information Criterion of the selected model.
         converged: Whether the EM algorithm converged.
         n_iter: Number of EM iterations performed.
         covariance_type: Covariance parameterization used (e.g. ``"full"``).
+
+    Note:
+        Per-sample ``probabilities``/``log_likelihoods`` and the per-``k``
+        ``bic_scores``/``aic_scores`` model-selection sweep from the source dict are
+        intentionally omitted — see :meth:`from_gmm_dict`.
     """
 
     cluster_centers: list[list[float]] = field(default_factory=list)
+    covariances: list = field(default_factory=list)
     weights: list[float] = field(default_factory=list)
     bic: float = 0.0
     aic: float = 0.0

--- a/tests/test_cluster_result.py
+++ b/tests/test_cluster_result.py
@@ -9,15 +9,54 @@ export, and the non-breaking / non-mutating guarantee.
 
 from __future__ import annotations
 
+import copy
 import dataclasses
 import json
 
-from sleap_roots_analyze.clustering import perform_kmeans_clustering
-from sleap_roots_analyze.result_types import ClusterResult, GMMResult, KMeansResult
+import numpy as np
+import pytest
+
+from sleap_roots_analyze.clustering import (
+    perform_gmm_clustering,
+    perform_kmeans_clustering,
+)
+from sleap_roots_analyze.result_types import (
+    ALGORITHM_GMM,
+    ALGORITHM_KMEANS,
+    ClusterResult,
+    GMMResult,
+    KMeansResult,
+)
+
+
+def _assert_dict_unchanged(d, before):
+    """Assert every value in ``d`` deep-equals ``before`` (numpy-aware)."""
+    assert set(d.keys()) == set(before.keys())
+    for k, prev in before.items():
+        cur = d[k]
+        if isinstance(prev, np.ndarray):
+            np.testing.assert_array_equal(np.asarray(cur), prev)
+        else:
+            assert cur == prev, k
 
 
 class TestKMeansResultJSON:
     """KMeans clean view serializes to native Python types."""
+
+    def test_fields_are_native_types_pre_serialization(self, kmeans_cluster_result):
+        """Float fields are native ``float`` on the dataclass, not laundered by JSON.
+
+        ``np.float64`` is a subclass of ``float``, so a JSON round-trip silently
+        casts a leak to native float before any assertion — assert on the fields.
+        """
+        result = ClusterResult.from_kmeans_dict(kmeans_cluster_result, random_state=42)
+
+        assert result.algorithm == ALGORITHM_KMEANS
+        assert type(result.inertia) is float
+        assert type(result.silhouette_score) is float
+        assert type(result.random_state) is int
+        assert all(type(v) is int for v in result.cluster_labels)
+        assert all(type(v) is float for row in result.cluster_centers for v in row)
 
     def test_json_roundtrip_native_types(self, kmeans_cluster_result):
         """KMeans view round-trips to native types with the right discriminator."""
@@ -25,16 +64,33 @@ class TestKMeansResultJSON:
         assert isinstance(result, KMeansResult)
         parsed = json.loads(json.dumps(dataclasses.asdict(result)))
 
-        assert parsed["algorithm"] == "kmeans"
+        assert parsed["algorithm"] == ALGORITHM_KMEANS
         assert all(type(v) is int for v in parsed["cluster_labels"])
         assert all(type(v) is float for row in parsed["cluster_centers"] for v in row)
         assert type(parsed["inertia"]) is float
         assert type(parsed["silhouette_score"]) is float
         assert type(parsed["random_state"]) is int
 
+    def test_to_json_roundtrips_finite_data(self, kmeans_cluster_result):
+        """On finite data, to_json emits strict JSON that parses back to to_dict."""
+        result = ClusterResult.from_kmeans_dict(kmeans_cluster_result, random_state=42)
+        assert json.loads(result.to_json()) == json.loads(json.dumps(result.to_dict()))
+
 
 class TestGMMResultJSON:
     """GMM clean view serializes to native Python types."""
+
+    def test_fields_are_native_types_pre_serialization(self, gmm_cluster_result):
+        """Float fields are native ``float`` on the dataclass, not laundered by JSON."""
+        result = ClusterResult.from_gmm_dict(gmm_cluster_result, random_state=42)
+
+        assert result.algorithm == ALGORITHM_GMM
+        assert type(result.bic) is float
+        assert type(result.aic) is float
+        assert type(result.converged) is bool
+        assert type(result.n_iter) is int
+        assert all(type(v) is float for v in result.weights)
+        assert all(type(v) is float for row in result.cluster_centers for v in row)
 
     def test_json_roundtrip_native_types(self, gmm_cluster_result):
         """GMM view round-trips to native types with the right discriminator."""
@@ -42,13 +98,26 @@ class TestGMMResultJSON:
         assert isinstance(result, GMMResult)
         parsed = json.loads(json.dumps(dataclasses.asdict(result)))
 
-        assert parsed["algorithm"] == "gmm"
+        assert parsed["algorithm"] == ALGORITHM_GMM
         assert all(type(v) is float for row in parsed["cluster_centers"] for v in row)
         assert all(type(v) is float for v in parsed["weights"])
         assert type(parsed["bic"]) is float
         assert type(parsed["aic"]) is float
         assert type(parsed["converged"]) is bool
         assert type(parsed["n_iter"]) is int
+
+    def test_to_json_roundtrips_finite_data(self, gmm_cluster_result):
+        """On finite data, to_json emits strict JSON that parses back to to_dict."""
+        result = ClusterResult.from_gmm_dict(gmm_cluster_result, random_state=42)
+        assert json.loads(result.to_json()) == json.loads(json.dumps(result.to_dict()))
+
+    @pytest.mark.parametrize("bad", [float("nan"), float("inf"), float("-inf")])
+    def test_to_json_rejects_non_finite_bic(self, gmm_cluster_result, bad):
+        """A non-finite bic raises at to_json instead of emitting invalid JSON."""
+        result = ClusterResult.from_gmm_dict(gmm_cluster_result, random_state=42)
+        tainted = dataclasses.replace(result, bic=bad)
+        with pytest.raises(ValueError, match="not JSON compliant"):
+            tainted.to_json()
 
 
 class TestClusterAdapters:
@@ -76,11 +145,40 @@ class TestClusterAdapters:
         assert result.covariance_type == d["covariance_type"]
         assert len(result.weights) == result.n_clusters
 
+    def test_gmm_adapter_value_asserts_all_scalar_fields(self, gmm_cluster_result):
+        """bic/aic/converged/n_iter/weights map by value, guarding a bic<->aic swap."""
+        d = gmm_cluster_result
+        result = ClusterResult.from_gmm_dict(d, random_state=42)
+
+        assert result.bic == pytest.approx(float(d["bic"]))
+        assert result.aic == pytest.approx(float(d["aic"]))
+        assert result.bic != result.aic  # distinct keys, not swapped/aliased
+        assert result.converged is bool(d["converged"])
+        assert result.n_iter == int(d["n_iter"])
+        assert result.weights == pytest.approx([float(w) for w in d["weights"]])
+
+    def test_gmm_adapter_retains_covariances(self, gmm_cluster_result):
+        """The fitted per-component covariances are retained (cluster shapes)."""
+        d = gmm_cluster_result
+        result = ClusterResult.from_gmm_dict(d, random_state=42)
+
+        np.testing.assert_allclose(
+            np.asarray(result.covariances), np.asarray(d["covariances"])
+        )
+        # covariance_type="full" -> (n_clusters, n_features, n_features)
+        if result.covariance_type == "full":
+            n_features = len(result.feature_names)
+            assert np.asarray(result.covariances).shape == (
+                result.n_clusters,
+                n_features,
+                n_features,
+            )
+
 
 class TestClusterDeterminism:
-    """Same seed -> identical cluster labels via the typed view (#118)."""
+    """Same seed -> identical result via the typed view (#118)."""
 
-    def test_same_seed_identical_labels(self, simple_cluster_data):
+    def test_kmeans_same_seed_identical_labels(self, simple_cluster_data):
         """Re-running KMeans with the same seed yields identical labels."""
         r1 = ClusterResult.from_kmeans_dict(
             perform_kmeans_clustering(
@@ -95,6 +193,23 @@ class TestClusterDeterminism:
             random_state=42,
         )
         assert r1.cluster_labels == r2.cluster_labels
+
+    def test_gmm_same_seed_identical_serialized(self, multimodal_data):
+        """GMM's EM is the most init-sensitive case: same seed -> identical result.
+
+        Asserts the full serialized view (labels + bic/aic/weights/covariances),
+        which a labels-only check would miss.
+        """
+        r1 = ClusterResult.from_gmm_dict(
+            perform_gmm_clustering(multimodal_data, n_components=2, random_state=42),
+            random_state=42,
+        )
+        r2 = ClusterResult.from_gmm_dict(
+            perform_gmm_clustering(multimodal_data, n_components=2, random_state=42),
+            random_state=42,
+        )
+        assert r1.cluster_labels == r2.cluster_labels
+        assert dataclasses.asdict(r1) == dataclasses.asdict(r2)
 
 
 class TestClusterResultExport:
@@ -116,15 +231,15 @@ class TestClusterResultNonBreaking:
     """Legacy clustering dicts are preserved and not mutated."""
 
     def test_kmeans_dict_not_mutated(self, kmeans_cluster_result):
-        """KMeans adapter does not mutate its input dict."""
+        """KMeans adapter does not mutate its input dict (keys *and* values)."""
         d = kmeans_cluster_result
-        before = set(d.keys())
+        before = copy.deepcopy(d)
         ClusterResult.from_kmeans_dict(d, random_state=42)
-        assert set(d.keys()) == before
+        _assert_dict_unchanged(d, before)
 
     def test_gmm_dict_not_mutated(self, gmm_cluster_result):
-        """GMM adapter does not mutate its input dict."""
+        """GMM adapter does not mutate its input dict (keys *and* values)."""
         d = gmm_cluster_result
-        before = set(d.keys())
+        before = copy.deepcopy(d)
         ClusterResult.from_gmm_dict(d, random_state=42)
-        assert set(d.keys()) == before
+        _assert_dict_unchanged(d, before)

--- a/tests/test_cluster_result.py
+++ b/tests/test_cluster_result.py
@@ -1,0 +1,130 @@
+"""Tests for the serializable clustering result dataclasses and adapters (#129).
+
+Covers the serializable-result-types contract for clustering: native-type JSON
+round-trips for both KMeans and GMM (the reproducibility CI gate), adapter field
+mapping (incl. GMM means -> cluster_centers and n_components -> n_clusters),
+random_state stamping, determinism (same seed -> identical labels, #118), public
+export, and the non-breaking / non-mutating guarantee.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+from sleap_roots_analyze.clustering import perform_kmeans_clustering
+from sleap_roots_analyze.result_types import ClusterResult, GMMResult, KMeansResult
+
+
+class TestKMeansResultJSON:
+    """KMeans clean view serializes to native Python types."""
+
+    def test_json_roundtrip_native_types(self, kmeans_cluster_result):
+        """KMeans view round-trips to native types with the right discriminator."""
+        result = ClusterResult.from_kmeans_dict(kmeans_cluster_result, random_state=42)
+        assert isinstance(result, KMeansResult)
+        parsed = json.loads(json.dumps(dataclasses.asdict(result)))
+
+        assert parsed["algorithm"] == "kmeans"
+        assert all(type(v) is int for v in parsed["cluster_labels"])
+        assert all(type(v) is float for row in parsed["cluster_centers"] for v in row)
+        assert type(parsed["inertia"]) is float
+        assert type(parsed["silhouette_score"]) is float
+        assert type(parsed["random_state"]) is int
+
+
+class TestGMMResultJSON:
+    """GMM clean view serializes to native Python types."""
+
+    def test_json_roundtrip_native_types(self, gmm_cluster_result):
+        """GMM view round-trips to native types with the right discriminator."""
+        result = ClusterResult.from_gmm_dict(gmm_cluster_result, random_state=42)
+        assert isinstance(result, GMMResult)
+        parsed = json.loads(json.dumps(dataclasses.asdict(result)))
+
+        assert parsed["algorithm"] == "gmm"
+        assert all(type(v) is float for row in parsed["cluster_centers"] for v in row)
+        assert all(type(v) is float for v in parsed["weights"])
+        assert type(parsed["bic"]) is float
+        assert type(parsed["aic"]) is float
+        assert type(parsed["converged"]) is bool
+        assert type(parsed["n_iter"]) is int
+
+
+class TestClusterAdapters:
+    """Adapters map the legacy dicts faithfully."""
+
+    def test_kmeans_adapter_maps_fields(self, kmeans_cluster_result):
+        """KMeans adapter maps counts, centers shape, and random_state."""
+        d = kmeans_cluster_result
+        result = ClusterResult.from_kmeans_dict(d, random_state=42)
+
+        n_features = len(d["feature_names"])
+        assert result.n_clusters == int(d["n_clusters"])
+        assert len(result.cluster_centers) == result.n_clusters
+        assert all(len(row) == n_features for row in result.cluster_centers)
+        assert sum(result.cluster_sizes) == len(result.cluster_labels)
+        assert result.random_state == 42
+
+    def test_gmm_adapter_maps_n_components_and_means(self, gmm_cluster_result):
+        """GMM adapter maps n_components->n_clusters and means->cluster_centers."""
+        d = gmm_cluster_result
+        result = ClusterResult.from_gmm_dict(d, random_state=42)
+
+        assert result.n_clusters == int(d["n_components"])
+        assert result.cluster_centers == [list(row) for row in d["means"]]
+        assert result.covariance_type == d["covariance_type"]
+        assert len(result.weights) == result.n_clusters
+
+
+class TestClusterDeterminism:
+    """Same seed -> identical cluster labels via the typed view (#118)."""
+
+    def test_same_seed_identical_labels(self, simple_cluster_data):
+        """Re-running KMeans with the same seed yields identical labels."""
+        r1 = ClusterResult.from_kmeans_dict(
+            perform_kmeans_clustering(
+                simple_cluster_data, n_clusters=3, random_state=42
+            ),
+            random_state=42,
+        )
+        r2 = ClusterResult.from_kmeans_dict(
+            perform_kmeans_clustering(
+                simple_cluster_data, n_clusters=3, random_state=42
+            ),
+            random_state=42,
+        )
+        assert r1.cluster_labels == r2.cluster_labels
+
+
+class TestClusterResultExport:
+    """Public API surface."""
+
+    def test_importable_from_package_root(self):
+        """All three clustering result types are importable and in __all__."""
+        import sleap_roots_analyze as sra
+
+        assert sra.ClusterResult is ClusterResult
+        assert sra.KMeansResult is KMeansResult
+        assert sra.GMMResult is GMMResult
+        for name in ("ClusterResult", "KMeansResult", "GMMResult"):
+            assert name in sra.__all__
+        assert len(sra.__all__) == len(set(sra.__all__))
+
+
+class TestClusterResultNonBreaking:
+    """Legacy clustering dicts are preserved and not mutated."""
+
+    def test_kmeans_dict_not_mutated(self, kmeans_cluster_result):
+        """KMeans adapter does not mutate its input dict."""
+        d = kmeans_cluster_result
+        before = set(d.keys())
+        ClusterResult.from_kmeans_dict(d, random_state=42)
+        assert set(d.keys()) == before
+
+    def test_gmm_dict_not_mutated(self, gmm_cluster_result):
+        """GMM adapter does not mutate its input dict."""
+        d = gmm_cluster_result
+        before = set(d.keys())
+        ClusterResult.from_gmm_dict(d, random_state=42)
+        assert set(d.keys()) == before

--- a/tests/test_pca_result.py
+++ b/tests/test_pca_result.py
@@ -302,3 +302,49 @@ class TestPCAResultNonBreaking:
         assert list(d["feature_names"]) == before_names
         assert d["n_components_selected"] == before_n
         assert id(d["scaler"]) == scaler_id and id(d["pca"]) == pca_id
+
+
+# Numeric tolerance per docs/reproducibility.md (#118), matching test_pipeline_reproduction.
+_RTOL = 1e-6
+_ATOL = 1e-9
+_REPRO_PLATFORMS = ["turface_19", "turface_150", "cylinder", "root_core"]
+
+
+class TestPCAResultReproductionGolden:
+    """PCAResult carries the #120 golden science (epic #130 acceptance).
+
+    Lives with the PCAResult type (#127) rather than the cluster PR — it validates
+    PCAResult against the #120 reproduction goldens, using the session reproduction
+    fixtures defined in tests/fixtures.py.
+    """
+
+    @pytest.mark.parametrize("platform", _REPRO_PLATFORMS)
+    def test_viz_pca_typed_view_golden(
+        self, final_data_by_platform, viz_pca_by_platform, platform
+    ):
+        """The typed view reproduces the golden explained variance and round-trips."""
+        golden = viz_pca_by_platform[platform]
+        n = golden["n_pca_components"]
+        res = perform_pca_analysis(
+            final_data_by_platform[platform][golden["trait_cols"]],
+            standardize=True,
+            explained_variance_threshold=0.95,
+            random_state=42,
+        )
+        result = PCAResult.from_pca_dict(
+            res, random_state=42, explained_variance_threshold=0.95
+        )
+
+        # Golden explained variance asserted via the typed field. The typed view
+        # retains the 0.95-threshold components (>= the golden count); summing its
+        # first ``n`` ratios reproduces the golden value (matching the legacy-dict test).
+        assert result.n_components >= n
+        reproduced = float(np.sum(result.explained_variance_ratio[:n]))
+        assert np.isclose(
+            reproduced, golden["pca_explained_variance"], rtol=_RTOL, atol=_ATOL
+        )
+
+        # Serializable with no custom encoder — the whole point of the typed view.
+        restored = json.loads(json.dumps(dataclasses.asdict(result)))
+        assert restored["explained_variance_ratio"] == result.explained_variance_ratio
+        assert restored["n_components"] == result.n_components

--- a/tests/test_pipeline_reproduction.py
+++ b/tests/test_pipeline_reproduction.py
@@ -13,9 +13,13 @@ See ``tests/fixtures.py`` for the ``scope="session"`` loaders these tests share.
 
 from __future__ import annotations
 
+import dataclasses
+import json
+
 import numpy as np
 import pytest
 
+from sleap_roots_analyze import PCAResult
 from sleap_roots_analyze.pca import perform_pca_analysis
 from sleap_roots_analyze.pipeline.config.utils import (
     load_qc_config,
@@ -261,6 +265,46 @@ def test_viz_pca_reproduction(final_data_by_platform, viz_pca_by_platform, platf
     assert np.isclose(
         reproduced, golden["pca_explained_variance"], rtol=RTOL, atol=ATOL
     )
+
+
+@pytest.mark.parametrize("platform", PLATFORMS)
+def test_viz_pca_typed_view_golden(
+    final_data_by_platform, viz_pca_by_platform, platform
+):
+    """The ``PCAResult`` typed view carries the golden explained variance (#130).
+
+    Epic #130 acceptance: the #120 golden numbers assert against the serializable typed
+    view, not just the legacy dict. A ``PCAResult`` built from a fresh
+    ``perform_pca_analysis`` must (a) retain the golden component count, (b) sum to the
+    golden explained variance over those components, and (c) round-trip through
+    ``json.dumps(dataclasses.asdict(...))`` with no custom serializer — the property that
+    lets the result cross a JSON boundary.
+    """
+    golden = viz_pca_by_platform[platform]
+    n = golden["n_pca_components"]
+    res = perform_pca_analysis(
+        final_data_by_platform[platform][golden["trait_cols"]],
+        standardize=True,
+        explained_variance_threshold=0.95,
+        random_state=42,
+    )
+    result = PCAResult.from_pca_dict(
+        res, random_state=42, explained_variance_threshold=0.95
+    )
+
+    # Golden explained variance, asserted via the typed field. The typed view retains
+    # the 0.95-threshold components (>= the pipeline's golden component count); summing
+    # its first ``n`` ratios reproduces the golden value, matching the legacy-dict test.
+    assert result.n_components >= n
+    reproduced = float(np.sum(result.explained_variance_ratio[:n]))
+    assert np.isclose(
+        reproduced, golden["pca_explained_variance"], rtol=RTOL, atol=ATOL
+    )
+
+    # Serializable with no custom encoder — the whole point of the typed view.
+    restored = json.loads(json.dumps(dataclasses.asdict(result)))
+    assert restored["explained_variance_ratio"] == result.explained_variance_ratio
+    assert restored["n_components"] == result.n_components
 
 
 @pytest.mark.parametrize("platform", UMAP_PLATFORMS)

--- a/tests/test_pipeline_reproduction.py
+++ b/tests/test_pipeline_reproduction.py
@@ -13,13 +13,9 @@ See ``tests/fixtures.py`` for the ``scope="session"`` loaders these tests share.
 
 from __future__ import annotations
 
-import dataclasses
-import json
-
 import numpy as np
 import pytest
 
-from sleap_roots_analyze import PCAResult
 from sleap_roots_analyze.pca import perform_pca_analysis
 from sleap_roots_analyze.pipeline.config.utils import (
     load_qc_config,
@@ -265,46 +261,6 @@ def test_viz_pca_reproduction(final_data_by_platform, viz_pca_by_platform, platf
     assert np.isclose(
         reproduced, golden["pca_explained_variance"], rtol=RTOL, atol=ATOL
     )
-
-
-@pytest.mark.parametrize("platform", PLATFORMS)
-def test_viz_pca_typed_view_golden(
-    final_data_by_platform, viz_pca_by_platform, platform
-):
-    """The ``PCAResult`` typed view carries the golden explained variance (#130).
-
-    Epic #130 acceptance: the #120 golden numbers assert against the serializable typed
-    view, not just the legacy dict. A ``PCAResult`` built from a fresh
-    ``perform_pca_analysis`` must (a) retain the golden component count, (b) sum to the
-    golden explained variance over those components, and (c) round-trip through
-    ``json.dumps(dataclasses.asdict(...))`` with no custom serializer — the property that
-    lets the result cross a JSON boundary.
-    """
-    golden = viz_pca_by_platform[platform]
-    n = golden["n_pca_components"]
-    res = perform_pca_analysis(
-        final_data_by_platform[platform][golden["trait_cols"]],
-        standardize=True,
-        explained_variance_threshold=0.95,
-        random_state=42,
-    )
-    result = PCAResult.from_pca_dict(
-        res, random_state=42, explained_variance_threshold=0.95
-    )
-
-    # Golden explained variance, asserted via the typed field. The typed view retains
-    # the 0.95-threshold components (>= the pipeline's golden component count); summing
-    # its first ``n`` ratios reproduces the golden value, matching the legacy-dict test.
-    assert result.n_components >= n
-    reproduced = float(np.sum(result.explained_variance_ratio[:n]))
-    assert np.isclose(
-        reproduced, golden["pca_explained_variance"], rtol=RTOL, atol=ATOL
-    )
-
-    # Serializable with no custom encoder — the whole point of the typed view.
-    restored = json.loads(json.dumps(dataclasses.asdict(result)))
-    assert restored["explained_variance_ratio"] == result.explained_variance_ratio
-    assert restored["n_components"] == result.n_components
 
 
 @pytest.mark.parametrize("platform", UMAP_PLATFORMS)


### PR DESCRIPTION
## Summary

Adds a frozen base `ClusterResult` plus `KMeansResult` / `GMMResult` subclasses and `from_kmeans_dict` / `from_gmm_dict` adapters to the shared `result_types.py` module. This is the **final child** of the serializable-result-types epic (#130), following the `PCAResult` (#127) / `HeritabilityResult` (#128) convention.

`perform_kmeans_clustering` / `perform_gmm_clustering` return `np.ndarray`-laden dicts that can't cross a JSON boundary. The epic flagged that KMeans and GMM returns differ substantially, so a single flat type doesn't fit — this models it as a **shared base + two subclasses** (the chosen design), with the `algorithm` field as the discriminator a JSON consumer reads.

Closes #129.

> **Stacked on #128** (`heritabilityresult-dataclass-128`, PR #150) → #127 (PR #149). Base retargets to `main` as the stack merges.

## Shape

- **Base `ClusterResult`**: `algorithm` (`"kmeans"`|`"gmm"`), `n_clusters`, `cluster_labels`, `cluster_sizes`, the three quality metrics, `feature_names`, `random_state`.
- **`KMeansResult`** adds `cluster_centers`, `inertia`.
- **`GMMResult`** adds `cluster_centers` (the GMM `means`), `weights`, `bic`, `aic`, `converged`, `n_iter`, `covariance_type`.

## Reproducibility (#118)

Clustering is stochastic, so `random_state` is **threaded into the adapters and stamped** into the result (the legacy dicts don't carry it). A determinism test asserts same seed → identical `cluster_labels` via the typed view.

## Backwards-compat

**Additive only (MINOR).** Both functions still return their exact dicts; the adapters do not mutate input. `ClusterResult`/`KMeansResult`/`GMMResult` exported in `__all__`.

## Testing

- New `tests/test_cluster_result.py` (8 tests) over the real `kmeans_cluster_result` / `gmm_cluster_result` fixtures: native-type JSON round-trips for both subclasses, adapter field mapping (incl. GMM `means`→`cluster_centers`, `n_components`→`n_clusters`), `random_state` stamping, determinism (#118), export, and non-mutation guards.
- `black`/`ruff` clean; `openspec validate add-clusterresult-dataclass --strict` passes; clustering + public-API introspection contract suites green.

## Out of scope (deferred to the epic)

- `docs/result-types.md` pattern doc → epic close (#130).
- Per-sample GMM `probabilities` and KMeans distance arrays omitted from the clean view (available via the legacy dict).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Epic-closing additions (#130)

Because this is the final child of the stack, it also lands the two remaining **epic-level acceptance items** for #130:

- **`docs/result-types.md`** — documents the serializable-dataclass pattern once (stdlib dataclass, JSON-native fields, `from_*_dict` adapters, `@property` derivations, additive backwards-compat, and a test-first recipe for new types).
- **`test_viz_pca_typed_view_golden`** (in `tests/test_pipeline_reproduction.py`) — asserts the #120 wheat-EDPIE golden explained variance against the **`PCAResult` typed view** (not just the legacy dict), across all four platforms, and proves `json.dumps(asdict(...))` round-trips.

With these, all three of #130's epic acceptance items are met once the stack merges: (1) three result types exported with round-trip tests, (2) pattern documented once, (3) golden numbers assert against the typed views.
