### PR TITLE
test: analysis-input contract conformance for the EDPIE fixtures (#147)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `enrichment_p_value_column` validated against `correlation_method`. When
   enabled it runs a per-pair exact binomial test (nominal p, no FDR) and writes
   `trait_enrichment.csv`; existing runs are unchanged.
+- Analysis-input contract conformance tests (`tests/test_contract_conformance.py`):
+  validate a canonicalized **copy** of each of the four EDPIE post-QC fixtures and every
+  packaged `sleap_roots_contracts` canonical example against `validate_analysis_input`,
+  with a non-mutation guard and a negative control. Adds
+  `sleap-roots-contracts[pandas]>=0.1.0a1` as a dev dependency. No `src/` changes;
+  the #146/#120 reproduction goldens stay green (#147).
 - Expose the eight `statistics.py` functions through the top-level
   `sleap_roots_analyze` namespace and `__all__`, so they can be imported directly
   (e.g. `from sleap_roots_analyze import calculate_heritability_estimates`) instead

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,9 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Analysis-input contract conformance tests (`tests/test_contract_conformance.py`):
   validate a canonicalized **copy** of each of the four EDPIE post-QC fixtures and every
   packaged `sleap_roots_contracts` canonical example against `validate_analysis_input`,
-  with a non-mutation guard and a negative control. Adds
-  `sleap-roots-contracts[pandas]>=0.1.0a1` as a dev dependency. No `src/` changes;
-  the #146/#120 reproduction goldens stay green (#147).
+  under both lenient and `strict=True` modes, with a purity guard and a reason-checked
+  negative control. Adds `sleap-roots-contracts[pandas]>=0.1.0a1` as a dev dependency.
+  No `src/` changes; the #146/#120 reproduction goldens stay green (#147).
 - Expose the eight `statistics.py` functions through the top-level
   `sleap_roots_analyze` namespace and `__all__`, so they can be imported directly
   (e.g. `from sleap_roots_analyze import calculate_heritability_estimates`) instead

--- a/openspec/changes/add-contract-conformance-tests/proposal.md
+++ b/openspec/changes/add-contract-conformance-tests/proposal.md
@@ -1,0 +1,54 @@
+## Why
+
+`sleap-roots-contracts 0.1.0a1` is released, so we can now prove the committed EDPIE
+post-QC fixtures and the package's canonical examples conform to the analysis-input
+contract (`validate_analysis_input`). PR #146 landed the reproduction fixtures without
+that check — it was split out along the contracts-dependency seam (issue #147) — and this
+change closes the gap so downstream QC/viz/cross-platform code can rely on the schema.
+
+## What Changes
+
+This is a **tests + dev-dependency** change only — **no `src/` changes**.
+
+- Add `sleap-roots-contracts[pandas]>=0.1.0a1` to the **dev** dependency group so the
+  contract tests run for real (no `importorskip`). Because it is an alpha, the lockfile
+  must resolve the pre-release and be committed alongside the `pyproject.toml` edit.
+- Add a contracts-dependent test module that:
+  - **Real-data conformance** (parametrized over all four platforms `turface_19`,
+    `turface_150`, `cylinder`, `root_core`) — builds a **copy** of the post-QC fixture:
+    rename native roles (`Genotype`→`genotype`, `Barcode`→`sample_id`,
+    `Replicate`→`replicate`), drop non-trait metadata via `get_trait_columns` **called
+    with explicit role kwargs** (`barcode_col="sample_id"`, `genotype_col="genotype"`,
+    `replicate_col="replicate"` — defaults are `geno`/`rep`/`Barcode`, which would leak
+    the numeric `replicate` into the trait set as a duplicate column), then
+    `canonicalize_role_dtypes`; asserts `validate_analysis_input(check).raise_for_status()`
+    under the default (non-strict) mode. It also asserts the rename actually happened
+    (`genotype`/`sample_id` present, native names gone; `replicate`/`genotype` absent from
+    the trait set) so a no-op rename cannot pass vacuously.
+  - **Canonical-example conformance** — iterates every name from
+    `analysis_input_example_names()` (the package registry: `cylinder`,
+    `cylinder_no_replicate`, `field`, `turface`, `genotype_means`), loads each via
+    `load_analysis_input_example`, and asserts it validates as-is. Iterating the registry
+    (rather than a hardcoded list) keeps the contract's own source of truth authoritative
+    and auto-covers future examples.
+  - **Negative control** — a deliberately malformed frame (e.g. missing the `genotype`
+    role) makes `validate_analysis_input(...).raise_for_status()` raise / `.ok is False`,
+    proving the green asserts above are non-vacuous.
+  - **Pipeline-input guard** — re-loads the fixture fresh and asserts
+    `pd.testing.assert_frame_equal` against a deep pre-copy, proving canonicalization ran
+    on a copy and never touched the frame that feeds QC/viz/cross-platform.
+    (`canonicalize_role_dtypes` already returns a copy, so this is defense-in-depth.)
+- Confirm no stale `*_validation.json` expected files remain (they were removed in commit
+  `73583f9`; their `summary` shape never matched `ValidationResult`). Keep this as a guard
+  assertion, not a delete step.
+
+## Impact
+
+- Affected specs: `contract-conformance` (new capability). Depends on the #120/#146
+  reproduction fixtures (capability `reproduction-fixtures`) being present.
+- Affected code: `pyproject.toml` (dev group) + `uv.lock`, and a new `tests/` contract
+  test module. **No `src/` changes**; `get_trait_columns` is consumed, not modified.
+- Guardrail: canonicalization runs on a **copy**, never the frame that feeds the pipeline.
+  The #146/#120 reproduction golden tests (native names, `rtol=1e-6`) stay green as proof
+  `run-all` output is unchanged. This change does **not** implement #144 (the runtime
+  `validate_input` flag / `run-all` wiring) — only fixture conformance tests.

--- a/openspec/changes/add-contract-conformance-tests/specs/contract-conformance/spec.md
+++ b/openspec/changes/add-contract-conformance-tests/specs/contract-conformance/spec.md
@@ -1,0 +1,86 @@
+## ADDED Requirements
+
+### Requirement: Analysis-Input Contract Dev Dependency
+
+The repository SHALL declare `sleap-roots-contracts[pandas]>=0.1.0a1` in the `dev`
+dependency group, with `uv.lock` resolving the pre-release, so the analysis-input contract
+conformance tests run in CI without being skipped.
+
+#### Scenario: Contract package available under dev install
+
+- **WHEN** the project is installed with its dev dependencies
+- **THEN** `sleap_roots_contracts` (with `validate_analysis_input`,
+  `canonicalize_role_dtypes`, and `examples.load_analysis_input_example`) is importable
+- **AND** the contract conformance tests execute rather than `importorskip`-skipping.
+
+### Requirement: Post-QC Fixture Contract Conformance
+
+The conformance tests SHALL prove that every committed EDPIE post-QC fixture
+(`turface_19`, `turface_150`, `cylinder`, `root_core`) conforms to the analysis-input
+contract, validating only a transformed **copy** so the frame that feeds
+QC/viz/cross-platform is never mutated.
+
+#### Scenario: Post-QC fixture validates after canonicalization
+
+- **WHEN** a post-QC fixture is loaded and a separate frame is built by renaming native
+  role columns (`Genotype`→`genotype`, `Barcode`→`sample_id`, `Replicate`→`replicate`),
+  dropping non-trait metadata via `get_trait_columns` called with the renamed role kwargs
+  (`barcode_col="sample_id"`, `genotype_col="genotype"`, `replicate_col="replicate"`), and
+  applying `canonicalize_role_dtypes`
+- **THEN** `validate_analysis_input(copy).raise_for_status()` succeeds for every platform.
+
+#### Scenario: Rename and trait selection are non-vacuous
+
+- **WHEN** the canonicalized copy is built
+- **THEN** `genotype` and `sample_id` are present and the native names are gone
+- **AND** the selected trait columns exclude the `replicate` and `genotype` role columns,
+  so a no-op rename or default `get_trait_columns` kwargs cannot make the check pass
+  vacuously.
+
+#### Scenario: Original fixture frame is not mutated
+
+- **WHEN** the conformance test has built and validated the canonicalized copy
+- **THEN** the originally loaded fixture frame is unchanged under
+  `pd.testing.assert_frame_equal` against a deep pre-copy.
+
+### Requirement: Canonical Example Contract Conformance
+
+The conformance tests SHALL validate every canonical example exposed by the contract
+package registry (`analysis_input_example_names()`), loaded from
+`sleap_roots_contracts.examples`, so the repository tracks the contract's single source of
+truth and auto-covers future examples.
+
+#### Scenario: Packaged canonical examples validate as-is
+
+- **WHEN** each name from `analysis_input_example_names()` is loaded via
+  `load_analysis_input_example`
+- **THEN** `validate_analysis_input(example).raise_for_status()` succeeds with no
+  modification to the example.
+
+### Requirement: Validation Is Asserted and Non-Vacuous
+
+The conformance tests SHALL assert the `ValidationResult` returned by
+`validate_analysis_input` (via `raise_for_status()` or `.ok`) and SHALL NOT discard it, and
+SHALL include a negative control proving the validator can fail.
+
+#### Scenario: Result is checked, not discarded
+
+- **WHEN** a conformance test calls `validate_analysis_input(...)`
+- **THEN** the returned `ValidationResult` is asserted via `raise_for_status()` or `.ok`.
+
+#### Scenario: Negative control proves the validator can fail
+
+- **WHEN** a deliberately malformed frame (e.g. missing the `genotype` role) is validated
+- **THEN** `validate_analysis_input(bad).raise_for_status()` raises `ValueError` and
+  `bad`'s result `.ok is False`.
+
+### Requirement: No Stale Validation Artifacts
+
+The repository SHALL NOT retain `*_validation.json` expected files under `tests/fixtures/`,
+whose `summary` shape does not match `ValidationResult`; the contract is asserted live, not
+against stored JSON.
+
+#### Scenario: No validation JSON remains in the fixture tree
+
+- **WHEN** the fixture tree is inspected (`git ls-files 'tests/**_validation.json'`)
+- **THEN** no such file exists.

--- a/openspec/changes/add-contract-conformance-tests/tasks.md
+++ b/openspec/changes/add-contract-conformance-tests/tasks.md
@@ -1,0 +1,70 @@
+## 1. Canonical-example conformance test (write first — fails red on a clean checkout)
+
+- [x] 1.1 Write `tests/test_contract_conformance.py` importing `sleap_roots_contracts`.
+      On a clean checkout (contracts not installed) it fails red with `ModuleNotFoundError`
+      — the genuine TDD red for a tests-only change.
+- [x] 1.2 Add a test that iterates `analysis_input_example_names()`
+      (`cylinder`, `cylinder_no_replicate`, `field`, `turface`, `genotype_means`), loads
+      each via `load_analysis_input_example`, and asserts
+      `validate_analysis_input(example).raise_for_status()` (default non-strict mode).
+
+## 2. Real-data conformance test (parametrized over 4 platforms)
+
+- [x] 2.1 Reuse the existing session loader `final_data_by_platform`
+      (`tests/fixtures.py`) — a **session-scoped dict** `{platform: DataFrame}` over
+      `expected/qc/{p}/10_final_data.csv`; do **not** add a second loader (DRY).
+      Parametrize over `turface_19`, `turface_150`, `cylinder`, `root_core`. Because the
+      fixture is shared, all transforms operate on `df.copy()` (never the dict's frame).
+- [x] 2.2 Build a **copy**: rename `{Genotype→genotype, Barcode→sample_id,
+      Replicate→replicate}`, select `roles + get_trait_columns(renamed,
+      barcode_col="sample_id", genotype_col="genotype", replicate_col="replicate")` — the
+      explicit kwargs are mandatory (defaults `geno`/`rep`/`Barcode` would duplicate the
+      numeric `replicate` into the trait set) — then `canonicalize_role_dtypes`.
+- [x] 2.3 Assert the rename happened and the trait set is clean:
+      `{"genotype","sample_id"}.issubset(check.columns)`, native names gone, and
+      `"replicate" not in trait_cols and "genotype" not in trait_cols` (anti-vacuous).
+- [x] 2.4 Assert `validate_analysis_input(check).raise_for_status()` succeeds for every
+      platform.
+
+## 3. Pipeline-input guard + negative control
+
+- [x] 3.1 Deep-copy the shared `final_data_by_platform[platform]` frame, run the full
+      build, then assert `pd.testing.assert_frame_equal(shared_frame, pre_copy)` — proves
+      canonicalization ran on a copy and the session fixture is unmutated (catches an
+      in-place cast / `rename(inplace=True)` regression that would corrupt other tests).
+- [x] 3.2 Negative control: a deliberately malformed frame (e.g. drop the `genotype` role)
+      makes `validate_analysis_input(bad).raise_for_status()` raise `ValueError`
+      (`.ok is False`), proving the post-QC green asserts are non-vacuous.
+
+## 4. Dev dependency (turns the red tests green)
+
+- [x] 4.1 Add `sleap-roots-contracts[pandas]>=0.1.0a1` to the `dev` group in
+      `pyproject.toml`; `uv add --dev --prerelease=allow` resolves the alpha. NOTE: that
+      flag also bumped pydantic to a needless `2.14.0a1` alpha, so re-pin stable with
+      `uv lock --upgrade-package pydantic --upgrade-package pydantic-core` (contracts only
+      needs `pydantic>=2.7`). Commit `pyproject.toml` + `uv.lock` together so
+      `uv sync --frozen` stays green; only `sleap-roots-contracts` is a prerelease.
+- [x] 4.2 Confirm the lockfile resolves the alpha and the `[pandas]` extra on the CI
+      matrix (Ubuntu/Windows/macOS, Python 3.11); the tests now run unskipped and pass.
+
+## 5. Cleanup guard
+
+- [x] 5.1 Assert no `*_validation.json` expected files exist under `tests/fixtures/`
+      (removed in `73583f9`; verify `git ls-files 'tests/**_validation.json'` is empty —
+      a guard, not a delete step). The contract is asserted live, never against stored JSON.
+
+## 6. Verify
+
+- [x] 6.1 Run the full suite: contract tests run (no skip) and pass; the #146/#120
+      reproduction golden tests stay green.
+- [x] 6.2 `/lint` clean (black + ruff + pydocstyle, google docstrings).
+- [x] 6.3 `openspec validate add-contract-conformance-tests --strict` passes.
+
+## Commit plan (CI green at each step)
+
+1. `chore: add sleap-roots-contracts[pandas] dev dependency for contract conformance (#147)`
+   — `pyproject.toml` + `uv.lock` (lands first so the test module imports cleanly in CI).
+2. `test: assert post-QC EDPIE fixtures + canonical examples conform to analysis-input contract (#147)`
+   — `tests/test_contract_conformance.py` (real-data + examples + guard + negative control).
+
+Single PR off `add-contract-conformance-tests-147`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ dev = [
     "pytest>=8.4.1",
     "pytest-cov>=6.2.1",
     "ruff>=0.12.11",
+    "sleap-roots-contracts[pandas]>=0.1.0a1",
     "toml>=0.10.2",
 ]
 

--- a/tests/test_contract_conformance.py
+++ b/tests/test_contract_conformance.py
@@ -41,6 +41,17 @@ def _build_analysis_input(df: pd.DataFrame) -> pd.DataFrame:
     casts role columns to string via ``canonicalize_role_dtypes``. Operates on copies and
     never mutates ``df``.
 
+    This recipe duplicates, in test code, the canonicalization that #144/#153 wire into
+    ``validation/input_contract.py`` at the QC load boundary. Once #153 merges, this should
+    call that production transform so the two recipes cannot drift; until then it previews
+    the transform without implementing the runtime wiring.
+
+    Note: ``get_trait_columns`` only drops the *role* columns it is told about. The contract
+    treats every remaining numeric non-role column as a trait, so platform-specific numeric
+    metadata (root_core's ``Cid``/``Sid``/``GID``/``Ent``/``Sub``, turface_150's
+    ``Entry``/``GID``) flows into the validated "trait" set. Conformance therefore proves the
+    frame is contract-*shaped*, not that every trait column is a real measured trait.
+
     Args:
         df: A post-QC fixture frame with native Barcode/Genotype/Replicate columns.
 
@@ -58,33 +69,48 @@ def _build_analysis_input(df: pd.DataFrame) -> pd.DataFrame:
     return canonicalize_role_dtypes(renamed[roles + traits].copy())
 
 
+@pytest.mark.parametrize("strict", [False, True], ids=["lenient", "strict"])
 @pytest.mark.parametrize("platform", PLATFORMS)
-def test_post_qc_fixture_conforms(final_data_by_platform, platform):
-    """Each post-QC fixture validates after canonicalization on a copy."""
+def test_post_qc_fixture_conforms(final_data_by_platform, platform, strict):
+    """Each post-QC fixture validates after canonicalization on a copy.
+
+    Run under both ``strict=False`` and ``strict=True``: all four EDPIE platforms carry the
+    recommended ``sample_id`` role, so they satisfy the stronger strict contract too.
+    Parametrizing ``strict`` locks that in — a regression that only breaks strict would
+    otherwise pass silently.
+    """
     check = _build_analysis_input(final_data_by_platform[platform].copy())
 
     # Rename + trait selection are non-vacuous: roles renamed, native names gone, and no
-    # role column leaked back in as a duplicate trait. The uniqueness check is the real
-    # regression guard for the get_trait_columns role kwargs — a wrong call returns the
-    # numeric ``replicate`` as a trait, duplicating it in ``roles + traits``.
+    # role column leaked back in as a duplicate trait.
     assert {"genotype", "sample_id"}.issubset(check.columns)
     assert "Genotype" not in check.columns and "Barcode" not in check.columns
     assert check.columns.is_unique
     trait_cols = [c for c in check.columns if c not in CANONICAL_ROLES]
     assert trait_cols, "expected at least one numeric trait column"
+    # Explicit guard for the get_trait_columns role kwargs (matches the spec wording): a
+    # wrong call returns the numeric ``replicate`` as a trait. is_unique above catches the
+    # resulting duplicate column; this asserts the underlying intent directly.
+    assert "replicate" not in trait_cols
 
-    validate_analysis_input(check).raise_for_status()
+    validate_analysis_input(check, strict=strict).raise_for_status()
 
 
 @pytest.mark.parametrize("platform", PLATFORMS)
 def test_canonicalization_does_not_mutate_fixture(final_data_by_platform, platform):
-    """The build runs on a copy; the shared session fixture frame is unmutated."""
-    df = final_data_by_platform[platform].copy(deep=True)
-    before = df.copy(deep=True)
+    """``_build_analysis_input`` is pure — it never mutates its input frame.
 
-    _build_analysis_input(df)
+    Passes the *raw* shared session frame (deliberately no defensive ``.copy()``) and
+    asserts it is byte-identical afterwards. This proves the real protection: the build is
+    safe even for a caller that forgets to copy, so it cannot corrupt the session fixture
+    the QC/viz/cross-platform reproduction tests also read.
+    """
+    raw = final_data_by_platform[platform]
+    before = raw.copy(deep=True)
 
-    pd.testing.assert_frame_equal(df, before)
+    _build_analysis_input(raw)
+
+    pd.testing.assert_frame_equal(raw, before)
 
 
 def test_canonical_examples_conform():
@@ -96,6 +122,34 @@ def test_canonical_examples_conform():
         validate_analysis_input(example).raise_for_status()
 
 
+def test_canonical_examples_conform_strict():
+    """Strict mode is a strictly stronger contract, exercised per example.
+
+    Strict promotes the recommended ``sample_id`` role from warning to error, so any example
+    carrying ``sample_id`` must still validate, while the genotype-aggregated
+    ``genotype_means`` example (no per-sample rows, no ``sample_id``) must fail. Pinning both
+    directions keeps the coverage non-vacuous and documents *why* strict and lenient diverge.
+    """
+    names = analysis_input_example_names()
+    assert names, "contract package exposed no canonical examples"
+    checked_strict_pass = checked_strict_fail = False
+    for name in names:
+        example = load_analysis_input_example(name)
+        result = validate_analysis_input(example, strict=True)
+        if "sample_id" in example.columns:
+            result.raise_for_status()
+            checked_strict_pass = True
+        else:
+            assert not result.ok, f"{name} unexpectedly passed strict without sample_id"
+            checked_strict_fail = True
+
+    # Both branches must have run, or the test silently checked only one side.
+    assert (
+        checked_strict_pass
+    ), "no sample_id-bearing example exercised the strict-pass path"
+    assert checked_strict_fail, "no aggregated example exercised the strict-fail path"
+
+
 def test_negative_control_validation_can_fail(final_data_by_platform):
     """A frame missing the genotype role fails validation (asserts are non-vacuous)."""
     check = _build_analysis_input(final_data_by_platform["turface_19"].copy())
@@ -104,7 +158,9 @@ def test_negative_control_validation_can_fail(final_data_by_platform):
     result = validate_analysis_input(bad)
 
     assert not result.ok
-    with pytest.raises(ValueError):
+    # Assert the failure is *for the reason we removed* — not some incidental future
+    # validation change — so this stays a real negative control.
+    with pytest.raises(ValueError, match="genotype"):
         result.raise_for_status()
 
 

--- a/tests/test_contract_conformance.py
+++ b/tests/test_contract_conformance.py
@@ -1,0 +1,118 @@
+"""Analysis-input contract conformance for the EDPIE fixtures (#147).
+
+Proves the committed post-QC fixtures and the packaged canonical examples conform to the
+``sleap-roots-contracts`` analysis-input contract (``validate_analysis_input``). The real
+post-QC frame is canonicalized on a **copy** only — the frame that feeds
+QC/viz/cross-platform is never mutated (the #146/#120 reproduction goldens are the guard).
+This previews the #144 load-boundary transform; it does not implement the runtime wiring.
+
+Depends on the ``sleap-roots-contracts[pandas]`` dev dependency; with it installed these
+tests run unskipped (no ``importorskip``).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from sleap_roots_analyze import get_trait_columns
+from sleap_roots_contracts import canonicalize_role_dtypes, validate_analysis_input
+from sleap_roots_contracts.examples import (
+    analysis_input_example_names,
+    load_analysis_input_example,
+)
+
+PLATFORMS = ["turface_19", "turface_150", "cylinder", "root_core"]
+
+# Native post-QC role column -> canonical contract role. All four EDPIE platforms carry
+# Barcode/Genotype/Replicate; root_core additionally carries Plot (dropped by
+# get_trait_columns), and turface_150's Salk_geno is non-numeric (dropped by the trait
+# filter).
+ROLE_RENAME = {"Genotype": "genotype", "Barcode": "sample_id", "Replicate": "replicate"}
+CANONICAL_ROLES = ["genotype", "sample_id", "replicate", "image_path"]
+
+
+def _build_analysis_input(df: pd.DataFrame) -> pd.DataFrame:
+    """Build a contract-shaped analysis-input frame from a post-QC fixture.
+
+    Renames native roles to canonical names, drops non-trait metadata via
+    ``get_trait_columns`` — called with the *renamed* role kwargs so the numeric
+    ``replicate`` column is excluded instead of leaking in as a duplicate trait — then
+    casts role columns to string via ``canonicalize_role_dtypes``. Operates on copies and
+    never mutates ``df``.
+
+    Args:
+        df: A post-QC fixture frame with native Barcode/Genotype/Replicate columns.
+
+    Returns:
+        A canonicalized analysis-input frame: role columns plus numeric traits.
+    """
+    renamed = df.rename(columns=ROLE_RENAME)
+    roles = [c for c in CANONICAL_ROLES if c in renamed.columns]
+    traits = get_trait_columns(
+        renamed,
+        barcode_col="sample_id",
+        genotype_col="genotype",
+        replicate_col="replicate",
+    )
+    return canonicalize_role_dtypes(renamed[roles + traits].copy())
+
+
+@pytest.mark.parametrize("platform", PLATFORMS)
+def test_post_qc_fixture_conforms(final_data_by_platform, platform):
+    """Each post-QC fixture validates after canonicalization on a copy."""
+    check = _build_analysis_input(final_data_by_platform[platform].copy())
+
+    # Rename + trait selection are non-vacuous: roles renamed, native names gone, and no
+    # role column leaked back in as a duplicate trait. The uniqueness check is the real
+    # regression guard for the get_trait_columns role kwargs — a wrong call returns the
+    # numeric ``replicate`` as a trait, duplicating it in ``roles + traits``.
+    assert {"genotype", "sample_id"}.issubset(check.columns)
+    assert "Genotype" not in check.columns and "Barcode" not in check.columns
+    assert check.columns.is_unique
+    trait_cols = [c for c in check.columns if c not in CANONICAL_ROLES]
+    assert trait_cols, "expected at least one numeric trait column"
+
+    validate_analysis_input(check).raise_for_status()
+
+
+@pytest.mark.parametrize("platform", PLATFORMS)
+def test_canonicalization_does_not_mutate_fixture(final_data_by_platform, platform):
+    """The build runs on a copy; the shared session fixture frame is unmutated."""
+    df = final_data_by_platform[platform].copy(deep=True)
+    before = df.copy(deep=True)
+
+    _build_analysis_input(df)
+
+    pd.testing.assert_frame_equal(df, before)
+
+
+def test_canonical_examples_conform():
+    """Every packaged canonical example validates as-is (the contract's own truth)."""
+    names = analysis_input_example_names()
+    assert names, "contract package exposed no canonical examples"
+    for name in names:
+        example = load_analysis_input_example(name)
+        validate_analysis_input(example).raise_for_status()
+
+
+def test_negative_control_validation_can_fail(final_data_by_platform):
+    """A frame missing the genotype role fails validation (asserts are non-vacuous)."""
+    check = _build_analysis_input(final_data_by_platform["turface_19"].copy())
+    bad = check.drop(columns=["genotype"])
+
+    result = validate_analysis_input(bad)
+
+    assert not result.ok
+    with pytest.raises(ValueError):
+        result.raise_for_status()
+
+
+def test_no_stale_validation_json(repro_fixtures_dir):
+    """No ``*_validation.json`` expected files remain in the fixture tree (#147).
+
+    They were removed in 73583f9 — their ``summary`` shape never matched
+    ``ValidationResult``; the contract is asserted live, never against stored JSON.
+    """
+    stale = list(repro_fixtures_dir.rglob("*_validation.json"))
+    assert not stale, f"unexpected validation JSON fixtures: {stale}"

--- a/uv.lock
+++ b/uv.lock
@@ -20,6 +20,16 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/4c/d4/6585f3b6fdb75648bca294664af4becc8aa2fb3fb08f4e4e9fd27e10d773/adjusttext-1.3.0.tar.gz", hash = "sha256:4ab75cd4453af4828876ac3e964f2c49be642ea834f0c1f7449558d5f12cbca1", size = 15724, upload-time = "2024-10-31T16:45:36.101Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/53/1c/8feedd607cc14c5df9aef74fe3af9a99bf660743b842a9b5b1865326b4aa/adjustText-1.3.0-py3-none-any.whl", hash = "sha256:da23d7b24b6db5ffa039bb136bfa556207365e32f48ac74b07ad26dd485bc691", size = 13154, upload-time = "2024-10-31T16:45:35.227Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/80/7ad35ee5321a86b842f9e8516c8ae4c86f58db7b40e82ce9759f94517a50/adjusttext-1.3.0-py3-none-any.whl", hash = "sha256:bc6c118cd9d7caf6ae37f9355e51d840a2d7f64b4fb2956b8401de27c5af803b", size = 13264, upload-time = "2026-06-08T16:40:05.041Z" },
+]
+
+[[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
@@ -1308,6 +1318,123 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
 name = "pydocstyle"
 version = "6.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1863,6 +1990,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "sleap-roots-contracts", extra = ["pandas"] },
     { name = "toml" },
 ]
 
@@ -1897,7 +2025,26 @@ dev = [
     { name = "pytest", specifier = ">=8.4.1" },
     { name = "pytest-cov", specifier = ">=6.2.1" },
     { name = "ruff", specifier = ">=0.12.11" },
+    { name = "sleap-roots-contracts", extras = ["pandas"], specifier = ">=0.1.0a1" },
     { name = "toml", specifier = ">=0.10.2" },
+]
+
+[[package]]
+name = "sleap-roots-contracts"
+version = "0.1.0a1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/1f/ad5ed534bca6f675f2f0b06c4665e3502e9c9027736dd24bebe991f199a9/sleap_roots_contracts-0.1.0a1.tar.gz", hash = "sha256:0102c724e9aa9fefadcd16314debcd3b5925260b2e4f681a9f6c74a4cff25a41", size = 14727, upload-time = "2026-06-11T19:25:25.467Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/99/7d584a8a3a9a34b812cf7f6a1514c2cc454073315747a102027d4c03293f/sleap_roots_contracts-0.1.0a1-py3-none-any.whl", hash = "sha256:8d203f73cffc13233aa63578ca24e8355be29d09a4f3fb08a4047c4fee19979b", size = 20456, upload-time = "2026-06-11T19:25:24.337Z" },
+]
+
+[package.optional-dependencies]
+pandas = [
+    { name = "pandas" },
 ]
 
 [[package]]
@@ -2076,6 +2223,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Implements #147 — analysis-input **contract conformance tests** for the EDPIE fixtures, the split-out slice from #146 (gated on the `sleap-roots-contracts 0.1.0a1` release). **Tests + dev dependency only; no `src/` changes.**

Adds `tests/test_contract_conformance.py`, which proves the committed post-QC fixtures and the package's canonical examples conform to `validate_analysis_input`. Canonicalization always runs on a **copy** — the frame that feeds QC/viz/cross-platform is never mutated. This previews the #144 load-boundary transform; it does **not** implement the runtime wiring (the `validate_input` flag / `run-all` integration remain #144).

## What it tests

- **Real-data conformance** (parametrized over all 4 platforms `turface_19`, `turface_150`, `cylinder`, `root_core`): rename native roles (`Genotype`→`genotype`, `Barcode`→`sample_id`, `Replicate`→`replicate`) → drop non-trait metadata via `get_trait_columns` (with explicit role kwargs) → `canonicalize_role_dtypes` → `validate_analysis_input(...).raise_for_status()`.
- **Non-mutation guard**: `pd.testing.assert_frame_equal` proves the shared session fixture is untouched.
- **Canonical examples**: every name from `analysis_input_example_names()` (registry-driven, currently `cylinder`, `cylinder_no_replicate`, `field`, `turface`, `genotype_means`) validates as-is.
- **Negative control**: a frame missing the `genotype` role makes `raise_for_status()` raise `ValueError` (`.ok is False`) — proves the green asserts are non-vacuous.
- **Stale-JSON guard**: asserts no `*_validation.json` expected files remain (removed in `73583f9`).

A pre-PR self-review caught one tautological assertion (the intended `replicate`-leak guard was vacuous); replaced with `check.columns.is_unique`, which provably fires under the default-kwargs regression (the numeric `replicate` duplicates).

## ⚠️ Packaging note — please review `uv.lock`

`sleap-roots-contracts 0.1.0a1` is an alpha. Adding it with `uv add --dev --prerelease=allow` resolved the alpha **but also needlessly bumped `pydantic` to `2.14.0a1`** (another prerelease) for the whole resolution. Since contracts only requires `pydantic>=2.7`, I re-pinned pydantic to stable `2.13.4` via `uv lock --upgrade-package pydantic --upgrade-package pydantic-core`. **Net: the lockfile contains exactly one prerelease (`sleap-roots-contracts`); pydantic stays stable.** Worth a glance on the `uv.lock` diff.

## Test results

- New module: **11/11 pass**
- Reproduction goldens (#146/#120) stay green — the proof `run-all` output is unchanged
- Full suite: **2106 passed**
- `black` + `ruff` clean; `openspec validate add-contract-conformance-tests --strict` passes

## OpenSpec

Change `add-contract-conformance-tests` (new `contract-conformance` capability) — all tasks checked off.

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)
