### PR TITLE
refactor: centralize path serialization in pipeline (#157)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -66,6 +66,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `diagnose_heritability_issues`, and `compare_trait_heritabilities` (Part of #116).
 
 ### Fixed
+- Pipeline provenance manifests now emit forward-slash (POSIX) paths on every OS.
+  Steps previously hand-stringified paths with `str(path)` before serialization,
+  which baked in backslashes on Windows (e.g. `out\a.csv` instead of `out/a.csv`)
+  in the `files_generated` and `metadata` fields of `pipeline_summary.json` and in
+  the standalone `*_manifest.json` files. Producers now store `Path` and let the
+  central serializers normalize once via `Path.as_posix()` (`convert_to_json_serializable`
+  and the `save_json` default hook); the `files_generated` field type was tightened
+  to `List[Path]` so the divergence can't recur. Completes the single-site fix from
+  #156. (#157)
 - Add the missing `from typing import Any` import in `statistics.py` so
   `typing.get_type_hints()` no longer raises `NameError` on the three functions that
   annotate `Dict[str, Any]`, unblocking downstream tool-schema generation.

--- a/docs/reproducibility.md
+++ b/docs/reproducibility.md
@@ -119,6 +119,17 @@ intentionally asymmetric: `ndarray`→list, unknown objects→`"<TypeName>"`). `
 survives an in-process round-trip and is compared NaN-aware; note it is non-standard
 JSON, so a stricter external consumer may reject it.
 
+**Path normalization is centralized — store `Path`, never `str(path)`.** Producers
+(pipeline steps, result objects) hand a `Path` object to the serializer and let it
+normalize to a POSIX string (`Path.as_posix()`) exactly once. Pre-stringifying with
+`str(path)` defeats this and bakes in OS-specific separators (backslashes on Windows),
+producing `out\a.csv` instead of `out/a.csv` in `pipeline_summary.json` and the
+standalone `*_manifest.json` files (#157). Both serialization sinks own this:
+`convert_to_json_serializable` (for the summary) and the `BaseStep.save_json` `default`
+hook (for standalone manifests). The `StepSummary.files_generated` field is typed
+`List[Path]` so the rule can't silently regress; [`tests/test_no_path_prestringify.py`](../tests/test_no_path_prestringify.py)
+is an AST guard that fails if a `str(path)` is reintroduced into a step.
+
 ## CI enforcement
 
 The gates run on every pull request and can be set as required status checks in

--- a/openspec/changes/refactor-path-serialization/proposal.md
+++ b/openspec/changes/refactor-path-serialization/proposal.md
@@ -1,0 +1,24 @@
+## Why
+
+PR #156's cross-OS serialization round-trip gate caught a latent bug: pipeline steps hand-stringify paths with `str(path)` before they reach the central serializer, so on Windows a serialized path becomes `out\a.csv` instead of `out/a.csv`. #156 fixed only one site (`PipelineSummary.to_json` no longer pre-`str()`s `files_generated`).
+
+The same `str(path)` anti-pattern is repeated across ~20 sites in the pipeline steps (issue #157). Each pre-stringification **defeats** `convert_to_json_serializable`'s `Path → as_posix()` normalization and bakes in `\` on Windows. The union type `files_generated: List[str | Path]` is what invites this divergence: it lets each producer choose to store a `str` or a `Path`. This is the per-run provenance manifest that rolls up into `pipeline_summary.json`, so the divergence is observable in shipped artifacts.
+
+## What Changes
+
+- Stop hand-stringifying paths at the producers across the pipeline steps. Store bare `Path` and let `convert_to_json_serializable` normalize once, centrally (no per-producer `.as_posix()` — that just relocates the choice). Affected sites:
+  - `files_generated=[str(...)]` / `.append(str(...))`: `calculate_cross_platform_correlations.py`, `calculate_trait_enrichment.py`, `reduce_trait_redundancy.py` (×3), `visualize_cross_platform.py` (×4), `load_cross_platform_data.py` (×3)
+  - `metadata[...] = str(path)` (and `[str(f.relative_to(run_dir)) …]`): `merge_all_traits.py`, `visualize_depth_profiles.py`, `filter_heritability.py`, `generate_dashboards.py`, `generate_summary_viz.py`, `load_above_ground.py`, `generate_interactive.py`, `generate_static_figures.py`
+- **BREAKING (internal)** Tighten the field type `files_generated: List[str | Path]` → `List[Path]` in `pipeline/core.py`, `pipeline/summary.py`, `pipeline/task.py` so the union can't re-invite divergence. (Internal dataclass field; not a public API.) This MUST land in the same commit as the producer edits — `List` is invariant, so a split breaks the mypy baseline gate either way.
+- Update 4 step tests that assert exact `str(...)` membership in `files_generated` (they break at runtime once elements are `Path`), and add an OS-independent regression test, a `None`-path test, and a CI-enforced source guard so the anti-pattern can't recur.
+- Tighten the existing `cli-pipeline` "Summary config is JSON serializable" scenario from "converted to strings" → "converted to POSIX strings", so the spec no longer permits the backslash form this change removes.
+- Verify against the cross-OS serialization round-trip gate from #156 (the `serialization-gate` CI job over ubuntu/windows/macos).
+
+## Impact
+
+- Affected specs: `cli-pipeline` (MODIFY config-serialization scenario; ADD provenance path serialization requirement)
+- Affected code: `src/sleap_roots_analyze/pipeline/{core,summary,task}.py` (type tightening) and ~13 step files under `src/sleap_roots_analyze/pipeline/steps/`
+- Affected tests: 4 existing membership assertions updated, plus new regression/guard tests (`tests/test_result_serialization.py`, a `None`-path test, `tests/test_no_path_prestringify.py`)
+- Affected docs: `docs/CHANGELOG.md` (Fixed entry — user-observable: Windows manifests flip `\`→`/`), `docs/reproducibility.md` (state the producer-side "store `Path`" rule once, as the gate's named source of truth), `openspec/project.md` (one-line pointer), and the now-understated comment at `pipeline/summary.py:88-91`
+- Merge-order coupling: the mypy baseline gate is on the still-open PR #158, not `main`. Land this refactor before #158 if possible; otherwise resync `.mypy-baseline.txt` in this PR's single commit.
+- Risk: low-to-medium. Producer edits are mechanical, but the type change requires the coordinated test updates above. No committed golden fixture asserts on serialized paths or carries backslash paths (to be verified, not just asserted — task 5.3), so the #146 reproduction fixtures are undisturbed. The cross-OS gate is the regression backstop.

--- a/openspec/changes/refactor-path-serialization/proposal.md
+++ b/openspec/changes/refactor-path-serialization/proposal.md
@@ -17,8 +17,9 @@ The same `str(path)` anti-pattern is repeated across ~20 sites in the pipeline s
 ## Impact
 
 - Affected specs: `cli-pipeline` (MODIFY config-serialization scenario; ADD provenance path serialization requirement)
-- Affected code: `src/sleap_roots_analyze/pipeline/{core,summary,task}.py` (type tightening) and ~13 step files under `src/sleap_roots_analyze/pipeline/steps/`
-- Affected tests: 4 existing membership assertions updated, plus new regression/guard tests (`tests/test_result_serialization.py`, a `None`-path test, `tests/test_no_path_prestringify.py`)
+- Affected code: `src/sleap_roots_analyze/pipeline/{core,summary,task}.py` (type tightening) and ~13 step files under `src/sleap_roots_analyze/pipeline/steps/`; plus, per PR #159 review: `pipelines/base_pipeline.py` (`output_directory` stores bare `Path`), `data_utils.py` (shared `path_to_posix` helper unifying the two serializer predicates), and `steps/generate_summary_viz.py` (third sink — its local viz-`summary.json` writer)
+- Affected tests: 4 existing membership assertions updated, plus new regression/guard tests (`tests/test_result_serialization.py` incl. `output_directory`, a `save_json` POSIX test in `tests/test_pipeline_core.py`, `tests/test_no_path_prestringify.py`)
+- Affected fixtures: two committed goldens whose path fields were Windows-backslashed (`viz/cylinder/summary.json` `run_directory`, `cross_platform/root_core_vs_cylinder/pipeline_summary.json` `output_directory`) regenerated to POSIX
 - Affected docs: `docs/CHANGELOG.md` (Fixed entry — user-observable: Windows manifests flip `\`→`/`), `docs/reproducibility.md` (state the producer-side "store `Path`" rule once, as the gate's named source of truth), `openspec/project.md` (one-line pointer), and the now-understated comment at `pipeline/summary.py:88-91`
 - Merge-order coupling: the mypy baseline gate is on the still-open PR #158, not `main`. Land this refactor before #158 if possible; otherwise resync `.mypy-baseline.txt` in this PR's single commit.
 - Risk: low-to-medium. Producer edits are mechanical, but the type change requires the coordinated test updates above. No committed golden fixture asserts on serialized paths or carries backslash paths (to be verified, not just asserted — task 5.3), so the #146 reproduction fixtures are undisturbed. The cross-OS gate is the regression backstop.

--- a/openspec/changes/refactor-path-serialization/specs/cli-pipeline/spec.md
+++ b/openspec/changes/refactor-path-serialization/specs/cli-pipeline/spec.md
@@ -1,0 +1,57 @@
+## MODIFIED Requirements
+
+### Requirement: Pipeline Summary Config Population
+
+The pipeline summary JSON SHALL include the complete configuration used for the run.
+
+#### Scenario: Summary includes config dict
+- **GIVEN** a pipeline run that completes
+- **WHEN** `pipeline_summary.json` is loaded
+- **THEN** the `config` field SHALL contain a non-empty dictionary
+- **AND** the dictionary SHALL include all config parameters
+
+#### Scenario: Summary config is JSON serializable
+- **GIVEN** a config with complex types (Path objects, dataclasses)
+- **WHEN** the pipeline saves the summary
+- **THEN** all config values SHALL be serialized to JSON-compatible types
+- **AND** Path objects SHALL be converted to POSIX strings via `Path.as_posix()` (forward-slash separators on every OS)
+
+## ADDED Requirements
+
+### Requirement: Provenance Path Serialization Is Centralized
+
+The pipeline provenance manifest (`pipeline_summary.json`) SHALL record every filesystem path through the central JSON serializer (`convert_to_json_serializable`) so that path normalization happens in exactly one place. Producing steps SHALL store `Path` objects in `files_generated` and `metadata`; they SHALL NOT pre-stringify paths with `str(path)`, which on Windows yields backslash separators and bypasses the serializer's `Path.as_posix()` normalization. The `files_generated` field SHALL be typed `List[Path]` so the type cannot invite per-producer divergence.
+
+#### Scenario: Generated file paths normalize to POSIX in the manifest
+
+- **GIVEN** a pipeline step that records a generated file in `files_generated`
+- **WHEN** `pipeline_summary.json` is written
+- **THEN** the serialized path SHALL equal `Path(p).as_posix()`
+- **AND** it SHALL use forward-slash (`/`) separators regardless of the host platform's native separator
+
+#### Scenario: Metadata path values normalize to POSIX in the manifest
+
+- **GIVEN** a pipeline step that records a path under `metadata` (e.g. `output_csv`, `dashboard_path`, or a relative `Path.relative_to(run_dir)`)
+- **WHEN** `pipeline_summary.json` is written
+- **THEN** the serialized path value SHALL equal `Path.as_posix()` of the stored path, preserving its relative-vs-absolute form
+- **AND** it SHALL use forward-slash (`/`) separators on every OS
+
+#### Scenario: Optional path values serialize to JSON null
+
+- **GIVEN** a step that records an optional path under `metadata` whose value is `None` (e.g. `reps_plot` when no replicate plot was produced)
+- **WHEN** `pipeline_summary.json` is written
+- **THEN** the serialized value SHALL be JSON `null`
+- **AND** dropping the producer-side `str(path)` SHALL NOT change a `None` value into the string `"None"`
+
+#### Scenario: Producers do not pre-stringify paths
+
+- **GIVEN** any pipeline step that contributes a path to `files_generated` or `metadata`
+- **WHEN** the step records the path
+- **THEN** it SHALL store a `Path` object (never `str(path)`)
+- **AND** a CI-enforced source guard SHALL fail if a `str(path)` pre-stringification is reintroduced into a step's `files_generated`/`metadata`
+
+#### Scenario: Serialization round-trip gate is green cross-OS
+
+- **GIVEN** the result-object JSON round-trip gate (`serialization-gate` CI job, issue #156) running on ubuntu, windows, and macos
+- **WHEN** a `PipelineSummary` carrying `Path` values is serialized and reloaded
+- **THEN** it SHALL round-trip to identical POSIX strings on all three platforms

--- a/openspec/changes/refactor-path-serialization/specs/cli-pipeline/spec.md
+++ b/openspec/changes/refactor-path-serialization/specs/cli-pipeline/spec.md
@@ -43,6 +43,13 @@ The pipeline provenance manifest (`pipeline_summary.json`) SHALL record every fi
 - **THEN** the serialized value SHALL be JSON `null`
 - **AND** dropping the producer-side `str(path)` SHALL NOT change a `None` value into the string `"None"`
 
+#### Scenario: Top-level and standalone-manifest paths normalize to POSIX
+
+- **GIVEN** the pipeline writes `output_directory` into `pipeline_summary.json` and per-step `*_manifest.json` / `summary.json` files containing `Path` values
+- **WHEN** those files are written on any OS
+- **THEN** every serialized path SHALL use forward-slash (`/`) separators
+- **AND** all serializer sinks (`convert_to_json_serializable`, the `save_json` default hook, and the viz `summary.json` writer) SHALL normalize paths via the same `PurePath.as_posix()` predicate
+
 #### Scenario: Producers do not pre-stringify paths
 
 - **GIVEN** any pipeline step that contributes a path to `files_generated` or `metadata`

--- a/openspec/changes/refactor-path-serialization/tasks.md
+++ b/openspec/changes/refactor-path-serialization/tasks.md
@@ -37,6 +37,16 @@
 - [x] 4.3 Add a regression test for the `None`-path branch (`visualize_depth_profiles` `reps_plot`): when no replicate plot is produced, `metadata[...]["reps_plot"]` SHALL serialize to JSON `null`, not `"None"`
 - [x] 4.4 Add a CI-enforced source guard (e.g. `tests/test_no_path_prestringify.py`) that scans `pipeline/steps/` and fails if `str(...)` co-occurs with a `files_generated`/`metadata` path assignment (AST- or multi-line-aware, so it catches `files_generated=[\n str(x)\n]`)
 
+## 4b. Review follow-ups (PR #159 subagent review)
+
+- [x] 4b.1 Fix Windows CI: `tests/test_no_path_prestringify.py` reads source with `encoding="utf-8"` (locale codec raised on emoji/`ρ`); also `rglob` + non-vacuous `>=13` assert + softened guard docstring
+- [x] 4b.2 `output_directory` no longer pre-stringified: `base_pipeline.py` stores bare `Path`; `PipelineSummary.output_directory` typed `str | Path`
+- [x] 4b.3 Third sink fixed: `generate_summary_viz._make_json_serializable` normalizes `PurePath` via `as_posix()` (was `str(obj)`) so the viz `summary.json` `run_directory` is POSIX
+- [x] 4b.4 Unify the two serializer predicates: shared `data_utils.path_to_posix` (PurePath) used by `save_json`; add a `save_json` Path-normalization test
+- [x] 4b.5 `PipelineSummary.load()` rehydrates `files_generated` to `List[Path]`; both readers use `encoding="utf-8"`
+- [x] 4b.6 Regenerate the two committed goldens whose path fields were backslashed (`viz/cylinder/summary.json`, `cross_platform/root_core_vs_cylinder/pipeline_summary.json`)
+- [x] 4b.7 Extend the cross-OS gate test to assert `output_directory` normalizes
+
 ## 5. Verify
 
 - [x] 5.1 `grep -rn "str(" src/sleap_roots_analyze/pipeline/steps/ | grep -iE "files_generated|metadata|relative_to"` returns no path-stringification sites

--- a/openspec/changes/refactor-path-serialization/tasks.md
+++ b/openspec/changes/refactor-path-serialization/tasks.md
@@ -1,0 +1,51 @@
+> **Atomicity note:** The type-tightening (§1) and the producer edits (§2–§3) MUST
+> land in a single atomic commit/PR. `List` is invariant, so under the mypy
+> baseline gate (PR #158) neither order is independently green: tighten-first adds
+> `[list-item]` errors at still-`str(...)` producers AND strands resolved baseline
+> entries; producers-first can add new invariance errors at not-yet-baselined files.
+> See §5 for the merge-order coupling with PR #158.
+
+## 1. Tighten the type (land with §2–§3 in one commit)
+
+- [x] 1.1 Change `files_generated: List[str | Path]` → `List[Path]` in `pipeline/summary.py` (`StepSummary` field at line 36 **and** the `mark_step_success` signature at line 127)
+- [x] 1.2 Change `files_generated: List[str | Path]` → `List[Path]` in `pipeline/core.py` (line 51)
+- [x] 1.3 Change `files_generated: List[str | Path]` → `List[Path]` in `pipeline/task.py` (line 29)
+
+## 2. Stop hand-stringifying at the producers — `files_generated`
+
+- [x] 2.1 `steps/calculate_cross_platform_correlations.py:393` — `files_generated=[corr_output]`
+- [x] 2.2 `steps/calculate_trait_enrichment.py:121,154` — `files_generated=[output_file]`
+- [x] 2.3 `steps/reduce_trait_redundancy.py:244,266,277` — `.append(cluster_file / dendrogram_file / heatmap_file)`
+- [x] 2.4 `steps/visualize_cross_platform.py:130,185,215,231` — `.append(<path>)`
+- [x] 2.5 `steps/load_cross_platform_data.py:182,183,184` — `files_generated=[exp1_output, exp2_output, alignment_output]` (these are in `files_generated`, not `metadata`)
+
+## 3. Stop hand-stringifying at the producers — `metadata`
+
+- [x] 3.1 `steps/merge_all_traits.py:142,143` — `output_csv`, `metadata_json`
+- [x] 3.2 `steps/visualize_depth_profiles.py:201,202,205` — `mean_plot`, `reps_plot`, `barplot`. **Keep the `if reps_plot_path else None` and `if barplot_path:` guards** — remove only the `str()` wrapper so the value stays `Path | None`.
+- [x] 3.3 `steps/filter_heritability.py:327,328,329` — `diagnostic_csv`, `variance_plot`, `boxplot`
+- [x] 3.4 `steps/generate_dashboards.py:107,110` — `dashboard_path` (`relative_to(run_dir)`), `run_directory`
+- [x] 3.5 `steps/generate_summary_viz.py:56` — `run_directory`
+- [x] 3.6 `steps/load_above_ground.py:101` — `csv_path`
+- [x] 3.7 `steps/generate_interactive.py:169` — `files: [f.relative_to(run_dir) for f in generated_files]`
+- [x] 3.8 `steps/generate_static_figures.py:284` — `files: [f.relative_to(run_dir) for f in generated_files]`
+
+## 4. Tests
+
+- [x] 4.1 Update the 4 existing tests that assert exact `str(...)` membership in `files_generated` (break once elements are `Path`): `test_step_calculate_cross_platform_correlations.py:258`, `test_step_visualize_cross_platform.py:165,592`, `test_step_load_cross_platform_data.py:513` — compare on `Path` (or `in [str(f) for f in ...]`)
+- [x] 4.2 Add an OS-independent red-before-green test: assert the serialized manifest value equals `Path(p).as_posix()` and contains no `\` for a representative producer, using a backslash-bearing / `PureWindowsPath`-backed value so it fails against current `str(path)` producers on any OS and passes after
+- [x] 4.3 Add a regression test for the `None`-path branch (`visualize_depth_profiles` `reps_plot`): when no replicate plot is produced, `metadata[...]["reps_plot"]` SHALL serialize to JSON `null`, not `"None"`
+- [x] 4.4 Add a CI-enforced source guard (e.g. `tests/test_no_path_prestringify.py`) that scans `pipeline/steps/` and fails if `str(...)` co-occurs with a `files_generated`/`metadata` path assignment (AST- or multi-line-aware, so it catches `files_generated=[\n str(x)\n]`)
+
+## 5. Verify
+
+- [x] 5.1 `grep -rn "str(" src/sleap_roots_analyze/pipeline/steps/ | grep -iE "files_generated|metadata|relative_to"` returns no path-stringification sites
+- [x] 5.2 Run `pytest tests/test_result_serialization.py` (the cross-OS round-trip gate) green
+- [x] 5.3 Run the #146 reproduction-fixture tests and inspect any committed `pipeline_summary.json` fixtures for path literals — **verify** (not just assert) the fixtures are undisturbed
+- [x] 5.4 Full `pytest` + `ruff check` + `black --check` clean
+- [x] 5.5 Update `docs/CHANGELOG.md` `[Unreleased] → Fixed`, `docs/reproducibility.md` serialization contract (producer-side "store `Path`" rule), the `summary.py:88-91` comment, and a one-line pointer in `openspec/project.md` (see proposal Impact)
+
+## 6. Merge-order coupling with PR #158 (mypy baseline gate)
+
+- [x] 6.1 Land this refactor **before** PR #158 if possible (then no mypy churn here; #158 rebases with 19 fewer baseline entries). If #158 lands first: fold the `.mypy-baseline.txt` resync into this PR's single commit (`mypy-baseline sync`) to drop the now-resolved `files_generated` invariance entries — CI runs `filter` without `--allow-unsynced`, so a stale baseline fails the gate
+- [x] 6.2 Run `mypy src/` locally post-change to confirm no NEW downstream error beyond the expected baseline delta (e.g. verify `generate_interactive.py` `image_links` frozen entries at lines 204–206 are not perturbed)

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -113,6 +113,7 @@ src/sleap_roots_analyze/
 - Always return both cleaned data AND removed samples for transparency
 - Export artifacts as CSV for reproducibility and inspection
 - Support both programmatic API and future CLI usage
+- Store `Path` objects through to serialization — never `str(path)`; the JSON serializers own POSIX normalization (see [docs/reproducibility.md](../docs/reproducibility.md))
 
 ### Testing Strategy
 

--- a/src/sleap_roots_analyze/data_utils.py
+++ b/src/sleap_roots_analyze/data_utils.py
@@ -53,6 +53,24 @@ def _convert_dict_key(key):
         return str(key)
 
 
+def path_to_posix(obj):
+    """Normalize a path to a POSIX string for a ``json.dump`` ``default`` hook.
+
+    Returns ``obj.as_posix()`` for any :class:`~pathlib.PurePath` (forward-slash
+    separators on every OS) and falls back to ``str(obj)`` for anything else, so the
+    only behavior change versus a bare ``default=str`` is OS-independent paths. Shared
+    by ``convert_to_json_serializable`` and ``BaseStep.save_json`` so both sinks use
+    one path predicate (#157).
+
+    Args:
+        obj: The object json could not natively serialize.
+
+    Returns:
+        The POSIX string for paths, otherwise ``str(obj)``.
+    """
+    return obj.as_posix() if isinstance(obj, PurePath) else str(obj)
+
+
 def convert_to_json_serializable(obj):
     """Convert numpy types, Path objects, and other types to JSON serializable types.
 

--- a/src/sleap_roots_analyze/data_utils.py
+++ b/src/sleap_roots_analyze/data_utils.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pandas as pd
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Dict, List, Optional, Tuple, Union, Any
 from datetime import datetime
 import json
@@ -71,7 +71,7 @@ def convert_to_json_serializable(obj):
         return [convert_to_json_serializable(item) for item in obj]
     elif isinstance(obj, tuple):
         return tuple(convert_to_json_serializable(item) for item in obj)
-    elif isinstance(obj, Path):
+    elif isinstance(obj, PurePath):
         return obj.as_posix()
     elif isinstance(obj, (np.integer, np.int64, np.int32)):
         return int(obj)

--- a/src/sleap_roots_analyze/pipeline/core.py
+++ b/src/sleap_roots_analyze/pipeline/core.py
@@ -119,18 +119,15 @@ class BaseStep(ABC):
         """
         import json
 
+        from sleap_roots_analyze.data_utils import path_to_posix
+
         output_path = run_dir / filename
-        with open(output_path, "w") as f:
-            # Normalize Path values to POSIX (forward-slash on every OS) in the
-            # default hook so producers can store bare Path; everything else keeps
-            # the prior str() fallback, so the only behavior change is that paths
-            # no longer carry backslashes on Windows.
-            json.dump(
-                data,
-                f,
-                indent=2,
-                default=lambda o: o.as_posix() if isinstance(o, Path) else str(o),
-            )
+        with open(output_path, "w", encoding="utf-8") as f:
+            # path_to_posix normalizes any PurePath to forward-slash on every OS so
+            # producers can store bare Path; everything else keeps the prior str()
+            # fallback. Shared with convert_to_json_serializable so both serializer
+            # sinks use one path predicate (#157).
+            json.dump(data, f, indent=2, default=path_to_posix)
         return output_path
 
     def reorder_dataframe_columns(

--- a/src/sleap_roots_analyze/pipeline/core.py
+++ b/src/sleap_roots_analyze/pipeline/core.py
@@ -48,7 +48,7 @@ class StepResult:
 
     data: Any
     metadata: Dict[str, Any] = field(default_factory=dict)
-    files_generated: List[str | Path] = field(default_factory=list)
+    files_generated: List[Path] = field(default_factory=list)
 
 
 class BaseStep(ABC):
@@ -121,7 +121,16 @@ class BaseStep(ABC):
 
         output_path = run_dir / filename
         with open(output_path, "w") as f:
-            json.dump(data, f, indent=2, default=str)
+            # Normalize Path values to POSIX (forward-slash on every OS) in the
+            # default hook so producers can store bare Path; everything else keeps
+            # the prior str() fallback, so the only behavior change is that paths
+            # no longer carry backslashes on Windows.
+            json.dump(
+                data,
+                f,
+                indent=2,
+                default=lambda o: o.as_posix() if isinstance(o, Path) else str(o),
+            )
         return output_path
 
     def reorder_dataframe_columns(

--- a/src/sleap_roots_analyze/pipeline/pipelines/base_pipeline.py
+++ b/src/sleap_roots_analyze/pipeline/pipelines/base_pipeline.py
@@ -95,7 +95,7 @@ class BasePipeline(ABC):
         self.summary = PipelineSummary(
             pipeline_name=pipeline_name,
             version=version,
-            output_directory=str(self.run_dir),
+            output_directory=self.run_dir,
         )
 
     def _setup_logger(self) -> logging.Logger:

--- a/src/sleap_roots_analyze/pipeline/steps/calculate_cross_platform_correlations.py
+++ b/src/sleap_roots_analyze/pipeline/steps/calculate_cross_platform_correlations.py
@@ -390,5 +390,5 @@ class CalculateCrossPlatformCorrelationsStep(BaseStep):
         return StepResult(
             data=result_data,
             metadata=metadata,
-            files_generated=[str(corr_output)],
+            files_generated=[corr_output],
         )

--- a/src/sleap_roots_analyze/pipeline/steps/calculate_trait_enrichment.py
+++ b/src/sleap_roots_analyze/pipeline/steps/calculate_trait_enrichment.py
@@ -118,7 +118,7 @@ class CalculateTraitEnrichmentStep(BaseStep):
                     "enrichment_n_tests": 0,
                     "enrichment_skipped_reason": "no testable correlations",
                 },
-                files_generated=[str(output_file)],
+                files_generated=[output_file],
             )
 
         result = calculate_enrichment_test(
@@ -151,5 +151,5 @@ class CalculateTraitEnrichmentStep(BaseStep):
                 "enrichment_fold": result.fold_enrichment,
                 "enrichment_interpretation": result.interpretation,
             },
-            files_generated=[str(output_file)],
+            files_generated=[output_file],
         )

--- a/src/sleap_roots_analyze/pipeline/steps/filter_heritability.py
+++ b/src/sleap_roots_analyze/pipeline/steps/filter_heritability.py
@@ -324,9 +324,9 @@ class FilterHeritabilityStep(BaseStep):
                 # Store diagnostic results for metadata
                 diagnostic_results = {
                     "comparison_df": comparison_df.to_dict("records"),
-                    "diagnostic_csv": str(diag_csv_path),
-                    "variance_plot": str(var_plot_path),
-                    "boxplot": str(box_plot_path),
+                    "diagnostic_csv": diag_csv_path,
+                    "variance_plot": var_plot_path,
+                    "boxplot": box_plot_path,
                     "traits_analyzed": len(trait_cols),
                     "traits_removed_plotted": len(traits_to_plot),
                 }

--- a/src/sleap_roots_analyze/pipeline/steps/generate_dashboards.py
+++ b/src/sleap_roots_analyze/pipeline/steps/generate_dashboards.py
@@ -104,10 +104,10 @@ class GenerateDashboardsStep(BaseStep):
 
         # Save manifest
         manifest = {
-            "dashboard_path": str(dashboard_path.relative_to(run_dir)),
+            "dashboard_path": dashboard_path.relative_to(run_dir),
             "total_static_figures": len(static_figures),
             "total_interactive_figures": len(interactive_figures),
-            "run_directory": str(run_dir),
+            "run_directory": run_dir,
         }
         manifest_file = self.save_json(manifest, "11_dashboard_manifest.json", run_dir)
 

--- a/src/sleap_roots_analyze/pipeline/steps/generate_interactive.py
+++ b/src/sleap_roots_analyze/pipeline/steps/generate_interactive.py
@@ -166,7 +166,7 @@ class GenerateInteractiveStep(BaseStep):
             # Save manifest
             manifest = {
                 "total_figures": len(generated_files),
-                "files": [str(f.relative_to(run_dir)) for f in generated_files],
+                "files": [f.relative_to(run_dir) for f in generated_files],
             }
             manifest_file = self.save_json(
                 manifest, "10_interactive_figures_manifest.json", run_dir

--- a/src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py
+++ b/src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py
@@ -281,7 +281,7 @@ class GenerateStaticFiguresStep(BaseStep):
                 "total_figures": len(generated_files),
                 "formats": formats,
                 "dpi": dpi,
-                "files": [str(f.relative_to(run_dir)) for f in generated_files],
+                "files": [f.relative_to(run_dir) for f in generated_files],
             }
             manifest_file = self.save_json(
                 manifest, "09_static_figures_manifest.json", run_dir

--- a/src/sleap_roots_analyze/pipeline/steps/generate_summary_viz.py
+++ b/src/sleap_roots_analyze/pipeline/steps/generate_summary_viz.py
@@ -53,7 +53,7 @@ class GenerateSummaryStep(BaseStep):
         summary_data = {
             "pipeline_name": config.pipeline_name,
             "version": config.version,
-            "run_directory": str(run_dir),
+            "run_directory": run_dir,
             "data_file": config.data.csv_path,
             "n_samples": metadata.get("n_samples", len(data)),
             "n_traits_initial": metadata.get("n_traits", 0),

--- a/src/sleap_roots_analyze/pipeline/steps/generate_summary_viz.py
+++ b/src/sleap_roots_analyze/pipeline/steps/generate_summary_viz.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import Optional
 
 import pandas as pd
@@ -324,7 +324,8 @@ class GenerateSummaryStep(BaseStep):
             return [self._make_json_serializable(item) for item in obj]
         elif isinstance(obj, (pd.DataFrame, pd.Series)):
             return str(type(obj))  # Just note the type for complex objects
-        elif isinstance(obj, Path):
-            return str(obj)
+        elif isinstance(obj, PurePath):
+            # POSIX (forward-slash) on every OS, matching the central serializer (#157).
+            return obj.as_posix()
         else:
             return obj

--- a/src/sleap_roots_analyze/pipeline/steps/load_above_ground.py
+++ b/src/sleap_roots_analyze/pipeline/steps/load_above_ground.py
@@ -98,7 +98,7 @@ class LoadAboveGroundTraitsStep:
 
         # Create metadata
         metadata = {
-            "csv_path": str(csv_path),
+            "csv_path": csv_path,
             "num_samples": len(df),
             "num_traits": len(trait_cols),
             "trait_columns": trait_cols,

--- a/src/sleap_roots_analyze/pipeline/steps/load_cross_platform_data.py
+++ b/src/sleap_roots_analyze/pipeline/steps/load_cross_platform_data.py
@@ -179,8 +179,8 @@ class LoadCrossPlatformDataStep(BaseStep):
             data=result_data,
             metadata=metadata,
             files_generated=[
-                str(exp1_output),
-                str(exp2_output),
-                str(alignment_output),
+                exp1_output,
+                exp2_output,
+                alignment_output,
             ],
         )

--- a/src/sleap_roots_analyze/pipeline/steps/merge_all_traits.py
+++ b/src/sleap_roots_analyze/pipeline/steps/merge_all_traits.py
@@ -139,7 +139,7 @@ class MergeAllTraitsStep:
         with open(metadata_path, "w") as f:
             json.dump(metadata, f, indent=2)
 
-        metadata["output_csv"] = str(output_path)
-        metadata["metadata_json"] = str(metadata_path)
+        metadata["output_csv"] = output_path
+        metadata["metadata_json"] = metadata_path
 
         return StepResult(data=merged, metadata=metadata)

--- a/src/sleap_roots_analyze/pipeline/steps/reduce_trait_redundancy.py
+++ b/src/sleap_roots_analyze/pipeline/steps/reduce_trait_redundancy.py
@@ -241,7 +241,7 @@ class ReduceTraitRedundancyStep(BaseStep):
         # Save cluster membership file
         cluster_file = run_dir / f"{exp_name}_trait_clusters.csv"
         cluster_df.to_csv(cluster_file, index=False)
-        files_generated.append(str(cluster_file))
+        files_generated.append(cluster_file)
 
         logger.info(
             "Saved %s cluster membership to %s (%d traits -> %d clusters -> %d representatives)",
@@ -263,7 +263,7 @@ class ReduceTraitRedundancyStep(BaseStep):
             exp_name,
             exp_display_name,
         )
-        files_generated.append(str(dendrogram_file))
+        files_generated.append(dendrogram_file)
 
         # Generate cluster heatmap visualization
         heatmap_file = self._create_cluster_heatmap(
@@ -274,7 +274,7 @@ class ReduceTraitRedundancyStep(BaseStep):
             exp_name,
             exp_display_name,
         )
-        files_generated.append(str(heatmap_file))
+        files_generated.append(heatmap_file)
 
         # Filter df to only include representative columns (plus genotype)
         keep_cols = ["genotype"] + representatives

--- a/src/sleap_roots_analyze/pipeline/steps/visualize_cross_platform.py
+++ b/src/sleap_roots_analyze/pipeline/steps/visualize_cross_platform.py
@@ -127,7 +127,7 @@ class VisualizeCrossPlatformStep(BaseStep):
         summary_output = run_dir / "cross_platform_correlation_summary.png"
         fig.savefig(summary_output, dpi=300, bbox_inches="tight")
         plt.close(fig)
-        files_generated.append(str(summary_output))
+        files_generated.append(summary_output)
 
         # Calculate genotype means for joint plots and boxplots
         exp1_traits = prev_result.metadata.get("exp1_trait_names", [])
@@ -182,7 +182,7 @@ class VisualizeCrossPlatformStep(BaseStep):
             )
             fig.savefig(joint_output, dpi=300, bbox_inches="tight")
             plt.close(fig)
-            files_generated.append(str(joint_output))
+            files_generated.append(joint_output)
 
         # 3. Create genotype boxplots for top N correlations
         n_boxplots = min(config.top_n_boxplots, len(correlation_df))
@@ -212,7 +212,7 @@ class VisualizeCrossPlatformStep(BaseStep):
             )
             fig.savefig(boxplot_output, dpi=300, bbox_inches="tight")
             plt.close(fig)
-            files_generated.append(str(boxplot_output))
+            files_generated.append(boxplot_output)
 
         # 4. Create representative heatmap when clustering is enabled
         # Check config directly since metadata may not be passed through all steps
@@ -228,7 +228,7 @@ class VisualizeCrossPlatformStep(BaseStep):
                 run_dir,
             )
             if heatmap_file:
-                files_generated.append(str(heatmap_file))
+                files_generated.append(heatmap_file)
                 representative_heatmap_generated = True
 
         # Prepare metadata

--- a/src/sleap_roots_analyze/pipeline/steps/visualize_depth_profiles.py
+++ b/src/sleap_roots_analyze/pipeline/steps/visualize_depth_profiles.py
@@ -198,11 +198,11 @@ class VisualizeDepthProfilesStep(BaseStep):
                     "value_column": value_col,
                     "n_genotypes": n_genotypes,
                     "n_depths": n_depths,
-                    "mean_plot": str(mean_plot_path),
-                    "reps_plot": str(reps_plot_path) if reps_plot_path else None,
+                    "mean_plot": mean_plot_path,
+                    "reps_plot": reps_plot_path if reps_plot_path else None,
                 }
                 if barplot_path:
-                    source_metadata["barplot"] = str(barplot_path)
+                    source_metadata["barplot"] = barplot_path
                 metadata["sources"].append(source_metadata)
 
             except Exception as e:

--- a/src/sleap_roots_analyze/pipeline/summary.py
+++ b/src/sleap_roots_analyze/pipeline/summary.py
@@ -33,7 +33,7 @@ class StepSummary:
     description: str = ""
     status: str = "pending"
     elapsed_time: float = 0.0
-    files_generated: List[str | Path] = field(default_factory=list)
+    files_generated: List[Path] = field(default_factory=list)
     metadata: Dict[str, Any] = field(default_factory=dict)
     error: Optional[str] = None
 
@@ -85,10 +85,11 @@ class PipelineSummary:
         Returns:
             JSON string representation of the summary.
         """
-        # Let convert_to_json_serializable normalize everything, including Path ->
-        # obj.as_posix(). A prior str(f) pre-pass over files_generated defeated that
-        # branch on Windows (str(WindowsPath("out/a.csv")) -> "out\\a.csv"), producing
-        # backslash paths in the JSON; the serializer must own Path normalization.
+        # The serializer owns Path normalization: convert_to_json_serializable maps
+        # Path -> obj.as_posix() so manifests are POSIX on every OS. Producers store
+        # Path (files_generated is List[Path]) and never pre-str() it -- str(
+        # WindowsPath("out/a.csv")) -> "out\\a.csv" would defeat this branch. See the
+        # serialization contract in docs/reproducibility.md (#156, #157).
         data = convert_to_json_serializable(self.to_dict())
         return json.dumps(data, indent=indent)
 
@@ -124,7 +125,7 @@ class PipelineSummary:
         self,
         step_name: str,
         elapsed_time: float,
-        files_generated: List[str | Path],
+        files_generated: List[Path],
         metadata: Dict[str, Any],
     ) -> None:
         """Mark a step as successfully completed.

--- a/src/sleap_roots_analyze/pipeline/summary.py
+++ b/src/sleap_roots_analyze/pipeline/summary.py
@@ -65,7 +65,7 @@ class PipelineSummary:
     steps: List[StepSummary] = field(default_factory=list)
     config: Dict[str, Any] = field(default_factory=dict)
     environment: Dict[str, Any] = field(default_factory=dict)
-    output_directory: str = ""
+    output_directory: str | Path = ""
     data_source: str = ""
 
     def to_dict(self) -> Dict[str, Any]:
@@ -114,10 +114,15 @@ class PipelineSummary:
             PipelineSummary object loaded from the file.
         """
         path = Path(path)
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
 
-        # Convert step dictionaries back to StepSummary objects
-        steps = [StepSummary(**step) for step in data.pop("steps", [])]
+        # Convert step dictionaries back to StepSummary objects, rehydrating the
+        # serialized POSIX path strings in files_generated back to Path so the
+        # loaded object matches the List[Path] annotation.
+        steps = []
+        for step in data.pop("steps", []):
+            step["files_generated"] = [Path(p) for p in step.get("files_generated", [])]
+            steps.append(StepSummary(**step))
 
         return cls(steps=steps, **data)
 

--- a/src/sleap_roots_analyze/pipeline/task.py
+++ b/src/sleap_roots_analyze/pipeline/task.py
@@ -26,7 +26,7 @@ class TaskResult:
 
     data: Any
     metadata: Dict[str, Any] = field(default_factory=dict)
-    files_generated: List[str | Path] = field(default_factory=list)
+    files_generated: List[Path] = field(default_factory=list)
 
 
 class Task:

--- a/tests/fixtures/real/wheat_edpie/expected/cross_platform/root_core_vs_cylinder/pipeline_summary.json
+++ b/tests/fixtures/real/wheat_edpie/expected/cross_platform/root_core_vs_cylinder/pipeline_summary.json
@@ -1349,6 +1349,6 @@
     "trait_clustering_linkage": "complete"
   },
   "environment": {},
-  "output_directory": "pipeline_runs\\2026-02-12_191823\\cross_platform\\cross_platform_Root_Core_EDPIE_vs_Cylinder_EDPIE_20260212_194356",
+  "output_directory": "pipeline_runs/2026-02-12_191823/cross_platform/cross_platform_Root_Core_EDPIE_vs_Cylinder_EDPIE_20260212_194356",
   "data_source": ""
 }

--- a/tests/fixtures/real/wheat_edpie/expected/viz/cylinder/summary.json
+++ b/tests/fixtures/real/wheat_edpie/expected/viz/cylinder/summary.json
@@ -1,7 +1,7 @@
 {
   "pipeline_name": "viz_cylinder_edpie",
   "version": "1.0",
-  "run_directory": "pipeline_runs\\2026-02-12_191823\\viz\\viz_cylinder_edpie_20260212_192902",
+  "run_directory": "pipeline_runs/2026-02-12_191823/viz/viz_cylinder_edpie_20260212_192902",
   "data_file": "pipeline_runs/2026-02-12_191823/qc/cylinder_edpie_qc_20260212_192028/10_final_data.csv",
   "n_samples": 123,
   "n_traits_initial": 588,

--- a/tests/test_no_path_prestringify.py
+++ b/tests/test_no_path_prestringify.py
@@ -1,0 +1,111 @@
+r"""Source guard: pipeline steps must not pre-stringify paths (issue #157).
+
+Producers store ``Path`` objects in ``files_generated`` and path-valued
+``metadata`` entries and let the central serializers normalize once
+(``convert_to_json_serializable`` for ``pipeline_summary.json``; the
+``save_json`` ``default`` hook for standalone manifests). A producer-side
+``str(path)`` defeats that normalization and bakes in backslash separators on
+Windows. This AST guard fails if the anti-pattern is reintroduced, so the fix
+can't silently regress in a future step. It is multi-line aware (unlike a
+line-oriented grep), so it catches ``files_generated=[\n    str(x),\n]`` too.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+STEPS_DIR = Path(__file__).resolve().parents[1] / (
+    "src/sleap_roots_analyze/pipeline/steps"
+)
+
+# Dict keys / subscript targets whose values are filesystem paths. A ``str()``
+# wrapping the value of one of these is the #157 anti-pattern. Error-message and
+# data-value keys (``error``, ``genotype``, ...) are intentionally excluded.
+_PATH_KEY_HINTS = (
+    "path",
+    "csv",
+    "json",
+    "plot",
+    "file",
+    "files",
+    "dir",
+    "directory",
+    "output",
+    "barplot",
+    "dashboard",
+)
+
+
+def _is_str_call(node: ast.AST) -> bool:
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "str"
+    )
+
+
+def _looks_like_path_key(key: ast.AST) -> bool:
+    if isinstance(key, ast.Constant) and isinstance(key.value, str):
+        low = key.value.lower()
+        return any(hint in low for hint in _PATH_KEY_HINTS)
+    return False
+
+
+def _step_files() -> list[Path]:
+    return sorted(p for p in STEPS_DIR.glob("*.py") if p.name != "__init__.py")
+
+
+@pytest.mark.parametrize("path", _step_files(), ids=lambda p: p.name)
+def test_no_str_prestringify_of_paths(path: Path) -> None:
+    """No ``str(...)`` feeds ``files_generated`` or a path-valued ``metadata`` key."""
+    tree = ast.parse(path.read_text(), filename=str(path))
+    violations: list[str] = []
+
+    for node in ast.walk(tree):
+        # files_generated=[...] / files_generated=[..., str(x)]
+        if isinstance(node, ast.keyword) and node.arg == "files_generated":
+            for inner in ast.walk(node.value):
+                if _is_str_call(inner):
+                    violations.append(f"files_generated keyword at line {inner.lineno}")
+
+        # files_generated.append(str(x))
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "append"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "files_generated"
+        ):
+            for inner in ast.walk(node):
+                if _is_str_call(inner):
+                    violations.append(f"files_generated.append at line {node.lineno}")
+
+        # {"...path...": str(x)} dict literal entries with a path-ish key
+        if isinstance(node, ast.Dict):
+            for key, value in zip(node.keys, node.values):
+                if (
+                    key is not None
+                    and _looks_like_path_key(key)
+                    and _is_str_call(value)
+                ):
+                    violations.append(
+                        f"dict key {ast.literal_eval(key)!r} at line {value.lineno}"
+                    )
+
+        # metadata["...path..."] = str(x) subscript assignments
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Subscript)
+                    and _looks_like_path_key(target.slice)
+                    and _is_str_call(node.value)
+                ):
+                    violations.append(f"subscript assign at line {node.lineno}")
+
+    assert not violations, (
+        f"{path.name}: pre-stringified path(s) found — store Path, not str(path). "
+        f"Sites: {violations}"
+    )

--- a/tests/test_no_path_prestringify.py
+++ b/tests/test_no_path_prestringify.py
@@ -8,6 +8,11 @@ Producers store ``Path`` objects in ``files_generated`` and path-valued
 Windows. This AST guard fails if the anti-pattern is reintroduced, so the fix
 can't silently regress in a future step. It is multi-line aware (unlike a
 line-oriented grep), so it catches ``files_generated=[\n    str(x),\n]`` too.
+
+It is a best-effort tripwire for accidental reintroduction, not a proof: it can
+be evaded by aliasing ``str``, f-strings, ``os.fspath``, or ``"%s" %``. It is
+also intentionally strict inside ``files_generated`` (any ``str(...)`` there is
+flagged, including ``str(count)``), since that list should only hold paths.
 """
 
 from __future__ import annotations
@@ -55,13 +60,21 @@ def _looks_like_path_key(key: ast.AST) -> bool:
 
 
 def _step_files() -> list[Path]:
-    return sorted(p for p in STEPS_DIR.glob("*.py") if p.name != "__init__.py")
+    # rglob so a future steps/<subdir>/*.py is not silently un-guarded.
+    return sorted(p for p in STEPS_DIR.rglob("*.py") if p.name != "__init__.py")
+
+
+def test_step_files_discovered() -> None:
+    """Guard against a vacuous pass if discovery ever finds nothing."""
+    assert len(_step_files()) >= 13
 
 
 @pytest.mark.parametrize("path", _step_files(), ids=lambda p: p.name)
 def test_no_str_prestringify_of_paths(path: Path) -> None:
     """No ``str(...)`` feeds ``files_generated`` or a path-valued ``metadata`` key."""
-    tree = ast.parse(path.read_text(), filename=str(path))
+    # Explicit UTF-8: source files contain non-ASCII (emoji, ρ), and Path.read_text
+    # defaults to the locale codec (cp1252 on Windows) which raises on them (#157).
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
     violations: list[str] = []
 
     for node in ast.walk(tree):

--- a/tests/test_pipeline_core.py
+++ b/tests/test_pipeline_core.py
@@ -1,5 +1,6 @@
 """Tests for pipeline core abstractions (BaseStep, StepResult)."""
 
+import json
 from pathlib import Path
 
 import pandas as pd
@@ -107,6 +108,29 @@ def test_base_step_save_json(tmp_path):
     assert loaded["key1"] == "value1"
     assert loaded["key2"] == 42
     assert loaded["key3"] == [1, 2, 3]
+
+
+def test_base_step_save_json_normalizes_paths_to_posix(tmp_path):
+    r"""save_json writes Path values as POSIX (forward-slash) on every OS (#157).
+
+    Uses PureWindowsPath so the Windows-separator path is exercised on any host:
+    ``str(...)`` would bake in ``a\b.png`` while the default hook must emit ``a/b.png``.
+    """
+    from pathlib import PureWindowsPath
+
+    step = ConcreteStep()
+    data = {
+        "files": [PureWindowsPath("figs", "a.png")],
+        "run_directory": PureWindowsPath("out", "run_01"),
+    }
+
+    output_path = step.save_json(data, "manifest.json", tmp_path)
+    text = output_path.read_text(encoding="utf-8")
+
+    assert "\\" not in text
+    loaded = json.loads(text)
+    assert loaded["files"] == ["figs/a.png"]
+    assert loaded["run_directory"] == "out/run_01"
 
 
 def test_base_step_must_implement_execute():

--- a/tests/test_result_serialization.py
+++ b/tests/test_result_serialization.py
@@ -236,11 +236,17 @@ def test_windows_paths_normalize_to_posix_on_any_os():
         files_generated=[win],
         metadata={"dashboard_path": win, "reps_plot": None},
     )
-    summary = PipelineSummary(pipeline_name="viz", steps=[step])
+    summary = PipelineSummary(
+        pipeline_name="viz",
+        steps=[step],
+        output_directory=PureWindowsPath("pipeline_runs", "viz_01"),
+    )
     loaded = json.loads(summary.to_json())
 
     assert loaded["steps"][0]["files_generated"] == ["out/sub/a.csv"]
     assert loaded["steps"][0]["metadata"]["dashboard_path"] == "out/sub/a.csv"
+    # output_directory normalizes too (regression for #157 review item 2).
+    assert loaded["output_directory"] == "pipeline_runs/viz_01"
     # An optional path that was None survives as JSON null, not "None".
     assert loaded["steps"][0]["metadata"]["reps_plot"] is None
     # No backslash leaked anywhere in the serialized manifest.

--- a/tests/test_result_serialization.py
+++ b/tests/test_result_serialization.py
@@ -36,7 +36,7 @@ import json
 import math
 import re
 from dataclasses import asdict, dataclass, field, is_dataclass
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 from typing import Any, Callable, Dict, List
 
 import numpy as np
@@ -215,6 +215,36 @@ def test_pipeline_summary_round_trips():
     assert loaded["steps"][0]["files_generated"] == ["out/a.csv"]
     assert loaded["steps"][0]["metadata"]["n_rows"] == 10
     assert loaded["config"]["seed"] == 42
+
+
+def test_windows_paths_normalize_to_posix_on_any_os():
+    r"""Path normalization is OS-independent: a Windows-style path serializes to POSIX.
+
+    Regression for #157. On Linux/macOS a producer's old ``str(Path("out/a.csv"))``
+    already yields ``"out/a.csv"``, so the manifest looks fine and only Windows CI
+    catches the backslash bug. ``PureWindowsPath`` lets us exercise the Windows
+    separator on any host: ``str(...)`` would bake in ``out\\a.csv``, while the
+    serializer must emit ``out/a.csv`` via ``as_posix()``. The producer-side fix is
+    to store the path object (here a ``PureWindowsPath``) and never ``str()`` it.
+    """
+    win = PureWindowsPath("out", "sub", "a.csv")
+    assert str(win) == "out\\sub\\a.csv"  # the bug, if a producer pre-stringifies
+
+    step = StepSummary(
+        name="viz",
+        status="success",
+        files_generated=[win],
+        metadata={"dashboard_path": win, "reps_plot": None},
+    )
+    summary = PipelineSummary(pipeline_name="viz", steps=[step])
+    loaded = json.loads(summary.to_json())
+
+    assert loaded["steps"][0]["files_generated"] == ["out/sub/a.csv"]
+    assert loaded["steps"][0]["metadata"]["dashboard_path"] == "out/sub/a.csv"
+    # An optional path that was None survives as JSON null, not "None".
+    assert loaded["steps"][0]["metadata"]["reps_plot"] is None
+    # No backslash leaked anywhere in the serialized manifest.
+    assert "\\" not in summary.to_json()
 
 
 # --- the gate over the registered analytical surface --------------------------

--- a/tests/test_step_calculate_cross_platform_correlations.py
+++ b/tests/test_step_calculate_cross_platform_correlations.py
@@ -255,7 +255,7 @@ def test_calculate_cross_platform_correlations_step_files_generated(
     # Check that correlation CSV was created
     corr_csv = tmp_path / "cross_platform_correlations.csv"
     assert corr_csv.exists()
-    assert str(corr_csv) in result.files_generated
+    assert corr_csv in result.files_generated
 
     # Verify CSV contents
     saved_df = pd.read_csv(corr_csv)

--- a/tests/test_step_load_cross_platform_data.py
+++ b/tests/test_step_load_cross_platform_data.py
@@ -510,7 +510,7 @@ def test_load_cross_platform_data_step_files_generated(cross_platform_config, tm
     for expected_file in expected_files:
         file_path = tmp_path / expected_file
         assert file_path.exists(), f"Expected file {expected_file} not found"
-        assert str(file_path) in result.files_generated
+        assert file_path in result.files_generated
 
 
 def test_load_cross_platform_data_step_alignment_summary(

--- a/tests/test_step_visualize_cross_platform.py
+++ b/tests/test_step_visualize_cross_platform.py
@@ -162,7 +162,7 @@ def test_visualize_cross_platform_step_summary_plot(
     # Check for summary plot
     summary_plot = tmp_path / "cross_platform_correlation_summary.png"
     assert summary_plot.exists()
-    assert str(summary_plot) in result.files_generated
+    assert summary_plot in result.files_generated
 
 
 def test_visualize_cross_platform_step_joint_plots(
@@ -589,7 +589,7 @@ def test_representative_heatmap_generated_when_clustering_enabled(tmp_path):
     assert (
         heatmap_file.exists()
     ), "Representative heatmap should be created when clustering is enabled"
-    assert str(heatmap_file) in result.files_generated
+    assert heatmap_file in result.files_generated
 
 
 def test_representative_heatmap_not_generated_when_clustering_disabled(tmp_path):


### PR DESCRIPTION
Closes #157.

## Why

PR #156's cross-OS serialization round-trip gate caught a latent bug: pipeline steps hand-stringify paths with `str(path)` before they reach the central serializer, so on Windows a serialized path becomes `out\a.csv` instead of `out/a.csv`. #156 fixed only one site; the same anti-pattern was repeated across ~21 sites in the pipeline steps. Each pre-stringification **defeats** `convert_to_json_serializable`'s `Path → as_posix()` normalization and bakes in `\` on Windows, in the `files_generated` and `metadata` fields of `pipeline_summary.json` (the per-run provenance manifest) and in the standalone `*_manifest.json` files.

## What changed

- **Store bare `Path` at all producer sites** (13 step files) — let the serializers normalize once, centrally.
- **Tighten the type** `files_generated: List[str | Path]` → `List[Path]` in `core.py`, `summary.py`, `task.py` so the union can't re-invite divergence. (`List` is invariant, so this lands with the producer edits in one commit.)
- **Fixed a second serialization sink** the issue didn't call out: `BaseStep.save_json` used `json.dump(..., default=str)`, which would re-bake backslashes for a raw `Path` in the standalone manifests. The `default` hook now normalizes **only** `Path` via `as_posix()` and keeps `str()` for everything else — so the only behavior change is OS-independent paths (no numpy/datetime regression, which a full switch to `convert_to_json_serializable` would have risked against the golden-template tests).
- **Generalized** `convert_to_json_serializable`'s `isinstance(obj, Path)` → `PurePath` (a safe superset — every `Path` is a `PurePath`) so an OS-independent `PureWindowsPath` regression test is possible.

## Tests

- Fixed 4 existing assertions that did exact `str(x) in result.files_generated` membership (these break at runtime once elements are `Path`); they now compare on `Path`, which also enforces `Path` storage.
- Added an **OS-independent** cross-OS test using `PureWindowsPath` (the bug is invisible on Linux/macOS because `str(Path("out/a.csv"))` already yields `out/a.csv` there) plus a `None`-path assertion, to `tests/test_result_serialization.py`.
- Added `tests/test_no_path_prestringify.py` — an **AST source guard** (multi-line aware, unlike a grep) that fails if a `str(path)` is reintroduced into a step's `files_generated`/`metadata`.

## Docs

CHANGELOG `Fixed` entry, the producer-side "store `Path`, never `str(path)`" rule in `docs/reproducibility.md` (the gate's named source of truth), a pointer in `openspec/project.md`, and an updated `summary.py` comment reflecting the now-systemic contract.

## Verification

- `tests/test_result_serialization.py` (the cross-OS `serialization-gate`) + the new guard green.
- All directly-affected suites green: cross-platform steps, trait-redundancy, dashboards/interactive/static, heritability, merge, depth profiles, provenance, golden templates, reproduction fixtures.
- `ruff` + `black` clean; `mypy` shows **no new errors** from the type change (only pre-existing pandas-stub/`image_links` baseline entries).
- Confirmed no committed golden fixture asserts on or carries backslash serialized paths, so the #146 reproduction fixtures are undisturbed.

## ⚠️ Merge-order note

The mypy baseline gate is on the still-open #158, not `main`. **Land this before #158** (its baseline then freezes with the 19 `files_generated` invariance entries already resolved). If #158 merges first, resync `.mypy-baseline.txt` in this PR — CI runs `mypy-baseline filter` without `--allow-unsynced`, so a stale baseline fails the gate.

This PR follows an OpenSpec change (`openspec/changes/refactor-path-serialization/`) reviewed via the review-openspec subagent team.

Related: #156, #133.

🤖 Generated with [Claude Code](https://claude.com/claude-code)