### PR TITLE
fix(qc): align cleanup defaults with canonical config

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- `apply_data_cleanup_filters` bare-default thresholds tightened to the canonical
+  QC values — `max_nans_per_trait` `0.3 → 0.2` and `max_nans_per_sample`
+  `0.2 → 0.0` — so they equal `CleanupConfig()`'s defaults (with `max_nan_fraction`
+  ↔ `max_nans_per_sample` name mapping). The function signature is now the single
+  source of truth for canonical cleanup, and `clean_traits_for_analysis` inherits
+  it instead of carrying a hardcoded copy (#167). **Behavior note:** code calling
+  `apply_data_cleanup_filters` with the *bare* defaults now cleans more strictly —
+  `max_nans_per_sample=0.0` drops every sample that still has any NaN in a surviving
+  trait, which can remove more plants than before. The QC pipeline
+  (`CleanupTraitsStep` passes explicit `config.cleanup.*`) and the
+  `clean_traits_for_analysis` entry point (already pinned to `0.2`/`0.0` since #164)
+  are reproducibility-neutral — their effective thresholds are unchanged.
+
 ## [0.1.0a3] - 2026-06-24 (Pre-release)
 
 ### Added

--- a/src/sleap_roots_analyze/data_cleanup.py
+++ b/src/sleap_roots_analyze/data_cleanup.py
@@ -650,8 +650,8 @@ def apply_data_cleanup_filters(
     df: pd.DataFrame,
     trait_cols: List[str],
     max_zeros_per_trait: float = 0.5,
-    max_nans_per_trait: float = 0.3,
-    max_nans_per_sample: float = 0.2,
+    max_nans_per_trait: float = 0.2,
+    max_nans_per_sample: float = 0.0,
     min_samples_per_trait: int = 10,
     barcode_col: str = "Barcode",
     genotype_col: str = "geno",
@@ -665,13 +665,25 @@ def apply_data_cleanup_filters(
     3. Remove samples with many NaNs
     4. Remove traits with insufficient samples
 
+    The signature defaults are the **QC pipeline's canonical** cleanup thresholds:
+    they equal ``CleanupConfig()``'s defaults (with ``max_nans_per_sample`` mapping
+    to ``CleanupConfig.max_nan_fraction``), so every default-using caller cleans the
+    same way the pipeline does. A drift guard
+    (``tests/test_data_cleanup.py::TestCanonicalDefaultDriftGuard``) asserts this
+    equality so the two cannot silently diverge (#167).
+
     Args:
         df: Original dataframe
         trait_cols: List of trait column names
-        max_zeros_per_trait: Maximum fraction of zeros allowed per trait (0-1)
-        max_nans_per_trait: Maximum fraction of NaNs allowed per trait (0-1)
-        max_nans_per_sample: Maximum fraction of NaNs allowed per sample (0-1)
-        min_samples_per_trait: Minimum number of valid samples required per trait
+        max_zeros_per_trait: Maximum fraction of zeros allowed per trait (0-1).
+            Default ``0.5`` (canonical QC).
+        max_nans_per_trait: Maximum fraction of NaNs allowed per trait (0-1).
+            Default ``0.2`` (canonical QC; drops NaN-heavier traits sooner).
+        max_nans_per_sample: Maximum fraction of NaNs allowed per sample (0-1).
+            Default ``0.0`` (canonical QC; drops any sample that still has *any*
+            NaN in a surviving trait).
+        min_samples_per_trait: Minimum number of valid samples required per trait.
+            Default ``10`` (canonical QC).
         barcode_col: Name of the barcode/plant ID column (default: "Barcode")
         genotype_col: Name of the genotype column (default: "geno")
         replicate_col: Name of the replicate column if present (default: "rep")
@@ -925,10 +937,10 @@ def clean_traits_for_analysis(
           (``max_zeros_per_trait=0.5``, ``max_nans_per_trait=0.2``,
           ``max_nans_per_sample=0.0``, ``min_samples_per_trait=10``), so the
           analysis-ready frame matches what the QC pipeline produces rather than a
-          looser clean. (``apply_data_cleanup_filters``'s own signature defaults are
-          looser for two of these — ``max_nans_per_trait=0.3``,
-          ``max_nans_per_sample=0.2``; aligning them is tracked in #167.) Caller
-          kwargs override; the effective thresholds are recorded in
+          looser clean. These are inherited directly from
+          ``apply_data_cleanup_filters``'s signature defaults, which were aligned to
+          the canonical QC values in #167 (so there is no separate copy to drift).
+          Caller kwargs override; the effective thresholds are recorded in
           ``cleanup_log["effective_thresholds"]`` and logged at INFO.
         - This entry point does **NOT** apply trait-name sanitization
           (``sanitize_trait_names``) or column reordering that
@@ -1008,14 +1020,12 @@ def clean_traits_for_analysis(
             "trait_cols explicitly or check the metadata column names."
         )
 
-    # Resolve effective thresholds. The entry point defaults to the QC pipeline's
-    # canonical cleaning (DataConfig in pipeline/config/components.py) so the
-    # analysis-ready frame it hands to PCA/UMAP equals what the QC pipeline would
-    # produce, not a looser clean. Two values differ from apply_data_cleanup_filters'
-    # own (looser) signature defaults and are pinned here; the rest are inherited
-    # from the signature. Aligning the shared function's own defaults is a broader,
-    # separate change (tracked in #167). Caller-passed kwargs still override.
-    _QC_DEFAULTS = {"max_nans_per_trait": 0.2, "max_nans_per_sample": 0.0}
+    # Resolve effective thresholds. The entry point inherits its defaults directly
+    # from apply_data_cleanup_filters' signature, which now *is* the QC pipeline's
+    # canonical cleaning (its defaults equal CleanupConfig()'s; aligned in #167). So
+    # the analysis-ready frame it hands to PCA/UMAP equals what the QC pipeline would
+    # produce, not a looser clean — with no separate hardcoded copy to drift. Caller-
+    # passed kwargs still override.
     sig = inspect.signature(apply_data_cleanup_filters)
     threshold_names = (
         "max_zeros_per_trait",
@@ -1024,9 +1034,7 @@ def clean_traits_for_analysis(
         "min_samples_per_trait",
     )
     thresholds = {
-        name: cleanup_kwargs.pop(
-            name, _QC_DEFAULTS.get(name, sig.parameters[name].default)
-        )
+        name: cleanup_kwargs.pop(name, sig.parameters[name].default)
         for name in threshold_names
     }
 

--- a/src/sleap_roots_analyze/data_cleanup.py
+++ b/src/sleap_roots_analyze/data_cleanup.py
@@ -1039,10 +1039,10 @@ def clean_traits_for_analysis(
     )
     # Guard against a renamed signature parameter: surface the drift here with a
     # clear message instead of as an opaque KeyError in the comprehension below.
-    missing = set(threshold_names) - set(sig.parameters)
-    assert not missing, (
+    missing_params = set(threshold_names) - set(sig.parameters)
+    assert not missing_params, (
         "threshold_names out of sync with apply_data_cleanup_filters signature: "
-        f"{sorted(missing)}"
+        f"{sorted(missing_params)}"
     )
     thresholds = {
         name: cleanup_kwargs.pop(name, sig.parameters[name].default)

--- a/src/sleap_roots_analyze/data_cleanup.py
+++ b/src/sleap_roots_analyze/data_cleanup.py
@@ -258,7 +258,11 @@ def remove_nan_samples(
     Args:
         df: Original dataframe
         trait_cols: List of trait columns to check for NaN
-        max_nan_fraction: Maximum fraction of NaN allowed per sample (0-1)
+        max_nan_fraction: Maximum fraction of NaN allowed per sample (0-1). This
+            standalone default (0.2) is intentionally looser than the canonical QC
+            per-sample budget (0.0, ``CleanupConfig.max_nan_fraction``); the
+            orchestrator ``apply_data_cleanup_filters`` always passes an explicit
+            value down, so this default only affects direct callers of this helper.
         barcode_col: Name of the barcode/plant ID column (default: "Barcode")
         genotype_col: Name of the genotype column (default: "geno")
         replicate_col: Name of the replicate column if present (default: "rep")
@@ -1032,6 +1036,13 @@ def clean_traits_for_analysis(
         "max_nans_per_trait",
         "max_nans_per_sample",
         "min_samples_per_trait",
+    )
+    # Guard against a renamed signature parameter: surface the drift here with a
+    # clear message instead of as an opaque KeyError in the comprehension below.
+    missing = set(threshold_names) - set(sig.parameters)
+    assert not missing, (
+        "threshold_names out of sync with apply_data_cleanup_filters signature: "
+        f"{sorted(missing)}"
     )
     thresholds = {
         name: cleanup_kwargs.pop(name, sig.parameters[name].default)

--- a/src/sleap_roots_analyze/pipeline/config/components.py
+++ b/src/sleap_roots_analyze/pipeline/config/components.py
@@ -57,13 +57,14 @@ class CleanupConfig:
 
     Attributes:
         max_nan_fraction: Max fraction of NaN values per sample (0.0-1.0).
-            Samples exceeding this will be removed. Recommended: 0.25
+            Samples exceeding this will be removed. Canonical QC default: 0.0
+            (drops any sample that still has a NaN in a surviving trait).
         max_zeros_per_trait: Max fraction of zero values per trait (0.0-1.0).
-            Traits exceeding this will be removed. Recommended: 0.5
+            Traits exceeding this will be removed. Canonical QC default: 0.5.
         max_nans_per_trait: Max fraction of NaN values per trait (0.0-1.0).
-            Traits exceeding this will be removed. Recommended: 0.2-0.3
+            Traits exceeding this will be removed. Canonical QC default: 0.2.
         min_samples_per_trait: Minimum number of valid samples required per trait.
-            Traits with fewer samples will be removed. Recommended: 10
+            Traits with fewer samples will be removed. Canonical QC default: 10.
         custom_replacements: Optional dict mapping old terms to new terms for
             domain-specific trait name terminology (e.g., {"crown": "seminal"} to
             replace "crown" with "seminal" in wheat trait names). Applied during

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -642,7 +642,11 @@ def create_trait_eda_plots(
     Args:
         df: DataFrame with trait data
         trait_cols: List of trait column names
-        thresholds: Dictionary with nan and zero thresholds (outlier ignored as it's not used for trait removal)
+        thresholds: Dictionary of cleanup thresholds. Recognized keys: ``"nan"``
+            (max NaN fraction per trait), ``"zero"`` (max zero fraction per trait),
+            ``"sample"`` (max NaN fraction per sample), and ``"outlier"`` (plotted
+            reference line only; not used for trait removal). Missing keys fall back
+            to the canonical QC defaults (``nan=0.2``, ``zero=0.5``, ``sample=0.0``).
         cleanup_log: Optional cleanup log from apply_data_cleanup_filters with actual removed traits
         min_samples_per_trait: Minimum number of valid samples required per trait
 
@@ -721,11 +725,11 @@ def create_trait_eda_plots(
     # NaN fraction
     sns.barplot(x="Trait", y="Fraction_NaNs", hue="Prefix", data=eda_df, ax=axes[0])
     axes[0].axhline(
-        y=thresholds.get("nan", 0.3),
+        y=thresholds.get("nan", 0.2),
         color="red",
         linestyle="--",
         alpha=0.7,
-        label=f"Threshold ({thresholds.get('nan', 0.3)})",
+        label=f"Threshold ({thresholds.get('nan', 0.2)})",
     )
     axes[0].set_title("Fraction of NaN Values per Trait")
     axes[0].tick_params(labelbottom=False)
@@ -826,12 +830,17 @@ def create_trait_eda_plots(
     # If no cleanup_log provided, use apply_data_cleanup_filters to determine what WOULD be removed
     # This ensures consistency with the actual pipeline behavior
     if not cleanup_log:
-        # Run apply_data_cleanup_filters to see what would be removed
+        # Run apply_data_cleanup_filters to see what would be removed. Fallbacks are
+        # the canonical QC defaults (#167) so a standalone caller that omits a
+        # threshold previews the same cleaning the pipeline performs. max_nans_per_sample
+        # is passed explicitly (canonical 0.0) rather than left to the function default,
+        # since sample removal feeds the subsequent low-sample trait removal.
         _, simulated_log = apply_data_cleanup_filters(
             df.copy(),
             trait_cols,
             max_zeros_per_trait=thresholds.get("zero", 0.5),
-            max_nans_per_trait=thresholds.get("nan", 0.3),
+            max_nans_per_trait=thresholds.get("nan", 0.2),
+            max_nans_per_sample=thresholds.get("sample", 0.0),
             min_samples_per_trait=min_samples_per_trait,
         )
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1722,7 +1722,7 @@ def viz_eda_thresholds():
         dict: Thresholds for NaN, zero, and outlier fractions
     """
     return {
-        "nan": 0.3,  # 30% maximum NaN
+        "nan": 0.2,  # 20% maximum NaN (canonical QC default)
         "zero": 0.5,  # 50% maximum zeros
         "outlier": 0.1,  # 10% maximum outliers (though not used for trait removal)
     }

--- a/tests/test_data_cleanup.py
+++ b/tests/test_data_cleanup.py
@@ -1937,8 +1937,12 @@ class TestCanonicalDefaultDriftGuard:
     def test_clean_traits_entry_point_defaults_match_cleanup_config(self):
         """clean_traits_for_analysis (no overrides) records the canonical thresholds.
 
-        Proves the public entry point inherits the corrected defaults rather than a
-        separate hardcoded copy.
+        This is a recorded-thresholds proxy, not a cleaned-frame parity check: it
+        asserts the entry point's ``effective_thresholds`` inherit the canonical
+        values from the helper signature (no separate hardcoded copy). Frame-level
+        parity with the pipeline is intentionally not asserted — ``CleanupTraitsStep``
+        also runs trait-name sanitization and the entry point adds an extra
+        ``dropna``, so the frames are deliberately not byte-equivalent.
         """
         from sleap_roots_analyze.data_cleanup import clean_traits_for_analysis
 

--- a/tests/test_data_cleanup.py
+++ b/tests/test_data_cleanup.py
@@ -1810,8 +1810,10 @@ class TestModularCleanupFunctions:
         """Edge case: max_nans_per_sample=0.0 removes any sample with at least one NaN."""
         from sleap_roots_analyze.data_cleanup import apply_data_cleanup_filters
 
-        # Use enough samples so the trait with 1 NaN is below the trait-level threshold
-        # (1/4 = 0.25 < default max_nans_per_trait=0.3), so the trait is kept.
+        # trait1 has 1 NaN out of 4 samples (1/4 = 0.25). Pass max_nans_per_trait=0.3
+        # explicitly so the trait is kept (0.25 < 0.3) and the sample-level filter is
+        # what we exercise; the canonical default (0.2) would drop the trait first,
+        # leaving no NaN sample to remove and defeating the test's intent.
         df = pd.DataFrame(
             {
                 "Barcode": ["b1", "b2", "b3", "b4"],
@@ -1824,6 +1826,7 @@ class TestModularCleanupFunctions:
         df_clean, cleanup_log = apply_data_cleanup_filters(
             df,
             trait_cols=["trait1", "trait2"],
+            max_nans_per_trait=0.3,  # keep trait1 (0.25 NaN); isolate sample-level filter
             max_nans_per_sample=0.0,
             min_samples_per_trait=1,  # Low threshold
         )
@@ -1883,6 +1886,82 @@ class TestModularCleanupFunctions:
             "rep" in msg.lower() or "replicate" in msg.lower()
             for msg in caplog.messages
         ), f"Expected warning about missing replicate column, got: {caplog.messages}"
+
+
+class TestCanonicalDefaultDriftGuard:
+    """Guard the canonical QC cleanup defaults against silent drift (#167).
+
+    ``apply_data_cleanup_filters``'s signature defaults are the single source of
+    truth for "canonical QC cleanup". ``clean_traits_for_analysis`` inherits them,
+    and ``CleanupConfig()`` must encode the same values (with the
+    ``max_nan_fraction`` <-> ``max_nans_per_sample`` name mapping). If any of these
+    drift apart, a default-using caller would silently clean differently from the
+    pipeline.
+    """
+
+    def _canonical_from_config(self):
+        from sleap_roots_analyze.pipeline.config import CleanupConfig
+
+        cfg = CleanupConfig()
+        # CleanupConfig.max_nan_fraction is the per-sample NaN budget; the function
+        # exposes the same knob as max_nans_per_sample.
+        return {
+            "max_zeros_per_trait": cfg.max_zeros_per_trait,
+            "max_nans_per_trait": cfg.max_nans_per_trait,
+            "max_nans_per_sample": cfg.max_nan_fraction,
+            "min_samples_per_trait": cfg.min_samples_per_trait,
+        }
+
+    def test_apply_filters_defaults_match_cleanup_config(self):
+        """apply_data_cleanup_filters' signature defaults == CleanupConfig() defaults."""
+        import inspect
+
+        from sleap_roots_analyze.data_cleanup import apply_data_cleanup_filters
+
+        canonical = self._canonical_from_config()
+        sig = inspect.signature(apply_data_cleanup_filters)
+        actual = {name: sig.parameters[name].default for name in canonical}
+        assert actual == canonical, (
+            "apply_data_cleanup_filters signature defaults drifted from "
+            f"CleanupConfig (#167): {actual} != {canonical}"
+        )
+        # Pin the literal canonical values so an in-tandem edit to *both* layers
+        # (which would keep them equal to each other) still trips this guard.
+        assert canonical == {
+            "max_zeros_per_trait": 0.5,
+            "max_nans_per_trait": 0.2,
+            "max_nans_per_sample": 0.0,
+            "min_samples_per_trait": 10,
+        }
+
+    def test_clean_traits_entry_point_defaults_match_cleanup_config(self):
+        """clean_traits_for_analysis (no overrides) records the canonical thresholds.
+
+        Proves the public entry point inherits the corrected defaults rather than a
+        separate hardcoded copy.
+        """
+        from sleap_roots_analyze.data_cleanup import clean_traits_for_analysis
+
+        canonical = self._canonical_from_config()
+        # Clean fixture: 12 samples, 2 non-constant traits, no NaN/zeros, so nothing
+        # is filtered and the recorded effective thresholds reflect the defaults.
+        n = 12
+        df = pd.DataFrame(
+            {
+                "Barcode": [f"b{i}" for i in range(n)],
+                "geno": ["A", "B"] * (n // 2),
+                "rep": list(range(n)),
+                "trait1": [float(i + 1) for i in range(n)],
+                "trait2": [float(2 * i + 1) for i in range(n)],
+            }
+        )
+        _, _, cleanup_log = clean_traits_for_analysis(
+            df, trait_cols=["trait1", "trait2"]
+        )
+        assert cleanup_log["effective_thresholds"] == canonical, (
+            "clean_traits_for_analysis default thresholds drifted from CleanupConfig "
+            f"(#167): {cleanup_log['effective_thresholds']} != {canonical}"
+        )
 
 
 class TestInspectNanSamples:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -956,6 +956,49 @@ class TestCreateTraitEDAPlots:
         for fig in figures.values():
             plt.close(fig)
 
+    def test_fallback_thresholds_are_canonical_when_keys_omitted(
+        self, viz_eda_sample_data
+    ):
+        """Key-less thresholds + cleanup_log=None hit the canonical fallbacks (#167).
+
+        When the thresholds dict omits "nan"/"sample" and no cleanup_log is given,
+        create_trait_eda_plots falls back to the canonical QC defaults: the NaN
+        reference line and the simulate-branch cleanup use max_nans_per_trait=0.2
+        (not the retired 0.3) and max_nans_per_sample=0.0. This guards the fallback
+        paths the rest of the suite skips (viz_eda_thresholds always passes "nan").
+        """
+        trait_cols = ["trait_good", "trait_high_nan", "trait_high_zero"]
+        # Deliberately omit "nan" and "sample" so the internal fallbacks are used.
+        thresholds = {"zero": 0.5, "outlier": 0.1}
+
+        figures = create_trait_eda_plots(
+            viz_eda_sample_data,
+            trait_cols,
+            thresholds,
+            cleanup_log=None,  # force the simulate branch
+        )
+
+        assert isinstance(figures, dict)
+        assert "trait_eda_overview" in figures
+
+        # The NaN-fraction subplot (axes[0]) draws a horizontal reference line at the
+        # canonical 0.2 fallback, never the retired 0.3.
+        nan_axis = figures["trait_eda_overview"].axes[0]
+        horizontal_ys = [
+            float(line.get_ydata()[0])
+            for line in nan_axis.lines
+            if len(line.get_ydata()) and len(set(line.get_ydata())) == 1
+        ]
+        assert any(abs(y - 0.2) < 1e-9 for y in horizontal_ys), (
+            f"expected canonical 0.2 NaN threshold line; got {horizontal_ys}"
+        )
+        assert all(abs(y - 0.3) > 1e-9 for y in horizontal_ys), (
+            f"retired 0.3 fallback still present: {horizontal_ys}"
+        )
+
+        for fig in figures.values():
+            plt.close(fig)
+
     def test_with_extreme_data(self, viz_eda_data_with_extremes, viz_eda_thresholds):
         """Test EDA plots with extreme data patterns."""
         trait_cols = [

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -989,12 +989,12 @@ class TestCreateTraitEDAPlots:
             for line in nan_axis.lines
             if len(line.get_ydata()) and len(set(line.get_ydata())) == 1
         ]
-        assert any(abs(y - 0.2) < 1e-9 for y in horizontal_ys), (
-            f"expected canonical 0.2 NaN threshold line; got {horizontal_ys}"
-        )
-        assert all(abs(y - 0.3) > 1e-9 for y in horizontal_ys), (
-            f"retired 0.3 fallback still present: {horizontal_ys}"
-        )
+        assert any(
+            abs(y - 0.2) < 1e-9 for y in horizontal_ys
+        ), f"expected canonical 0.2 NaN threshold line; got {horizontal_ys}"
+        assert all(
+            abs(y - 0.3) > 1e-9 for y in horizontal_ys
+        ), f"retired 0.3 fallback still present: {horizontal_ys}"
 
         for fig in figures.values():
             plt.close(fig)


### PR DESCRIPTION
Aligns the shared data-cleanup thresholds with the canonical QC config so every default-using caller cleans the same way the pipeline does. Closes #167.

## Changes
- **`apply_data_cleanup_filters` now uses the `CleanupConfig` defaults.** Signature defaults changed `max_nans_per_trait` 0.3 → 0.2 and `max_nans_per_sample` 0.2 → 0.0 (the other two already matched), so they equal `CleanupConfig()` with the `max_nan_fraction` ↔ `max_nans_per_sample` name mapping.
- **`clean_traits_for_analysis` inherits from the helper signature instead of carrying `_QC_DEFAULTS`.** Dropped the hardcoded `_QC_DEFAULTS = {0.2, 0.0}` copy; it now resolves all four thresholds from `inspect.signature(apply_data_cleanup_filters)`, giving a single source of truth. Behavior is unchanged (still 0.2/0.0).
- **`visualization.py` stale `0.3` fallbacks aligned to `0.2`.** In `create_trait_eda_plots`, the NaN threshold reference line and the simulate-branch `apply_data_cleanup_filters` call now fall back to the canonical 0.2, and `max_nans_per_sample` is passed explicitly (canonical 0.0) instead of relying on the function default.
- **Drift-guard tests prevent future mismatch.** New `TestCanonicalDefaultDriftGuard` asserts both `apply_data_cleanup_filters`'s signature defaults and `clean_traits_for_analysis`'s recorded effective thresholds equal `CleanupConfig()`. One existing test that implicitly relied on the old 0.3 default was made explicit.

## Caller audit (all 3 callers of `apply_data_cleanup_filters`)
- `CleanupTraitsStep` (pipeline) — passes explicit `config.cleanup.*`; unaffected.
- `clean_traits_for_analysis` — now inherits the canonical defaults; behavior unchanged.
- `create_trait_eda_plots` (visualization) — the only caller hard-coding the old 0.3 / implicitly relying on the old per-sample default; now aligned.

## Validation
- Affected suites pass: `test_data_cleanup`, `test_clean_traits_entry_point`, `test_step_cleanup`, `test_step_exploratory_analysis`, `test_visualization`, `test_qc_pipeline`, `test_pipeline_runner_summary`, `test_pipeline_summary_completeness`.
- `ruff check` passes on all changed files.

## Scope
No bloom-mcp changes, no release/version-pin changes, no unrelated reformatting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
