### PR TITLE
feat(#165): public outlier-removal entry point remove_outlier_samples

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -90,8 +90,8 @@ apply_data_cleanup_filters(
     df: pd.DataFrame,
     trait_cols: List[str],
     max_zeros_per_trait: float = 0.5,
-    max_nans_per_trait: float = 0.3,
-    max_nans_per_sample: float = 0.2,
+    max_nans_per_trait: float = 0.2,
+    max_nans_per_sample: float = 0.0,
     min_samples_per_trait: int = 10,
     barcode_col: str = "Barcode",
     genotype_col: str = "geno",
@@ -178,8 +178,8 @@ Validation runs in order: (1) empty input, (2) no NaN in surviving traits,
 > (`max_zeros_per_trait=0.5`, `max_nans_per_trait=0.2`, `max_nans_per_sample=0.0`,
 > `min_samples_per_trait=10`), so the analysis-ready frame matches what the QC
 > pipeline produces rather than a looser clean. (`apply_data_cleanup_filters`' own
-> signature defaults are looser — `max_nans_per_trait=0.3`, `max_nans_per_sample=0.2`;
-> aligning them is tracked in #167.) Caller kwargs override. With
+> signature defaults now equal these canonical values — `max_nans_per_trait=0.2`,
+> `max_nans_per_sample=0.0` — aligned in #167.) Caller kwargs override. With
 > `max_nans_per_sample=0.0`, any sample carrying a NaN in a surviving trait is
 > dropped. Two samples is the runnability floor only.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1041,12 +1041,17 @@ so the trimmed frame stays analysis-ready.
 
 **Warns:**
 - `UserWarning`: when the removed fraction exceeds 0.5 (likely mis-set
-  `contamination`/threshold), and in the `p > n` regime after trimming.
+  `contamination`/threshold), and in the `p > n` regime after trimming. On the
+  Mahalanobis path it also warns on a small sample (`n < 30` — fragile chi-squared
+  tail / covariance) and when the detector's chi-squared goodness-of-fit reports the
+  distributional assumption is violated (so the `chi2_percentile` threshold's meaning
+  is questionable).
 
 **Raises:**
 - `ValueError`: empty input; duplicate columns; explicit `trait_cols`
-  missing/non-numeric; unknown `method`; non-unique index; NaN in trait columns
-  (message points to `clean_traits_for_analysis`); or a detector failure.
+  missing/non-numeric; unknown `method`; unknown / cross-method `**detect_kwargs`
+  for the chosen detector (names the keys + supported set); non-unique index; NaN in
+  trait columns (message points to `clean_traits_for_analysis`); or a detector failure.
 - `OutlierRemovalError` (a `ValueError`): when trimming leaves <2 samples or no
   non-constant trait; carries `outlier_report` as an attribute.
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -979,6 +979,93 @@ Outlier detection using Mahalanobis distance on PCA-transformed data.
 
 ### Functions
 
+#### `remove_outlier_samples`
+
+```python
+remove_outlier_samples(
+    clean_df: pd.DataFrame,
+    trait_cols: Optional[List[str]] = None,
+    *,
+    method: str = "mahalanobis",
+    barcode_col: str = "Barcode",
+    genotype_col: str = "geno",
+    replicate_col: Optional[str] = "rep",
+    random_state: int = 42,
+    **detect_kwargs,
+) -> Tuple[pd.DataFrame, Dict]
+```
+
+Public outlier-removal entry point — the **quality**-step follow-up to
+[`clean_traits_for_analysis`](#clean_traits_for_analysis) (#164). Takes a clean
+(NaN-free) trait table and detects + removes outlier **samples** so PCA / UMAP /
+clustering can optionally run on outlier-trimmed data. Composes the existing
+public primitives — [`detect_outliers_mahalanobis`](#detect_outliers_mahalanobis)
+/ [`detect_outliers_isolation_forest`](#detect_outliers_isolation_forest) for
+detection and [`remove_outliers_from_data`](#remove_outliers_from_data) for row
+removal — and defines no detection/removal logic of its own, so its semantics
+cannot drift from the QC pipeline's outlier steps. Intended chain:
+`clean_traits_for_analysis` → (optional) `remove_outlier_samples` →
+`perform_pca_analysis` / UMAP / clustering.
+
+Enforces, before any detector runs, a **NaN-free** and **unique-index** input
+(both correctness guards for one-to-one index alignment — the detectors run PCA
+which silently drops NaN rows, and removal is label-based). After removal it
+re-applies the #164 readiness gates (≥2 surviving samples, ≥1 non-constant trait)
+so the trimmed frame stays analysis-ready.
+
+> **Note:** the default `method="mahalanobis"` with `chi2_percentile=97.5` trims
+> roughly the top 2.5% of samples *by construction* on a well-fit chi-squared tail
+> — i.e. it removes ~2.5% even on clean data. Tighten `chi2_percentile` or switch
+> to `method="isolation_forest"` with an explicit `contamination` to control this.
+
+**Parameters:**
+- `clean_df`: A clean (NaN-free in trait columns), unique-indexed wide trait table
+  (e.g. the first element returned by `clean_traits_for_analysis`)
+- `trait_cols`: Trait columns to score; inferred via `get_trait_columns` if `None`
+- `method`: `"mahalanobis"` (default) or `"isolation_forest"`; unknown raises
+- `barcode_col` / `genotype_col` / `replicate_col`: metadata columns excluded from
+  inferred traits (`barcode_col` is also read to populate `outlier_barcodes`)
+- `random_state`: Seed forwarded to the detector for reproducibility (default: 42)
+- `**detect_kwargs`: Per-method parameters forwarded to the chosen detector
+  (`contamination` for isolation forest; `chi2_percentile`, `variance_threshold`,
+  `use_chi_squared`, `distance_threshold`, `robust_covariance` for Mahalanobis)
+
+**Returns:**
+- `Tuple[pd.DataFrame, Dict]`: `(trimmed_df, outlier_report)`. `trimmed_df` is
+  `clean_df` with the flagged rows removed (all columns preserved). `outlier_report`
+  is an auditable, JSON-serializable dict: `method`, `method_params`, `random_state`,
+  `n_input_samples`, `n_outliers`, `n_output_samples`, `removal_fraction`,
+  `outlier_indices`, `outlier_barcodes`, `threshold_type`, `threshold_value`,
+  `n_components`, `variance_threshold`, `goodness_of_fit` (the last four are
+  populated for Mahalanobis and `None` for isolation forest).
+
+**Warns:**
+- `UserWarning`: when the removed fraction exceeds 0.5 (likely mis-set
+  `contamination`/threshold), and in the `p > n` regime after trimming.
+
+**Raises:**
+- `ValueError`: empty input; duplicate columns; explicit `trait_cols`
+  missing/non-numeric; unknown `method`; non-unique index; NaN in trait columns
+  (message points to `clean_traits_for_analysis`); or a detector failure.
+- `OutlierRemovalError` (a `ValueError`): when trimming leaves <2 samples or no
+  non-constant trait; carries `outlier_report` as an attribute.
+
+**Example:**
+```python
+from sleap_roots_analyze import (
+    clean_traits_for_analysis,
+    remove_outlier_samples,
+    perform_pca_analysis,
+)
+
+clean_df, trait_cols, _ = clean_traits_for_analysis(df)
+trimmed_df, report = remove_outlier_samples(clean_df, trait_cols)
+print(f"Removed {report['n_outliers']} outliers: {report['outlier_barcodes']}")
+pca = perform_pca_analysis(trimmed_df[trait_cols])  # outlier-trimmed PCA
+```
+
+---
+
 #### `detect_outliers_mahalanobis`
 
 ```python
@@ -1125,6 +1212,81 @@ outliers = identify_outliers_from_distances(
 )
 
 print(f"Found {outliers['n_outliers']} outliers")
+```
+
+---
+
+#### `detect_outliers_isolation_forest`
+
+```python
+detect_outliers_isolation_forest(
+    data: Union[pd.DataFrame, np.ndarray],
+    contamination: float = 0.1,
+    random_state: int = 42
+) -> Dict
+```
+
+Detect outliers using an Isolation Forest. Anomalies require fewer random splits
+to isolate, so they receive more negative anomaly scores. `contamination` is the
+expected outlier proportion (a quota), so it may flag exactly that fraction even on
+clean data. One of the detectors composed by
+[`remove_outlier_samples`](#remove_outlier_samples).
+
+**Parameters:**
+- `data`: DataFrame with numeric trait data or numpy array
+- `contamination`: Expected proportion of outliers, 0–0.5 (default: 0.1)
+- `random_state`: Random seed for reproducibility (default: 42)
+
+**Returns:**
+Dictionary containing:
+- `outlier_indices`: List of row indices identified as outliers
+- `anomaly_scores`: Per-sample anomaly scores (more negative = more anomalous)
+- `contamination`: Contamination parameter used
+- `outlier_labels`: `-1` for outliers, `1` for inliers
+- `data_indices`: Original indices of the data
+- `error`: Error message if detection failed (only if error occurred)
+
+**Example:**
+```python
+result = detect_outliers_isolation_forest(df_traits, contamination=0.2)
+print(f"Found {result['n_outliers']} outliers")
+```
+
+---
+
+#### `remove_outliers_from_data`
+
+```python
+remove_outliers_from_data(
+    df: pd.DataFrame,
+    outlier_indices: Union[List, np.ndarray, pd.Index],
+    keep_metadata: bool = True,
+    return_outliers: bool = True,
+    reset_index: bool = False
+) -> Union[pd.DataFrame, Tuple[pd.DataFrame, pd.DataFrame]]
+```
+
+Remove outlier samples (by index label) from a dataset and optionally return them.
+Handles integer/string/custom indices and preserves them. The row-dropping helper
+composed by [`remove_outlier_samples`](#remove_outlier_samples).
+
+**Parameters:**
+- `df`: Original DataFrame with data
+- `outlier_indices`: Indices of outliers to remove (from a detection function)
+- `keep_metadata`: Preserve all columns (`True`) or keep only numeric (`False`)
+- `return_outliers`: Also return the removed-rows DataFrame (default: True)
+- `reset_index`: Reset the index of the cleaned frame after removal (default: False)
+
+**Returns:**
+- If `return_outliers=False`: the cleaned DataFrame
+- If `return_outliers=True`: a tuple `(cleaned_df, outliers_df)`
+
+**Example:**
+```python
+result = detect_outliers_mahalanobis(df_traits)
+cleaned_df, outlier_df = remove_outliers_from_data(
+    df_traits, result["outlier_indices"]
+)
 ```
 
 ---

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Public outlier-removal entry point `remove_outlier_samples` (#165): the
+  **quality**-step follow-up to `clean_traits_for_analysis`. Takes a clean
+  (NaN-free) trait table and detects + removes outlier samples so PCA/UMAP/
+  clustering can optionally run on outlier-trimmed data, composing the existing
+  public `detect_outliers_mahalanobis` / `detect_outliers_isolation_forest` and
+  `remove_outliers_from_data` primitives (no new detection/removal algorithm).
+  Importable from `sleap_roots_analyze`, it returns `(trimmed_df, outlier_report)`
+  — an auditable, JSON-serializable report — and composes after
+  `clean_traits_for_analysis`, before `perform_pca_analysis` / UMAP / clustering.
+  Enforces NaN-free + unique-index preconditions, re-applies the readiness gates,
+  and warns on over-removal (> 50%) and the `p > n` regime.
+
 ## [0.1.0a3] - 2026-06-24 (Pre-release)
 
 ### Added

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,8 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Importable from `sleap_roots_analyze`, it returns `(trimmed_df, outlier_report)`
   — an auditable, JSON-serializable report — and composes after
   `clean_traits_for_analysis`, before `perform_pca_analysis` / UMAP / clustering.
-  Enforces NaN-free + unique-index preconditions, re-applies the readiness gates,
-  and warns on over-removal (> 50%) and the `p > n` regime.
+  Enforces NaN-free + unique-index preconditions, rejects unknown / cross-method
+  `detect_kwargs` with an actionable error, re-applies the readiness gates, and warns
+  on over-removal (> 50%), the `p > n` regime, and — on the Mahalanobis path — a small
+  sample (`n < 30`) or a violated chi-squared goodness-of-fit.
 
 ### Changed
 - `apply_data_cleanup_filters` bare-default thresholds tightened to the canonical

--- a/openspec/changes/add-outlier-removal-entry-point/design.md
+++ b/openspec/changes/add-outlier-removal-entry-point/design.md
@@ -1,0 +1,218 @@
+## Context
+
+`clean_traits_for_analysis` (#164, `data_cleanup.py:905`) produces a **runnable** frame but
+deliberately leaves outliers in — PCA/UMAP run fine with them (they are not NaNs), so trimming
+them is a separate **quality** step. The detection + removal primitives already exist and are
+already public:
+
+- `detect_outliers_mahalanobis(data, *, standardize=True, variance_threshold=0.95,
+  use_chi_squared=True, chi2_percentile=97.5, distance_threshold=None,
+  robust_covariance=False, random_state=42) -> dict` (`outlier_detection.py:22`) — keys:
+  `outlier_indices`, `mahalanobis_distances`, `n_outliers`, `n_components`, `threshold_type`,
+  `threshold_value`, `feature_names`, `goodness_of_fit`, `error`.
+- `detect_outliers_isolation_forest(data, contamination=0.1, random_state=42) -> dict`
+  (`:753`) — keys: `method`, `contamination`, `outlier_indices`, `n_outliers`,
+  `anomaly_scores`, `outlier_labels`, `data_indices`, `error`.
+- `remove_outliers_from_data(df, outlier_indices, keep_metadata=True, return_outliers=True,
+  reset_index=False) -> (cleaned_df, outliers_df)` (`:1144`).
+
+All three are already in `__all__` (`__init__.py:72,74,80`). The QC pipeline composes them
+across steps 05 (`DetectOutliersStep`) → 07 (`RemoveOutliersStep`), but with config-driven
+multi-method strategies and artifact emission — there is no importable "detect with one method,
+remove, return a report" one-call function. This change adds exactly that, **importing** the
+existing functions (the #116/#164 single-source-of-truth pattern).
+
+## Goals / Non-Goals
+
+- Goals:
+  - One public `remove_outlier_samples(clean_df, trait_cols=None, *, method="mahalanobis", …)`
+    that **imports and composes** `detect_outliers_*` + `remove_outliers_from_data` and returns
+    `(trimmed_df, outlier_report)`.
+  - Keep the trimmed frame **analysis-ready** (the #164 readiness gates) so it can flow
+    straight into PCA/UMAP/clustering.
+  - A clean-input precondition that prevents the silent `dropna()`-misalignment failure mode.
+  - Deterministic given `random_state`; auditable, JSON-serializable report.
+- Non-Goals: any new detection/removal algorithm; multi-method consensus
+  (`combine_outlier_methods`, pipeline `consensus`/`subset`); outlier visualization (step 06);
+  any change to `clean_traits_for_analysis`, the cleanup thresholds, or the pipeline steps; the
+  downstream bloom-mcp tool (separate repo).
+
+## Decisions
+
+- **D1 — New module `outlier_removal.py`, not `data_cleanup.py`.** Outlier trimming is a
+  distinct quality concern (the issue is emphatic it is *separate from, and after*, the minimal
+  cleanup). A new module keeps the NaN-cleanup module focused and gives the new capability a
+  clear home. Imports `detect_outliers_*` / `remove_outliers_from_data` from
+  `outlier_detection.py` and `validate_clean_traits` / `get_trait_columns` /
+  `MIN_SAMPLES_FOR_ANALYSIS` from `data_cleanup.py`.
+
+- **D2 — Signature.**
+  `remove_outlier_samples(clean_df, trait_cols=None, *, method="mahalanobis",
+  barcode_col="Barcode", genotype_col="geno", replicate_col="rep", random_state=42,
+  **detect_kwargs) -> tuple[pd.DataFrame, dict]`.
+  - `trait_cols=None` → inferred via `get_trait_columns` (same ergonomics as
+    `clean_traits_for_analysis`); `barcode_col`/`genotype_col`/`replicate_col` are all forwarded
+    to `get_trait_columns` and used only to *exclude* metadata during inference (`barcode_col`
+    additionally identifies the column read for `outlier_barcodes`). Column-name defaults match
+    the sibling
+    (`"Barcode"`/`"geno"`/`"rep"`) because the entry point consumes the **raw-named** clean
+    frame the sibling produces (no name sanitization).
+  - `**detect_kwargs` forwards per-method parameters to the chosen detector
+    (`contamination=` for isolation forest; `chi2_percentile=`, `variance_threshold=`,
+    `use_chi_squared=`, `distance_threshold=`, `robust_covariance=` for Mahalanobis) — mirrors
+    `clean_traits_for_analysis`'s `**cleanup_kwargs` pass-through.
+
+- **D3 — Default method = `"mahalanobis"` with the chi-squared threshold.** It is the module's
+  primary, statistically principled detector (distance on PCA-transformed data, chi² threshold)
+  and needs no contamination guess. `"isolation_forest"` is offered for callers who want a
+  direct `contamination` knob. An unknown `method` raises a `ValueError` naming the supported
+  set, so a typo fails fast instead of silently doing nothing.
+
+- **D4 — Return `(trimmed_df, outlier_report)` (2-tuple).** Unlike the sibling's 3-tuple,
+  `trait_cols` is **invariant** here — outlier removal drops *rows*, never trait *columns* — so
+  re-returning it would be redundant; the caller reuses the `trait_cols` from
+  `clean_traits_for_analysis`. The report parallels the sibling's enriched `cleanup_log`. (See
+  Open Questions: confirm 2-tuple vs. a symmetric 3-tuple.)
+
+- **D5 — `outlier_report` schema (auditable + JSON-serializable).** The spec's **Auditable
+  Outlier Report** requirement is the single source of truth for the key list; this is the
+  rationale. `method` (str — the **dispatch key**, e.g. `"isolation_forest"`, set by the entry
+  point, NOT the detector's internal `"IsolationForest"` label), `method_params` (effective
+  per-method params used), `random_state` (int), `n_input_samples`/`n_outliers`/`n_output_samples`
+  (ints), `removal_fraction` (float), `outlier_indices` (list of removed sample **labels**),
+  `outlier_barcodes` (list when `barcode_col` is a column of `clean_df`, else `None`).
+  Method-dependent: for **Mahalanobis**, `threshold_type` / `threshold_value`, the PCA basis the
+  distances were computed on (`n_components`, effective `variance_threshold`), and the chi²
+  `goodness_of_fit` (which flags when the percentile threshold's distributional assumption is
+  violated). For **isolation forest** these are `None` — its return dict has no
+  `threshold_type`/`threshold_value`/`goodness_of_fit` (verified: it returns `method`,
+  `contamination`, `outlier_indices`, `n_outliers`, `anomaly_scores`, `outlier_labels`,
+  `data_indices`), and its control knob (`contamination`) lives in `method_params`. All values
+  are cast to plain Python scalars/lists (numpy ints/floats → `int()`/`float()`) so `json.dumps`
+  succeeds. Large per-sample arrays (`mahalanobis_distances`, `anomaly_scores`) are **not**
+  copied in — compact + serializable; a caller who needs them calls the detector directly. The
+  report mirrors the pipeline's `07_outlier_removal_log.json` (`removal_fraction`,
+  `removed_sample_barcodes`); note the deliberate key rename `removed_sample_barcodes` →
+  `outlier_barcodes` (different object — the entry point's report, not the pipeline artifact).
+
+- **D6 — Clean-input precondition (correctness, not just defense).** Before detecting, verify
+  the trait columns are NaN-free via the exposed `validate_clean_traits`. The detectors run PCA
+  which silently `df.dropna()`s rows and reports `outlier_indices` against the **post-dropna**
+  index; feeding a NaN-carrying frame would therefore drop rows the caller never sees and
+  misalign the indices handed to `remove_outliers_from_data`. On violation, raise a `ValueError`
+  that names the offending traits and points to `clean_traits_for_analysis` — **wrapping**
+  `validate_clean_traits`'s message, which is `"Validation failed: N NaN values found in trait
+  columns!\nAffected traits: [...]"` and does **not** itself mention the entry point (so the
+  pointer must be added by the wrapper, and the test must match the wrapper's text).
+
+- **D6b — Unique-index precondition (the other half of alignment).** `clean_traits_for_analysis`
+  does **not** `reset_index` (verified — it `dropna`s and returns the frame as-is), so the input
+  inherits the caller's index, which can carry **duplicate labels** (e.g. `set_index("Barcode")`
+  on replicated barcodes, or concatenated frames). Removal is **label-based**
+  (`remove_outliers_from_data` uses `df.drop(index=...)` / `df.loc[...]`), so a duplicate label
+  would silently drop or duplicate inlier rows sharing a flagged outlier's label —
+  mis-removing rows. `validate_clean_traits` only checks NaN, not uniqueness. So the entry point
+  also requires `clean_df.index.is_unique`, raising an actionable `ValueError` otherwise. NaN-free
+  **and** unique-index together make the "labels align 1:1 with rows" guarantee sound.
+
+- **D7 — Output readiness guard (reuse #164 gates) + p > n warning.** The whole point is a frame
+  still safe for PCA/UMAP/clustering, so after removal re-check: ≥`MIN_SAMPLES_FOR_ANALYSIS` (2)
+  surviving samples, and ≥1 non-constant trait (`var(ddof=0) > 0`, the same basis
+  `standardize_data` uses). If trimming would breach either, raise a distinct, actionable
+  `ValueError` naming the surviving count / the degeneracy — rather than returning a frame too
+  small or constant to analyze. Checks run in a fixed order (samples, then non-constant) for a
+  deterministic message. The raised `ValueError` **carries `outlier_report` as an attribute** so a
+  caller who hit an over-aggressive trim can still inspect what would have been removed (resolving
+  the "I wanted the frame/report anyway" tension noted in Risks). Additionally, because trimming
+  *shrinks n*, an `n > p` frame can become `p > n`; the entry point re-applies #164's **`p > n`
+  `UserWarning`** (surviving samples < surviving traits) so that statistically-fragile regime is
+  not entered silently — a guardrail the first draft dropped.
+
+- **D8 — Over-removal safety rail.** Emit a `UserWarning` when `removal_fraction` exceeds a
+  guard (default `0.5`): removing the majority of samples almost always means a mis-set
+  `contamination`/threshold, not real outliers. A warning (not a hard error) keeps the function
+  usable on genuinely dirty data while flagging the likely-mistake case. It is emitted **before**
+  the D7 readiness gates, so it is observable even when the same aggressive trim then fails a
+  readiness gate (otherwise the warning pointing you at the over-removal would be swallowed by the
+  raise). (Threshold configurability — e.g. a `max_removal_fraction` kwarg — is an Open Question.)
+
+- **D9 — Determinism.** `random_state` (default 42, matching the detectors) is threaded into the
+  detector and recorded in the report: same input + same `random_state` + same params ⇒ identical
+  `outlier_indices` and identical trimmed frame. The seed is only *load-bearing* on stochastic
+  paths — `method="isolation_forest"`, `robust_covariance=True` (MinCovDet), or large-n
+  randomized SVD; for the **default exact-SVD Mahalanobis** path the result is identical
+  regardless of seed (so a determinism test on that path is necessary but not sufficient — the
+  determinism test must also exercise a seed-sensitive path, per tasks 1.12b). This satisfies the
+  repo's stochastic-determinism / reproducibility gates — see D11 for the mandatory registry
+  registration that gate enforces.
+
+- **D10 — `remove_outliers_from_data(keep_metadata=True)`.** Preserve metadata columns
+  (`Barcode`/`geno`/`rep`) in the trimmed frame so the result is a drop-in replacement for the
+  clean frame in the downstream call chain, and so `outlier_barcodes` can be read from the
+  removed rows.
+
+- **D11 — Reproducibility-gate registration (mandatory, else CI red).** The repo's
+  `tests/test_reproducibility.py` runs a package-wide sweep (`walk_packages`) that **fails if any
+  public function with a `random_state` parameter is absent** from the `CASES` registry in
+  `tests/reproducibility_cases.py` (or `EXCLUDED`), and additionally pins `EXPECTED_QUALNAMES` and
+  the case count. `remove_outlier_samples` will be auto-discovered, so this change must register
+  it in `CASES` (preferred — it *is* a determinism-relevant function) and update the
+  `EXPECTED_QUALNAMES` / count anchors in lockstep. An in-suite determinism test (tasks 1.12) is
+  necessary but **not sufficient** — the package-wide registry is the actual gate, and it also
+  satisfies `openspec/specs/stochastic-determinism`'s "regression test enforces determinism"
+  requirement.
+
+## Risks / Trade-offs
+
+- **Single-method only vs. the pipeline's consensus strategies.** A single method can over- or
+  under-flag relative to a multi-method consensus. → Accepted for a minimal, tested entry point;
+  multi-method consensus (`combine_outlier_methods`) is a named follow-up, and the `method`
+  parameter leaves room to add a `"consensus"` value later without a signature break.
+- **Detector returns an `error` key instead of raising** (e.g. empty/all-NaN data). → The
+  entry point's empty-input + NaN-free preconditions make that path unreachable under normal
+  flow; defensively, if a detector result carries `error` / lacks `outlier_indices`, raise a
+  `ValueError` surfacing it rather than treating "no indices" as "no outliers".
+- **Default `method="mahalanobis"` could surprise callers expecting a contamination knob.** →
+  Documented in the docstring and report (`method`, `method_params`); `isolation_forest` is one
+  kwarg away.
+- **Readiness guard can reject aggressive trims (mild tension with "optional quality step").**
+  The issue frames trimming as optional and "give me the trimmed frame"; a hard `ValueError` on a
+  sub-threshold result discards that frame. A caller might want to *inspect what got removed* even
+  at 1 survivor. → Keep the raise (the frame is not analyzable — PCA needs ≥2 samples / a varying
+  trait — and it matches #164's contract), but **attach `outlier_report` to the raised exception**
+  (D7) so the caller can still see the over-removal it would want to diagnose. A caller who wants
+  the raw trimmed frame regardless can call the detector + `remove_outliers_from_data` directly.
+  The error is actionable (loosen the threshold / use fewer-flagging params).
+- **Report omits per-sample distance arrays.** → Intentional (compact, serializable); the
+  detector remains public for callers who need full arrays. The audit-relevant scalars it *does*
+  keep — `n_components`, effective `variance_threshold`, `goodness_of_fit`, `threshold_value` —
+  are enough to reproduce the decision. Documented.
+- **Default `chi2_percentile=97.5` trims ~2.5% by construction.** On a well-fit chi² tail the
+  Mahalanobis threshold flags roughly the top 2.5% *regardless* of whether those samples are
+  biologically aberrant. → Defensible as a documented, conventional default; the docstring/spec
+  state the ~2.5%-by-design behavior so callers know the default removes ~2.5% even on clean data
+  and can tighten `chi2_percentile` or switch to `isolation_forest` with an explicit
+  `contamination`. The `goodness_of_fit` in the report surfaces when the chi² assumption (and thus
+  the percentile's meaning) is violated.
+
+## Migration Plan
+
+Additive: one new module, one `__all__` entry, docs. No deprecations, no consumer migration, no
+pipeline-step or `clean_traits_for_analysis` changes. `tasks.md` follows the repo's TDD
+convention (red → green). Lands on `0.1.0a4` for the bloom-mcp quality tool to consume.
+
+## Open Questions
+
+- **Public name** `remove_outlier_samples` — the issue's suggestion ("maintainers' call");
+  confirm before merge (alternatives: `trim_outlier_samples`, `remove_outliers_for_analysis`).
+- **Return arity** — 2-tuple `(trimmed_df, outlier_report)` per the issue, vs. a 3-tuple
+  `(trimmed_df, trait_cols, outlier_report)` symmetric with `clean_traits_for_analysis`.
+  Recommend 2-tuple (columns are invariant); confirm.
+- **Default method** — `"mahalanobis"` (recommended) vs. `"isolation_forest"` (direct
+  `contamination` control). Confirm the default and whether to ship a `"consensus"` value now.
+- **Over-removal rail** — fixed `UserWarning` at `removal_fraction > 0.5` vs. a configurable
+  `max_removal_fraction` kwarg (warn or hard-error). Recommend the fixed warning for v1.
+- **Non-unique index handling** — D6b *raises* on a non-unique index (strict, predictable). The
+  alternative is to internally `reset_index` before detect/remove and map labels back. Recommend
+  raising for v1 (explicit; avoids hidden index mutation), but confirm whether a convenience
+  auto-reset is preferred for ergonomics.

--- a/openspec/changes/add-outlier-removal-entry-point/proposal.md
+++ b/openspec/changes/add-outlier-removal-entry-point/proposal.md
@@ -1,0 +1,155 @@
+# Proposal: Public Outlier-Removal Entry Point — `remove_outlier_samples`
+
+## Why
+
+The minimal-QC entry point `clean_traits_for_analysis` (#164, landed in `0.1.0a3`) hands
+downstream consumers a **runnable** trait table — no NaNs, ≥2 samples, ≥1 varying trait — so
+`perform_pca_analysis` / UMAP / clustering no longer silently drop rows. But "runnable" is
+not "high quality": **outlier samples are not NaNs**, so PCA/UMAP *run fine* with them while
+they **distort principal-component directions** and skew clustering. Trimming them is a
+**quality** step, deliberately kept **separate from, and after**, the minimal cleanup
+(explicit non-goal of #164).
+
+The detection and removal logic already exists and is already public, but only as
+**primitives** a consumer must re-stitch:
+
+- `detect_outliers_mahalanobis` (`src/sleap_roots_analyze/outlier_detection.py:22`) and
+  `detect_outliers_isolation_forest` (`:753`) return raw result **dicts**
+  (`outlier_indices`, `threshold_*`, …) — the caller must know each method's keys.
+- `remove_outliers_from_data` (`:1144`) takes those `outlier_indices` and drops the rows.
+- The QC pipeline composes them across **steps 05 → 07** (`DetectOutliersStep` →
+  `VisualizeOutliersStep` → `RemoveOutliersStep`), but that composition (method dispatch,
+  index alignment, a removal log) lives **inside the pipeline steps** with no importable
+  one-call equivalent.
+
+So a consumer who wants "give me the trimmed frame" today must: pick a detector, call it with
+the right per-method kwargs, read the right result key, hand the indices to
+`remove_outliers_from_data`, and assemble their own report — **untested, duplicated** outside
+`analyze` (the same re-stitching problem #116/#164 set out to undo).
+
+This adds **one public, tested entry point** that *imports and composes those already-public
+functions* — no new detection or removal algorithm — mirroring the #164 pattern.
+
+Tracked by [talmolab/sleap-roots-analyze#165](https://github.com/talmolab/sleap-roots-analyze/issues/165).
+
+## What Changes
+
+### Add the entry point that composes the existing detect + remove functions
+
+Add public **`remove_outlier_samples`** in a new module
+`src/sleap_roots_analyze/outlier_removal.py` (kept out of the NaN-cleanup module
+`data_cleanup.py` because this is a distinct quality concern) that:
+
+1. **Rejects malformed input up front** with actionable `ValueError`s — empty input,
+   duplicate column names, explicit `trait_cols` missing from `clean_df` or non-numeric, an
+   **unknown `method`** (naming the supported methods), and a **non-unique index** (label-based
+   removal would otherwise silently mis-drop rows that share a flagged outlier's label, since
+   `clean_traits_for_analysis` does not reset the index).
+2. **Resolves trait columns** via `get_trait_columns` when `trait_cols` is not passed
+   (mirroring `clean_traits_for_analysis`).
+3. **Enforces the clean-input precondition** — verifies the trait columns contain **no NaN**
+   via the already-exposed `validate_clean_traits`, **wrapping** its error to add a pointer to
+   `clean_traits_for_analysis` (the validator's own message does not mention the entry point).
+   This is a correctness guard, not just defense: the detectors call PCA which silently
+   `dropna()`s rows, so a NaN-carrying input would make the detector's `outlier_indices`
+   misalign with `clean_df`'s rows. With NaN-free + unique-index inputs, detection labels align
+   one-to-one with `clean_df`'s rows.
+4. **Detects** outliers with a single selected `method` (`"mahalanobis"` default, or
+   `"isolation_forest"`) by calling the **existing** `detect_outliers_mahalanobis` /
+   `detect_outliers_isolation_forest`, forwarding `random_state` (for determinism) and any
+   per-method `**detect_kwargs` (e.g. `contamination=`, `chi2_percentile=`). If the detector
+   returns an `error` (degenerate PCA, empty/all-NaN), the entry point **raises** rather than
+   silently reporting zero outliers.
+5. **Removes** the flagged samples by calling the **existing** `remove_outliers_from_data`
+   (`keep_metadata=True`, so metadata columns survive), yielding the trimmed frame.
+6. **Guards output analysis-readiness** — the trimmed frame must still be safe to hand to
+   PCA/UMAP/clustering, so it re-applies the #164 readiness gates (≥`MIN_SAMPLES_FOR_ANALYSIS`
+   surviving samples, ≥1 non-constant `var(ddof=0) > 0` trait) and raises an actionable
+   `ValueError` — **carrying `outlier_report` on the exception** so a caller can still inspect
+   what would have been removed — rather than returning a frame too small or degenerate to
+   analyze. It emits a `UserWarning` when the removed fraction is large (default > 0.5, before
+   the readiness gates — the signature of a mis-set `contamination`/threshold), and re-applies
+   #164's **`p > n` `UserWarning`** when trimming pushes surviving traits above surviving samples.
+7. **Returns** `(trimmed_df, outlier_report)`, where `outlier_report` is an auditable,
+   JSON-serializable dict (plain Python types only). Its full key list is the single source of
+   truth in the spec's **Auditable Outlier Report** requirement: `method` (the dispatch key),
+   effective `method_params`, `random_state`, `n_input_samples`, `n_outliers`,
+   `n_output_samples`, `removal_fraction`, `outlier_indices`, `outlier_barcodes` (or `None`),
+   and the detector's `threshold_type` / `threshold_value` — populated for Mahalanobis (with
+   `n_components` and `goodness_of_fit`) and `None` for isolation forest, whose control is
+   `contamination`.
+
+### Public API + docs
+
+8. **Export `remove_outlier_samples`** from `__init__.py` / `__all__`, with a Google-style
+   docstring (Args/Returns/Raises) and `typing.get_type_hints()`-resolvable hints (#116
+   acceptance bar; enforced by the package `test_public_api_docs` audit gate). The underlying
+   `detect_outliers_mahalanobis`, `detect_outliers_isolation_forest`, and
+   `remove_outliers_from_data` are **already** in `__all__`
+   (`src/sleap_roots_analyze/__init__.py:72,74,80`), so the issue's "expose the detect/remove
+   functions if not already" is satisfied at the API-surface level. **Note:** `__all__`
+   membership ≠ documentation — `docs/API.md` currently documents only
+   `detect_outliers_mahalanobis` of the three, so the API.md task also backfills the two missing
+   primitive entries the new entry cross-references (see item 9).
+9. Add `remove_outlier_samples` (and the two missing composed primitives) to `docs/API.md`, and
+   a `docs/CHANGELOG.md` `[Unreleased]` entry — mirroring #164's acceptance.
+10. **Register for the reproducibility gate.** Because `remove_outlier_samples` exposes
+    `random_state`, the package-wide stochastic-determinism sweep
+    (`tests/test_reproducibility.py`) auto-discovers it and fails unless it is registered. Add it
+    to `tests/reproducibility_cases.py` `CASES` (or `EXCLUDED` with a reason) and update the
+    pinned `EXPECTED_QUALNAMES` / case-count anchors in lockstep.
+
+### What "single source of truth" means here
+
+The entry point and the pipeline (steps 05/07) call the **same** detection
+(`detect_outliers_*`) and removal (`remove_outliers_from_data`) functions, so the *outlier
+algorithm and index-alignment semantics cannot drift*. As with #164, it does **not** guarantee
+byte-identical *output* to the pipeline, because the pipeline operates on
+**name-sanitized** columns and supports **multi-method consensus** strategies the entry point
+deliberately omits (see Out of scope). The entry point operates on the **raw-named** clean
+frame produced by `clean_traits_for_analysis`.
+
+### Composition
+
+`clean_traits_for_analysis` → **(optional)** `remove_outlier_samples` → `perform_pca_analysis`
+/ UMAP / clustering. The function *is* the opt-in: outlier trimming runs only when a consumer
+calls it, and is parameterized by `method` + per-method threshold/contamination kwargs. It
+does **not** alter `clean_traits_for_analysis` or run as part of it.
+
+### Out of scope (explicitly)
+
+- The full `QCPipeline` and `DetectOutliersStep` / `RemoveOutliersStep` refactor — those keep
+  their config-driven, multi-artifact behavior unchanged. This change adds *no* pipeline-step
+  edits (contrast #164, which refactored step 03).
+- **Multi-method consensus / subset removal** (`combine_outlier_methods`, the pipeline's
+  `consensus` / `subset` strategies). The entry point trims with a **single** method to stay
+  minimal and testable; multi-method consensus is a possible follow-up.
+- **Outlier visualization** (pipeline step 06 `visualize_outliers.py` / the
+  `outlier_visualization` plots). The report is data-only; rendering dashboards stays in the
+  pipeline.
+- Any change to `clean_traits_for_analysis`, the minimal-QC cleanup, or NaN handling.
+- The downstream **bloom-mcp** quality tool (a `remove_outliers` tool composing after
+  `qc_clean`, before viz) — that lives in the `bloom` repo and consumes this function; it is
+  not built here.
+
+## Impact
+
+- Affected specs: **outlier-trimming** (new capability).
+- Affected code:
+  - `src/sleap_roots_analyze/outlier_removal.py` — **new** module with
+    `remove_outlier_samples` (composition + report assembly + readiness guards).
+  - `src/sleap_roots_analyze/__init__.py` — import + `__all__` entry for
+    `remove_outlier_samples` (detect/remove functions already exported).
+  - `docs/API.md` — new public function + the two missing composed-primitive entries;
+    `docs/CHANGELOG.md` — `[Unreleased]` entry.
+  - `tests/test_remove_outlier_samples.py` (new) — TDD coverage.
+  - `tests/reproducibility_cases.py` + `tests/test_reproducibility.py` — register the new
+    `random_state` function and update the pinned `EXPECTED_QUALNAMES` / count anchors (else the
+    package-wide reproducibility-coverage gate fails CI).
+- **No behavior change** to any existing function or pipeline step (additive module +
+  one `__all__` entry).
+- **Depends on #164** (`clean_traits_for_analysis`, `validate_clean_traits`,
+  `MIN_SAMPLES_FOR_ANALYSIS`) — already landed in `0.1.0a3`. Independent of #167 (shared
+  cleanup-default alignment).
+- **Release coupling:** rides the next `analyze` pre-release (`0.1.0a4`) that the bloom-mcp
+  quality tool will consume; `[Unreleased]` until then.

--- a/openspec/changes/add-outlier-removal-entry-point/specs/outlier-trimming/spec.md
+++ b/openspec/changes/add-outlier-removal-entry-point/specs/outlier-trimming/spec.md
@@ -1,0 +1,384 @@
+## ADDED Requirements
+
+### Requirement: Outlier-Removal Entry Point
+
+The system SHALL provide a single public function `remove_outlier_samples` that detects and
+removes outlier **samples** from a clean, analysis-ready trait table by **importing and
+composing** the existing public detection functions (`detect_outliers_mahalanobis` /
+`detect_outliers_isolation_forest`) and the existing public removal function
+(`remove_outliers_from_data`) — introducing no new outlier-detection or removal algorithm. It
+SHALL return a tuple `(trimmed_df, outlier_report)` where `trimmed_df` is the input frame with
+the flagged outlier rows removed (metadata columns preserved) and `outlier_report` is an
+auditable, JSON-serializable dict describing which samples were removed and why.
+
+#### Scenario: Detect and remove outliers from a clean trait table
+
+- **WHEN** `remove_outlier_samples(clean_df)` is called on a clean (NaN-free) trait table
+  containing injected outlier rows
+- **THEN** trait columns are resolved via `get_trait_columns` when not explicitly passed
+- **AND** the selected detector and `remove_outliers_from_data` are used to drop the flagged rows
+- **AND** the function returns a 2-tuple `(trimmed_df, outlier_report)`
+- **AND** `len(trimmed_df)` equals `len(clean_df) - outlier_report["n_outliers"]`
+
+#### Scenario: Trimmed frame preserves metadata columns and trait columns
+
+- **WHEN** `remove_outlier_samples(clean_df, trait_cols=[...])` returns `(trimmed_df, _)`
+- **THEN** `trimmed_df` SHALL contain the same columns as `clean_df` (metadata and trait
+  columns alike — outlier removal drops rows, never columns)
+- **AND** the supplied `trait_cols` remain valid columns of `trimmed_df`
+
+#### Scenario: Caller-supplied trait columns are honored
+
+- **WHEN** `remove_outlier_samples(clean_df, trait_cols=[...])` is called with an explicit
+  trait-column list
+- **THEN** `get_trait_columns` is not used to infer columns
+- **AND** outlier detection operates over exactly the supplied trait columns
+
+### Requirement: Method Selection and Parameters
+
+`remove_outlier_samples` SHALL trim using a single detection `method` selected by the caller,
+defaulting to `"mahalanobis"` (Mahalanobis distance on PCA-transformed data with a chi-squared
+threshold) and also supporting `"isolation_forest"`. It SHALL forward `random_state` and any
+per-method `**detect_kwargs` (e.g. `contamination`, `chi2_percentile`, `variance_threshold`) to
+the chosen detector unchanged, and SHALL reject an unknown `method` with an actionable error.
+
+#### Scenario: Default method is Mahalanobis
+
+- **WHEN** `remove_outlier_samples(clean_df)` is called without specifying `method`
+- **THEN** detection SHALL use `detect_outliers_mahalanobis`
+- **AND** `outlier_report["method"]` SHALL equal `"mahalanobis"`
+- **AND** the removed rows SHALL be exactly those flagged by `detect_outliers_mahalanobis`
+
+#### Scenario: Isolation-forest method with a contamination parameter
+
+- **WHEN** `remove_outlier_samples(clean_df, method="isolation_forest", contamination=0.2)` is
+  called
+- **THEN** detection SHALL use `detect_outliers_isolation_forest` with `contamination=0.2`
+- **AND** `outlier_report["method"]` SHALL equal `"isolation_forest"` (the dispatch key, not the
+  detector's internal `"IsolationForest"` label)
+- **AND** `outlier_report["method_params"]` SHALL record `contamination=0.2`
+
+#### Scenario: Mahalanobis kwargs are forwarded and echoed
+
+- **WHEN** `remove_outlier_samples(clean_df, method="mahalanobis", chi2_percentile=99.0)` is
+  called
+- **THEN** `chi2_percentile=99.0` SHALL be forwarded to `detect_outliers_mahalanobis`
+- **AND** `outlier_report["method_params"]` SHALL record `chi2_percentile=99.0`
+
+#### Scenario: Unknown method is rejected
+
+- **WHEN** `remove_outlier_samples(clean_df, method="not_a_method")` is called
+- **THEN** a `ValueError` naming the supported methods (`"mahalanobis"`, `"isolation_forest"`)
+  SHALL be raised before any detection runs
+
+### Requirement: Single Source of Truth With Detection and Removal Primitives
+
+`remove_outlier_samples` and the QC pipeline's outlier steps SHALL share the same underlying
+functions so the detection and removal semantics cannot drift: the entry point SHALL call the
+public `detect_outliers_mahalanobis` / `detect_outliers_isolation_forest` (the functions
+`DetectOutliersStep` uses) and the public `remove_outliers_from_data` (the row-dropping helper
+the removal step uses), rather than re-implementing detection or removal. This change SHALL NOT
+modify `DetectOutliersStep`, `RemoveOutliersStep`, any other pipeline step, or
+`clean_traits_for_analysis`.
+
+#### Scenario: Entry point composes the already-public primitives
+
+- **WHEN** the source of `remove_outlier_samples` is inspected
+- **THEN** it SHALL import and call `detect_outliers_mahalanobis` /
+  `detect_outliers_isolation_forest` and `remove_outliers_from_data` from
+  `sleap_roots_analyze.outlier_detection`
+- **AND** it SHALL define no alternative outlier-scoring or row-removal logic of its own
+
+#### Scenario: No behavior change to existing functions
+
+- **WHEN** the existing pipeline-step and outlier-detection test suites run after this change
+- **THEN** their outcomes SHALL be unchanged (the change is additive: a new module plus one
+  `__all__` entry)
+
+### Requirement: Clean-Input Precondition
+
+`remove_outlier_samples` SHALL require a NaN-free input in the trait columns and SHALL verify
+this via the exposed `validate_clean_traits` before detecting. When the precondition is
+violated it SHALL raise an actionable `ValueError` that both names the affected traits and
+directs the caller to run `clean_traits_for_analysis` first — wrapping `validate_clean_traits`'s
+message (which does not itself mention the entry point) so the pointer is present. This is a
+correctness guard: the detectors run PCA which silently drops NaN rows and reports outlier
+indices against the post-`dropna` index, so a NaN-carrying input would misalign the indices
+handed to `remove_outliers_from_data`. A NaN-free input guarantees the detector's
+`outlier_indices` align one-to-one with the input frame's rows.
+
+#### Scenario: NaN-carrying input is rejected with guidance
+
+- **WHEN** `remove_outlier_samples` is called on a frame whose trait columns still contain NaN
+- **THEN** a `ValueError` naming the affected traits AND mentioning `clean_traits_for_analysis`
+  SHALL be raised before any detector runs
+
+#### Scenario: Detection labels align with input rows on clean input
+
+- **WHEN** `remove_outlier_samples(clean_df)` runs on a NaN-free frame
+- **THEN** every label in `outlier_report["outlier_indices"]` SHALL be a member of
+  `clean_df.index`
+- **AND** the rows removed from `trimmed_df` SHALL be exactly those labels
+
+### Requirement: Unique Sample Index Required
+
+`remove_outlier_samples` SHALL require the input frame to have a **unique** index and SHALL
+raise an actionable `ValueError` when it does not. Because `clean_traits_for_analysis` does not
+reset the index, the input inherits the caller's index, which may carry duplicate labels (e.g.
+after `set_index("Barcode")` on replicated barcodes or after concatenation). Removal is
+label-based (`remove_outliers_from_data` uses `df.drop(index=...)` / `df.loc[...]`), so a
+duplicate label would silently drop or duplicate inlier rows that share a flagged outlier's
+label. Enforcing a unique index makes the one-to-one alignment guarantee sound.
+
+#### Scenario: Non-unique index is rejected
+
+- **WHEN** `remove_outlier_samples` is called on a frame whose index has duplicate labels
+- **THEN** a `ValueError` stating the index must be unique SHALL be raised before any detector
+  runs
+
+#### Scenario: Default RangeIndex input is accepted
+
+- **WHEN** `remove_outlier_samples` is called on a frame with a unique (e.g. default
+  `RangeIndex`) index
+- **THEN** the uniqueness check SHALL pass and processing SHALL proceed
+
+### Requirement: Output Analysis-Readiness Preserved
+
+The frame returned by `remove_outlier_samples` SHALL remain safe to hand directly to
+`perform_pca_analysis` / UMAP / clustering. After removal the function SHALL re-apply the
+analysis-readiness gates — at least `MIN_SAMPLES_FOR_ANALYSIS` (2) surviving samples, and at
+least one non-constant numeric trait (`var(ddof=0) > 0`, the basis `standardize_data` uses) —
+in a fixed order (samples, then non-constant), raising a distinct, actionable `ValueError`
+rather than returning a frame too small or degenerate to analyze. The raised `ValueError` SHALL
+carry the `outlier_report` (as an attribute) so a caller can still inspect what would have been
+removed. The function SHALL additionally emit a `UserWarning` in the `p > n` regime (surviving
+samples fewer than surviving traits), matching `clean_traits_for_analysis`'s guardrail, since
+trimming can push an `n > p` frame into `p > n`.
+
+#### Scenario: Raises when trimming leaves fewer than 2 samples
+
+- **WHEN** outlier removal would leave fewer than `MIN_SAMPLES_FOR_ANALYSIS` samples
+- **THEN** a `ValueError` naming the surviving sample count SHALL be raised
+- **AND** the raised error SHALL carry the `outlier_report`
+
+#### Scenario: Raises when trimming leaves only a constant trait
+
+- **WHEN** outlier removal leaves a single numeric trait whose `var(ddof=0)` is 0
+- **THEN** a `ValueError` stating that no non-constant trait remains SHALL be raised
+
+#### Scenario: Passes when a constant trait survives alongside a varying one
+
+- **WHEN** outlier removal leaves multiple traits, at least one with `var(ddof=0) > 0`
+- **THEN** the readiness gate SHALL pass and the function SHALL return successfully (a constant
+  trait alongside a varying one does not fail the gate)
+
+#### Scenario: Trimmed frame runs PCA without dropping rows
+
+- **WHEN** `remove_outlier_samples(clean_df)` returns `(trimmed_df, _)` on a valid clean frame
+- **THEN** `perform_pca_analysis(trimmed_df[trait_cols])` SHALL run successfully and report a
+  sample count equal to `len(trimmed_df)` (no rows dropped)
+
+#### Scenario: Warns when trimming enters the p > n regime
+
+- **WHEN** the trimmed frame has more surviving traits than samples
+- **THEN** a `UserWarning` noting `p > n` statistical unreliability SHALL be emitted and the
+  function SHALL still return `(trimmed_df, outlier_report)`
+
+### Requirement: Over-Removal Safety Rail
+
+`remove_outlier_samples` SHALL emit a `UserWarning` when the removed fraction of samples exceeds
+a guard fraction (default `0.5`), surfacing the likely-mis-set-`contamination`/threshold case
+without itself failing on genuinely dirty data. This warning SHALL be emitted **before** the
+output-readiness gates are evaluated, so it is observable even when removal subsequently fails a
+readiness gate.
+
+#### Scenario: Warns when the majority of samples are removed
+
+- **WHEN** the selected method flags more than half of the input samples as outliers and ≥2
+  varying samples survive
+- **THEN** a `UserWarning` noting the large removal fraction SHALL be emitted
+- **AND** the function SHALL still return `(trimmed_df, outlier_report)`
+
+#### Scenario: Over-removal warning precedes a readiness failure
+
+- **WHEN** the selected method flags so many samples that fewer than 2 survive
+- **THEN** the over-removal `UserWarning` SHALL be emitted before the readiness `ValueError` is
+  raised
+
+### Requirement: Auditable Outlier Report
+
+`remove_outlier_samples` SHALL return an `outlier_report` dict that makes the removal auditable
+and reproducible. It SHALL contain at least: `method` (the dispatch key), `method_params` (the
+effective per-method parameters used), `random_state`, `n_input_samples`, `n_outliers`,
+`n_output_samples`, `removal_fraction`, `outlier_indices` (the removed sample labels),
+`outlier_barcodes` (the barcodes of removed samples when `barcode_col` is a column of the input,
+else `None`), the detector's `threshold_type` and `threshold_value`, and — for the Mahalanobis
+method — the PCA basis the distances were computed on (`n_components`, effective
+`variance_threshold`) and the chi-squared `goodness_of_fit`. For `method="isolation_forest"`,
+`threshold_type`/`threshold_value`/`goodness_of_fit` SHALL be `None` (isolation forest has no
+distance threshold; its control is `contamination`, recorded in `method_params`). The report
+SHALL be JSON-serializable using only plain Python scalar/list types (no numpy scalars or
+arrays) and SHALL NOT embed large per-sample arrays (e.g. full distance/score vectors).
+
+#### Scenario: Report records counts, fraction, and removed sample identities
+
+- **WHEN** `remove_outlier_samples(clean_df)` returns `(_, outlier_report)`
+- **THEN** `outlier_report["n_input_samples"]`, `n_outliers`, and `n_output_samples` SHALL be
+  consistent (`n_input_samples == n_outliers + n_output_samples`)
+- **AND** `outlier_report["removal_fraction"]` SHALL equal `n_outliers / n_input_samples`
+- **AND** `outlier_report["outlier_indices"]` SHALL list the removed sample labels
+
+#### Scenario: Barcodes are listed when present and None when absent
+
+- **WHEN** the input has a `barcode_col` column
+- **THEN** `outlier_report["outlier_barcodes"]` SHALL list the removed rows' barcodes
+- **WHEN** the input has no `barcode_col` column
+- **THEN** `outlier_report["outlier_barcodes"]` SHALL be `None`
+
+#### Scenario: Mahalanobis report carries threshold and goodness-of-fit; isolation forest does not
+
+- **WHEN** `remove_outlier_samples(clean_df, method="mahalanobis")` returns `(_, report)`
+- **THEN** `report["threshold_type"]`, `threshold_value`, `n_components`, and `goodness_of_fit`
+  SHALL be populated from the detector result
+- **WHEN** `remove_outlier_samples(clean_df, method="isolation_forest")` returns `(_, report)`
+- **THEN** `report["threshold_type"]`, `threshold_value`, and `goodness_of_fit` SHALL be `None`
+
+#### Scenario: Report is JSON-serializable with plain types
+
+- **WHEN** `outlier_report` is passed to `json.dumps`
+- **THEN** serialization SHALL succeed without raising
+- **AND** every value in `outlier_indices` SHALL be a plain Python `int` or `str` (not a numpy
+  scalar), and `threshold_value` (when present) SHALL be a plain Python `float`
+
+### Requirement: Deterministic Outlier Selection
+
+`remove_outlier_samples` SHALL be deterministic given its inputs: the same `clean_df`, `method`,
+`random_state`, and per-method parameters SHALL produce the same set of `outlier_indices` and
+the same `trimmed_df`. The `random_state` (default `42`) SHALL be threaded into the detector and
+recorded in `outlier_report`. The seed is only consequential for paths with stochastic
+estimators — `method="isolation_forest"`, `robust_covariance=True` (MinCovDet), or large-n
+randomized SVD; for the default exact-SVD Mahalanobis path the result is identical regardless of
+seed, and the determinism guarantee holds in either case.
+
+#### Scenario: Repeated calls with the same seed are identical
+
+- **WHEN** `remove_outlier_samples(clean_df, random_state=7)` is called twice on the same frame
+- **THEN** both calls SHALL return identical `outlier_report["outlier_indices"]`
+- **AND** the two `trimmed_df` results SHALL be equal
+- **AND** `outlier_report["random_state"]` SHALL equal `7`
+
+#### Scenario: Seed is load-bearing on the isolation-forest path
+
+- **WHEN** `remove_outlier_samples(clean_df, method="isolation_forest")` is run on a fixture
+  near the contamination boundary with two different `random_state` values
+- **THEN** the two runs MAY differ, and each run SHALL be reproducible under its own seed
+  (re-running with the same seed yields the identical `outlier_indices`)
+
+### Requirement: Detector-Failure Surfacing
+
+`remove_outlier_samples` SHALL surface a detector failure rather than silently treating it as
+"zero outliers removed". When the chosen detector returns a result carrying an `error` key or
+lacking `outlier_indices` (e.g. degenerate PCA, empty/all-NaN data), the entry point SHALL raise
+a `ValueError` surfacing the detector's error, not return the input frame unchanged with
+`n_outliers == 0`.
+
+#### Scenario: Detector error is raised, not silently swallowed
+
+- **WHEN** the chosen detector returns a result containing an `error` key or no `outlier_indices`
+- **THEN** `remove_outlier_samples` SHALL raise a `ValueError` surfacing that error
+- **AND** SHALL NOT return `(clean_df, report-with-n_outliers-0)`
+
+### Requirement: Input Misuse Diagnostics
+
+`remove_outlier_samples` SHALL reject malformed input up front with an actionable `ValueError`
+rather than a bare pandas error or an opaque later failure: empty input, duplicate column names,
+and explicit `trait_cols` that are missing from the dataframe or non-numeric.
+
+#### Scenario: Empty input is rejected before delegating
+
+- **WHEN** `remove_outlier_samples` is called on a table with no rows
+- **THEN** a `ValueError` from `remove_outlier_samples` with an actionable message SHALL be
+  raised before any detector runs
+
+#### Scenario: Duplicate column names are rejected
+
+- **WHEN** the input dataframe has duplicate column names
+- **THEN** a `ValueError` naming the duplicated columns SHALL be raised
+
+#### Scenario: Explicit trait_cols not in the dataframe are rejected
+
+- **WHEN** an explicit `trait_cols` entry is not a column of `clean_df`
+- **THEN** a `ValueError` naming the missing columns SHALL be raised (not a bare `KeyError`)
+
+#### Scenario: Explicit non-numeric trait_cols are rejected
+
+- **WHEN** an explicit `trait_cols` entry is a non-numeric column
+- **THEN** a `ValueError` naming the non-numeric columns SHALL be raised
+
+### Requirement: Reproducibility-Gate Registration
+
+Because `remove_outlier_samples` exposes a `random_state` parameter, the package-wide
+stochastic-determinism sweep (`tests/test_reproducibility.py`, which walks every module and
+fails if any `random_state`-bearing public function is unregistered) SHALL continue to pass.
+This change SHALL register `remove_outlier_samples` in the reproducibility registry
+(`tests/reproducibility_cases.py` `CASES`, or `EXCLUDED` with a documented justification) and
+update the pinned `EXPECTED_QUALNAMES` / case-count anchors in `tests/test_reproducibility.py`
+in lockstep.
+
+#### Scenario: Reproducibility sweep covers the new function
+
+- **WHEN** `tests/test_reproducibility.py`'s package-wide coverage sweep runs
+- **THEN** `remove_outlier_samples` SHALL be present in `CASES` (or `EXCLUDED` with a reason)
+- **AND** the suite (including the `EXPECTED_QUALNAMES` / count anchors) SHALL pass
+
+### Requirement: Public API Surface
+
+The package SHALL export `remove_outlier_samples` from the top-level `sleap_roots_analyze`
+namespace and list it in `__all__`, with a Google-style docstring (Args/Returns/Raises) and
+type hints resolvable by `typing.get_type_hints()`. The detection and removal functions it
+composes (`detect_outliers_mahalanobis`, `detect_outliers_isolation_forest`,
+`remove_outliers_from_data`) are already exported and SHALL remain exported.
+
+#### Scenario: Entry point is importable from the package root
+
+- **WHEN** a consumer runs `from sleap_roots_analyze import remove_outlier_samples`
+- **THEN** the import SHALL succeed
+- **AND** the imported object SHALL be identity-equal (`is`) to the function defined in
+  `sleap_roots_analyze.outlier_removal`
+
+#### Scenario: Entry point and composed primitives are listed in `__all__`
+
+- **WHEN** `sleap_roots_analyze.__all__` is inspected
+- **THEN** it SHALL contain `remove_outlier_samples`, `detect_outliers_mahalanobis`,
+  `detect_outliers_isolation_forest`, and `remove_outliers_from_data`
+- **AND** SHALL contain no duplicate entries
+
+#### Scenario: Public function satisfies the package API-docs audit
+
+- **WHEN** `typing.get_type_hints(remove_outlier_samples)` is called and the package
+  `test_public_api_docs` audit runs
+- **THEN** `get_type_hints` SHALL return without raising `NameError`
+- **AND** the docstring SHALL include populated Args, Returns, and Raises sections in Google
+  style (the audit gate enforces this for every `__all__` entry)
+
+### Requirement: API Reference and Changelog Documentation
+
+The project documentation SHALL list the new public function and record it in the changelog,
+keeping the hand-maintained reference in sync. Because the new API.md entry cross-references the
+composed primitives, any of those primitives currently absent from `docs/API.md`
+(`detect_outliers_isolation_forest`, `remove_outliers_from_data`) SHALL be added so the
+references resolve.
+
+#### Scenario: API reference lists the new public function and resolvable cross-references
+
+- **WHEN** `docs/API.md` is viewed
+- **THEN** it SHALL include a reference entry for `remove_outlier_samples` with a signature
+  matching the code
+- **AND** the `outlier_detection` primitives it composes SHALL each have an API.md entry
+
+#### Scenario: Changelog records the new public API
+
+- **WHEN** `docs/CHANGELOG.md` `[Unreleased]` section is viewed
+- **THEN** it SHALL include an `### Added` entry noting `remove_outlier_samples` is importable
+  from `sleap_roots_analyze` as the outlier-trimming entry point following
+  `clean_traits_for_analysis`, with a `(#165)` issue suffix

--- a/openspec/changes/add-outlier-removal-entry-point/specs/outlier-trimming/spec.md
+++ b/openspec/changes/add-outlier-removal-entry-point/specs/outlier-trimming/spec.md
@@ -71,6 +71,15 @@ the chosen detector unchanged, and SHALL reject an unknown `method` with an acti
 - **THEN** a `ValueError` naming the supported methods (`"mahalanobis"`, `"isolation_forest"`)
   SHALL be raised before any detection runs
 
+#### Scenario: Unknown or cross-method detect_kwargs are rejected
+
+- **WHEN** a `**detect_kwargs` key is not a parameter of the chosen detector (a typo, or a
+  cross-method knob such as `contamination` with `method="mahalanobis"` or `chi2_percentile`
+  with `method="isolation_forest"`)
+- **THEN** a `ValueError` naming the unrecognized key(s) and the supported parameter set for that
+  method SHALL be raised before any detection runs (not a bare `TypeError` leaking the internal
+  detector name, and not silently dropped from `method_params`)
+
 ### Requirement: Single Source of Truth With Detection and Removal Primitives
 
 `remove_outlier_samples` and the QC pipeline's outlier steps SHALL share the same underlying
@@ -204,6 +213,36 @@ readiness gate.
 - **WHEN** the selected method flags so many samples that fewer than 2 survive
 - **THEN** the over-removal `UserWarning` SHALL be emitted before the readiness `ValueError` is
   raised
+
+### Requirement: Mahalanobis Quality Signals
+
+On the Mahalanobis path the default `chi2_percentile=97.5` trims roughly the top 2.5% of samples
+by construction — even on outlier-free data — and that threshold's meaning rests on the squared
+distances following a chi-squared distribution. So that a routine default trim of genuinely-clean
+data does not pass with no signal, `remove_outlier_samples` SHALL emit a `UserWarning` when the
+sample count is small (`n < 30` — fragile chi-squared tail / covariance estimate) and SHALL emit a
+`UserWarning` when the detector's chi-squared goodness-of-fit reports
+`distributional_assumption_valid` is `False`. Both SHALL be emitted before the output-readiness
+gates (so they are observable even when an aggressive trim then fails a gate), and SHALL NOT fire
+on the isolation-forest path (which has no chi-squared assumption).
+
+#### Scenario: Warns on a small Mahalanobis sample
+
+- **WHEN** `remove_outlier_samples(clean_df)` runs the Mahalanobis path on fewer than 30 samples
+- **THEN** a `UserWarning` noting the small-sample fragility SHALL be emitted and the function
+  SHALL still return `(trimmed_df, outlier_report)`
+
+#### Scenario: Warns when the chi-squared assumption is violated
+
+- **WHEN** the detector's `goodness_of_fit` reports `distributional_assumption_valid == False`
+- **THEN** a `UserWarning` noting the chi-squared assumption is violated SHALL be emitted and the
+  function SHALL still return `(trimmed_df, outlier_report)`
+
+#### Scenario: No quality warnings on a clean, large Mahalanobis sample
+
+- **WHEN** `remove_outlier_samples(clean_df)` runs the Mahalanobis path on a clean frame with
+  `n ≥ 30` and a well-fit chi-squared tail
+- **THEN** neither the small-sample nor the goodness-of-fit `UserWarning` SHALL be emitted
 
 ### Requirement: Auditable Outlier Report
 

--- a/openspec/changes/add-outlier-removal-entry-point/tasks.md
+++ b/openspec/changes/add-outlier-removal-entry-point/tasks.md
@@ -1,0 +1,151 @@
+## 1. Tests first (red)
+
+- [x] 1.1 New file `tests/test_remove_outlier_samples.py`. Add a seeded (`np.random.seed(42)`)
+      fixture builder: a clean (NaN-free) `geno`/`rep`/`Barcode` + several numeric-trait frame
+      of ~40 samples with a handful of injected outlier rows (a few samples pushed ~8 SD out on
+      2–3 traits). **Pin the fixture against the default detector**: it MUST be validated so that
+      `detect_outliers_mahalanobis(chi2_percentile=97.5)` flags *exactly* the injected indices
+      (verified during authoring — Mahalanobis on this fixture is deterministic and exact).
+- [x] 1.2 Test: `remove_outlier_samples(clean_df)` returns a 2-tuple `(trimmed_df, report)`;
+      `len(trimmed_df) == len(clean_df) - report["n_outliers"]`; columns of `trimmed_df` equal
+      columns of `clean_df` (rows dropped, not columns).
+- [x] 1.3 Test: for the **default Mahalanobis** path, `report["outlier_indices"]` equals the
+      injected labels exactly and those labels are absent from `trimmed_df`. For
+      `method="isolation_forest"`, assert only `set(injected) <= set(report["outlier_indices"])`
+      (contamination is a quota, so it may flag extra rows — do NOT assert equality).
+- [x] 1.4 Test: every label in `report["outlier_indices"]` is a member of `clean_df.index`
+      (alignment), and `report["outlier_barcodes"]` lists the removed rows' `Barcode` values.
+- [x] 1.5 Test: method selection — default is `"mahalanobis"` (`report["method"]`);
+      `method="isolation_forest", contamination=0.2` sets `report["method"] == "isolation_forest"`
+      (the dispatch key, not `"IsolationForest"`) and records `method_params["contamination"] ==
+      0.2`; unknown `method` raises `ValueError` naming the supported methods before any detection.
+- [x] 1.6 Test: clean-input precondition — a frame with a NaN in a trait column raises
+      `ValueError` whose message names the trait(s) **and** contains `"clean_traits_for_analysis"`
+      (the entry point must WRAP `validate_clean_traits`'s message, which does not itself mention
+      the entry point); use `pytest.raises(..., match=r"clean_traits_for_analysis")`. Assert it
+      raises before any detector runs.
+- [x] 1.7 Test: unique-index precondition — a frame whose index has duplicate labels raises
+      `ValueError` stating the index must be unique, before any detector runs; a default
+      `RangeIndex` frame passes the check.
+- [x] 1.8 Test: output readiness —
+      (a) a fixture where trimming would leave <2 samples raises `ValueError` naming the count,
+          and the raised error carries `outlier_report` (assert the attribute is present);
+      (b) the constant-trait gate is unit-tested directly on the readiness helper (constructing a
+          "trait varies in clean_df but is constant only after the detector removes exactly the
+          varying rows" fixture is not reliably achievable through real detection, so test the
+          gate in isolation and document it as white-box);
+      (c) happy path: `perform_pca_analysis(trimmed_df[trait_cols])` runs and reports sample count
+          == `len(trimmed_df)`;
+      (d) a varying trait surviving alongside a constant one passes the gate (returns successfully).
+- [x] 1.9 Test: p > n warning — a fixture where trimming leaves more surviving traits than
+      samples emits a `UserWarning` mentioning `p > n` (use `pytest.warns`) and still returns.
+- [x] 1.10 Test: over-removal rail — use n≈30 with `method="mahalanobis", use_chi_squared=False,
+      distance_threshold=<tuned>` so >50% of samples are removed yet ≥2 varying samples survive;
+      assert a `UserWarning` about the large removal fraction fires AND the call still returns.
+      Add a sibling case where over-removal breaches readiness (<2 survive) and assert BOTH the
+      `UserWarning` fires AND a `ValueError` is then raised (order: warn before gate).
+- [x] 1.11 Test: report schema — keys present and consistent
+      (`n_input_samples == n_outliers + n_output_samples`,
+      `removal_fraction == n_outliers / n_input_samples`); for Mahalanobis `threshold_type`,
+      `threshold_value`, `n_components`, `goodness_of_fit` populated; for isolation forest those
+      four are `None`; `outlier_barcodes` is `None` when no `Barcode` column. **JSON adversarial**:
+      build the fixture so a missing cast would surface numpy types — assert
+      `all(type(i) in (int, str) for i in report["outlier_indices"])`,
+      `type(report["threshold_value"]) is float` (Mahalanobis), and `json.dumps(report)` succeeds.
+- [x] 1.12 Test: determinism —
+      (a) default Mahalanobis: two calls with `random_state=7` return identical `outlier_indices`
+          and equal `trimmed_df`; `report["random_state"] == 7` (records the seed);
+      (b) **seed-sensitive path**: `method="isolation_forest"` (or `robust_covariance=True`) — a
+          re-run with the SAME seed yields identical `outlier_indices` (proves the seed is
+          actually threaded and load-bearing, not vacuously constant).
+- [x] 1.13 Test: detector-failure surfacing — monkeypatch the chosen detector to return a result
+      with an `error` key / no `outlier_indices`; assert `remove_outlier_samples` raises
+      `ValueError` surfacing it (NOT a silent `(clean_df, n_outliers=0)`).
+- [x] 1.14 Test: input misuse — empty input; duplicate column names; explicit `trait_cols`
+      missing from `clean_df`; explicit non-numeric `trait_cols` — each raises a distinct,
+      actionable `ValueError` (not a bare pandas error).
+- [x] 1.15 Test: caller-supplied `trait_cols` bypasses `get_trait_columns`; `replicate_col=None`
+      is honored on a frame with no replicate column.
+- [x] 1.16 Test (single-source-of-truth): spy/monkeypatch
+      `sleap_roots_analyze.outlier_removal.detect_outliers_mahalanobis` and
+      `remove_outliers_from_data`; assert `remove_outlier_samples(clean_df)` calls them, and that
+      `inspect.getsource(remove_outlier_samples)` contains no independent distance/score
+      thresholding logic.
+- [x] 1.17 Test (public API): `remove_outlier_samples` importable from `sleap_roots_analyze`,
+      present in `__all__` (alongside the already-present `detect_outliers_mahalanobis`,
+      `detect_outliers_isolation_forest`, `remove_outliers_from_data`), no duplicate `__all__`
+      entries, identity-equal to the module definition, and `get_type_hints` resolves on it.
+
+## 2. Implement the entry point (green)
+
+- [x] 2.1 New module `src/sleap_roots_analyze/outlier_removal.py`. Implement
+      `remove_outlier_samples(clean_df, trait_cols=None, *, method="mahalanobis",
+      barcode_col="Barcode", genotype_col="geno", replicate_col="rep", random_state=42,
+      **detect_kwargs) -> tuple[pd.DataFrame, dict]`:
+      empty-input guard → duplicate-column + explicit-`trait_cols` (missing/non-numeric) guards
+      → unknown-`method` guard → **unique-index guard** → resolve trait cols (`get_trait_columns`
+      if `None`) → **NaN-free precondition via `validate_clean_traits`, wrapped to add the
+      `clean_traits_for_analysis` pointer** → dispatch to `detect_outliers_mahalanobis` /
+      `detect_outliers_isolation_forest` (thread `random_state`, forward `**detect_kwargs`;
+      **raise if the result carries `error` / lacks `outlier_indices`**) →
+      `remove_outliers_from_data(clean_df, outlier_indices, keep_metadata=True,
+      return_outliers=True)` → assemble `outlier_report` (spec "Auditable Outlier Report" schema;
+      `method` from the dispatch key; threshold/`n_components`/`goodness_of_fit` from the detector
+      for Mahalanobis, `None` for isolation forest) → **over-removal `UserWarning` if
+      `removal_fraction > 0.5` (before the readiness gates)** → output readiness gates
+      (≥`MIN_SAMPLES_FOR_ANALYSIS` samples, then ≥1 `var(ddof=0) > 0` trait), raising a
+      `ValueError` that **carries `outlier_report`** → **`p > n` `UserWarning`** → return
+      `(trimmed_df, outlier_report)`.
+- [x] 2.2 Reuse the shared helpers from `data_cleanup.py` (`get_trait_columns`,
+      `validate_clean_traits`, `MIN_SAMPLES_FOR_ANALYSIS`) and the detectors/remover from
+      `outlier_detection.py` — no re-implementation of detection or removal.
+- [x] 2.3 Ensure `outlier_report` values are plain Python types (cast numpy scalars with
+      `int()` / `float()`, indices/barcodes to lists) so `json.dumps` succeeds; omit large
+      per-sample arrays (`mahalanobis_distances`, `anomaly_scores`).
+- [x] 2.4 Google-style docstring: document the composition (detect → remove), the `method`
+      choices and per-method `**detect_kwargs` (without pinning the detectors' own default values,
+      which live in `outlier_detection.py`), the clean-input + unique-index preconditions and why
+      (PCA `dropna` index alignment), the output readiness gates (and that the raise carries the
+      report), the over-removal and p > n warnings, the report schema, the ~2.5%-by-design trim of
+      the default `chi2_percentile=97.5`, and determinism via `random_state` (noting when the seed
+      is/ isn't load-bearing).
+
+## 3. Public API + types
+
+- [x] 3.1 Add `remove_outlier_samples` to `src/sleap_roots_analyze/__init__.py` imports and
+      `__all__` (verify the detect/remove functions are already present; do not duplicate).
+- [x] 3.2 Resolvable type hints (`typing.get_type_hints` must not raise); annotate
+      `**detect_kwargs: Any` and import `Any` if needed. The package `test_public_api_docs` audit
+      gate enforces complete hints + Google Args/Returns/Raises for every `__all__` entry, so this
+      is gate-checked, not optional.
+
+## 4. Reproducibility + mypy gates (repo-health, required for green CI)
+
+- [x] 4.1 **Register `remove_outlier_samples` in the reproducibility registry**: add it to
+      `tests/reproducibility_cases.py` `CASES` (or `EXCLUDED` with a documented reason), and
+      update the pinned `EXPECTED_QUALNAMES` and case-count anchors in
+      `tests/test_reproducibility.py` in lockstep. Without this the package-wide
+      `test_sweep_covers_all_stochastic_functions` gate auto-discovers the new `random_state`
+      function and fails (CI red). Run `uv run pytest tests/test_reproducibility.py` to confirm.
+- [x] 4.2 Run `uv run mypy … | mypy-baseline filter`; resolve any new errors the new module
+      introduces (new:0). Do not mask real type errors with the baseline.
+
+## 5. Docs + verify
+
+- [x] 5.1 Add `remove_outlier_samples` to `docs/API.md` (signature matching code). While there,
+      add the missing `detect_outliers_isolation_forest` and `remove_outliers_from_data` entries
+      it cross-references (currently absent from the `outlier_detection` section), so the new
+      entry's references resolve.
+- [x] 5.2 Add a `docs/CHANGELOG.md` `[Unreleased] → ### Added` entry with a `(#165)` suffix,
+      noting it composes after `clean_traits_for_analysis`.
+- [x] 5.3 `uv run pytest tests/test_remove_outlier_samples.py -q` green; new tests deterministic
+      (seeded). Then run the **full** suite `uv run pytest -m "not integration" tests/` once — the
+      new `__all__` entry + module are picked up by `test_public_api.py`,
+      `test_public_api_docs.py`, `test_packaging.py`, and `test_reproducibility.py`, none of which
+      are "outlier suites".
+- [x] 5.4 `uv run black --check . && uv run ruff check .` clean.
+- [ ] 5.5 `openspec validate add-outlier-removal-entry-point --strict` passes. (NOT RUN:
+      `openspec` CLI not installed in the dev WSL env; the change's proposal/spec/design markdown
+      is unchanged from authoring and structurally intact — run this on a machine with the CLI.)
+- [x] 5.6 Confirm the change rides the `0.1.0a4` pre-release cut for the bloom-mcp quality tool
+      to consume.

--- a/src/sleap_roots_analyze/__init__.py
+++ b/src/sleap_roots_analyze/__init__.py
@@ -81,6 +81,10 @@ from sleap_roots_analyze.outlier_detection import (
     combine_outlier_methods,
 )
 
+from sleap_roots_analyze.outlier_removal import (
+    remove_outlier_samples,
+)
+
 from sleap_roots_analyze.visualization import (
     create_trait_histograms,
     create_trait_boxplots_by_genotype,
@@ -262,6 +266,8 @@ __all__ = [
     "identify_outliers_from_distances",
     "remove_outliers_from_data",
     "combine_outlier_methods",
+    # Outlier-removal entry point (#165)
+    "remove_outlier_samples",
     # Visualization functions
     "create_trait_histograms",
     "create_trait_boxplots_by_genotype",

--- a/src/sleap_roots_analyze/outlier_removal.py
+++ b/src/sleap_roots_analyze/outlier_removal.py
@@ -1,0 +1,393 @@
+"""Public outlier-removal entry point for analysis-ready trait tables.
+
+This module adds a single tested entry point, :func:`remove_outlier_samples`,
+that **detects and removes outlier samples** from a clean (NaN-free) trait table
+so PCA/UMAP/clustering can optionally run on outlier-trimmed data. It is the
+quality-step follow-up to the minimal-QC entry point
+:func:`sleap_roots_analyze.data_cleanup.clean_traits_for_analysis` (#164): that
+function makes a frame *runnable* (no NaNs, >=2 samples, >=1 varying trait), and
+this one makes it *higher quality* by trimming outliers that distort
+principal-component directions even though they are not NaNs.
+
+The function introduces **no new detection or removal algorithm**. It imports and
+composes the already-public primitives — ``detect_outliers_mahalanobis`` /
+``detect_outliers_isolation_forest`` for detection and ``remove_outliers_from_data``
+for row removal (the same functions the QC pipeline's outlier steps use) — so the
+detection and index-alignment semantics cannot drift from the pipeline. See the
+OpenSpec change ``add-outlier-removal-entry-point`` (issue #165).
+"""
+
+from __future__ import annotations
+
+import inspect
+import warnings
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+import numpy as np
+import pandas as pd
+
+from sleap_roots_analyze.data_cleanup import (
+    MIN_SAMPLES_FOR_ANALYSIS,
+    get_trait_columns,
+    validate_clean_traits,
+)
+from sleap_roots_analyze.data_utils import convert_to_json_serializable
+
+# Imported as module-level names (not called via the ``outlier_detection`` module
+# object) so a test can monkeypatch ``outlier_removal.detect_outliers_*`` /
+# ``remove_outliers_from_data`` to assert the entry point composes them.
+from sleap_roots_analyze.outlier_detection import (
+    detect_outliers_isolation_forest,
+    detect_outliers_mahalanobis,
+    remove_outliers_from_data,
+)
+
+# Dispatch table: the public ``method`` keys -> the detector each selects. The
+# report records the *key* (e.g. ``"isolation_forest"``), not the detector's own
+# internal ``method`` label (``"IsolationForest"``).
+_DETECTORS: Dict[str, Callable[..., Dict[str, Any]]] = {
+    "mahalanobis": detect_outliers_mahalanobis,
+    "isolation_forest": detect_outliers_isolation_forest,
+}
+
+# Removing more than this fraction of samples almost always signals a mis-set
+# contamination/threshold rather than that many real outliers -> UserWarning.
+_OVER_REMOVAL_GUARD = 0.5
+
+
+class OutlierRemovalError(ValueError):
+    """Raised when the outlier-trimmed frame is not analysis-ready.
+
+    A subclass of :class:`ValueError` (so callers can keep catching ``ValueError``)
+    that additionally carries the assembled :attr:`outlier_report`, so a caller who
+    hit an over-aggressive trim can still inspect *what would have been removed*
+    even though the result failed a readiness gate.
+
+    Attributes:
+        outlier_report: The report dict the entry point assembled before the
+            readiness gate failed.
+    """
+
+    def __init__(self, message: str, outlier_report: Dict[str, Any]) -> None:
+        """Initialize the error with a message and the assembled report.
+
+        Args:
+            message: The actionable error message.
+            outlier_report: The report dict to attach for caller inspection.
+        """
+        super().__init__(message)
+        self.outlier_report = outlier_report
+
+
+def _assert_output_analysis_ready(
+    trimmed_df: pd.DataFrame,
+    trait_cols: List[str],
+    outlier_report: Dict[str, Any],
+) -> Tuple[int, int]:
+    """Re-apply the #164 analysis-readiness gates to the trimmed frame.
+
+    Factored out as a white-box helper so the constant-trait branch — which is not
+    reliably reachable through real detection on a frame that varied *before*
+    trimming — can be unit-tested directly. Checks run in a fixed order (sample
+    count first, then non-constant trait) for a deterministic message.
+
+    Args:
+        trimmed_df: The frame after outlier rows were removed.
+        trait_cols: The trait column names to gate on.
+        outlier_report: The assembled report, attached to any raised error.
+
+    Returns:
+        Tuple ``(n_samples, n_nonconstant_traits)`` when both gates pass.
+
+    Raises:
+        OutlierRemovalError: If fewer than ``MIN_SAMPLES_FOR_ANALYSIS`` samples
+            survive, or if no surviving numeric trait has ``var(ddof=0) > 0``. The
+            error carries ``outlier_report``.
+    """
+    n_samples = len(trimmed_df)
+    if n_samples < MIN_SAMPLES_FOR_ANALYSIS:
+        raise OutlierRemovalError(
+            f"remove_outlier_samples: only {n_samples} sample(s) remain after "
+            f"removing {outlier_report['n_outliers']} outlier(s); need at least "
+            f"{MIN_SAMPLES_FOR_ANALYSIS} for analysis. Loosen the detection "
+            "threshold (e.g. raise chi2_percentile or lower contamination).",
+            outlier_report,
+        )
+
+    numeric = trimmed_df[trait_cols].select_dtypes(include=[np.number])
+    n_nonconstant = int((numeric.var(ddof=0) > 0).sum()) if not numeric.empty else 0
+    if n_nonconstant < 1:
+        raise OutlierRemovalError(
+            "remove_outlier_samples: no non-constant numeric trait remains after "
+            "outlier removal; PCA/UMAP/clustering require at least one varying "
+            "trait. Loosen the detection threshold.",
+            outlier_report,
+        )
+    return n_samples, n_nonconstant
+
+
+def remove_outlier_samples(
+    clean_df: pd.DataFrame,
+    trait_cols: Optional[List[str]] = None,
+    *,
+    method: str = "mahalanobis",
+    barcode_col: str = "Barcode",
+    genotype_col: str = "geno",
+    replicate_col: Optional[str] = "rep",
+    random_state: int = 42,
+    **detect_kwargs: Any,
+) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+    """Detect and remove outlier samples from a clean, analysis-ready trait table.
+
+    Quality-step follow-up to
+    :func:`~sleap_roots_analyze.data_cleanup.clean_traits_for_analysis` (#164): it
+    takes the clean (NaN-free) frame that entry point produces and trims outlier
+    samples that distort PCA/UMAP/clustering even though they are not NaNs. It
+    **composes the existing public primitives** —
+    :func:`~sleap_roots_analyze.outlier_detection.detect_outliers_mahalanobis` /
+    :func:`~sleap_roots_analyze.outlier_detection.detect_outliers_isolation_forest`
+    for detection and
+    :func:`~sleap_roots_analyze.outlier_detection.remove_outliers_from_data` for
+    removal — and defines no detection or removal logic of its own, so its
+    semantics cannot drift from the QC pipeline's outlier steps.
+
+    The function is the opt-in: trimming runs only when a consumer calls it. The
+    intended chain is ``clean_traits_for_analysis`` -> (optional)
+    ``remove_outlier_samples`` -> ``perform_pca_analysis`` / UMAP / clustering.
+
+    Preconditions (both enforced before any detector runs). The input trait columns
+    must be **NaN-free** and the input index must be **unique**. Both are
+    correctness guards, not mere defense: the detectors run PCA which silently
+    ``dropna()``s rows and reports outlier indices against the post-``dropna``
+    index, and removal is label-based — so a NaN-carrying or duplicate-labelled
+    input would misalign the indices handed to ``remove_outliers_from_data`` and
+    mis-drop rows. Together they guarantee detection labels align one-to-one with
+    the input's rows.
+
+    After removal the function re-applies the #164 readiness gates (at least
+    ``MIN_SAMPLES_FOR_ANALYSIS`` surviving samples, at least one non-constant
+    ``var(ddof=0) > 0`` trait) so the trimmed frame is still safe to hand straight
+    to PCA/UMAP/clustering; if a gate fails it raises
+    :class:`OutlierRemovalError` (a ``ValueError``) **carrying the report** so the
+    caller can still inspect what would have been removed. It emits a
+    ``UserWarning`` when the removed fraction is large (> 0.5, before the readiness
+    gates — the signature of a mis-set ``contamination``/threshold) and another in
+    the ``p > n`` regime (surviving traits outnumber samples), matching
+    ``clean_traits_for_analysis``.
+
+    Determinism: ``random_state`` is threaded into the detector and recorded in the
+    report; the same ``clean_df`` + ``method`` + ``random_state`` + per-method
+    params yield identical ``outlier_indices`` and ``trimmed_df``. The seed is only
+    load-bearing on stochastic paths (``method="isolation_forest"``,
+    ``robust_covariance=True``, or large-n randomized SVD); the default exact-SVD
+    Mahalanobis path is identical regardless of seed.
+
+    Note:
+        The default ``method="mahalanobis"`` with ``chi2_percentile=97.5`` trims
+        roughly the top 2.5% of samples *by construction* on a well-fit chi-squared
+        tail — i.e. it removes ~2.5% even on clean data. Tighten ``chi2_percentile``
+        or switch to ``method="isolation_forest"`` with an explicit
+        ``contamination`` to control this; the report's ``goodness_of_fit`` surfaces
+        when the chi-squared assumption (and thus the percentile's meaning) is
+        violated.
+
+    Args:
+        clean_df: A clean (NaN-free in the trait columns), unique-indexed wide trait
+            table, e.g. the first element returned by ``clean_traits_for_analysis``.
+        trait_cols: Trait column names to score. If ``None``, resolved via
+            :func:`~sleap_roots_analyze.data_cleanup.get_trait_columns`.
+        method: Detection method, either ``"mahalanobis"`` (default — Mahalanobis
+            distance on PCA-transformed data with a chi-squared threshold) or
+            ``"isolation_forest"``. An unknown value raises ``ValueError``.
+        barcode_col: Barcode/plant-ID column. Excluded from inferred traits, and the
+            column read to populate ``outlier_barcodes``.
+        genotype_col: Genotype column to exclude when inferring traits.
+        replicate_col: Replicate column to exclude if present (``None`` if absent).
+        random_state: Seed forwarded to the detector for reproducibility.
+        **detect_kwargs: Per-method parameters forwarded to the chosen detector
+            unchanged — ``contamination`` for ``"isolation_forest"``;
+            ``chi2_percentile``, ``variance_threshold``, ``use_chi_squared``,
+            ``distance_threshold``, ``robust_covariance`` for ``"mahalanobis"``.
+            Detector defaults apply for any not passed.
+
+    Returns:
+        Tuple ``(trimmed_df, outlier_report)`` where ``trimmed_df`` is ``clean_df``
+        with the flagged outlier rows removed (all columns preserved — outlier
+        removal drops rows, never columns) and ``outlier_report`` is an auditable,
+        JSON-serializable dict with keys: ``method``, ``method_params``,
+        ``random_state``, ``n_input_samples``, ``n_outliers``, ``n_output_samples``,
+        ``removal_fraction``, ``outlier_indices``, ``outlier_barcodes``,
+        ``threshold_type``, ``threshold_value``, ``n_components``,
+        ``variance_threshold``, and ``goodness_of_fit``. The four method-dependent
+        keys (``threshold_type``, ``threshold_value``, ``n_components``,
+        ``goodness_of_fit``) are populated for Mahalanobis and ``None`` for
+        isolation forest (whose control is ``contamination``, in ``method_params``).
+
+    Raises:
+        ValueError: On empty input; duplicate column names; explicit ``trait_cols``
+            missing from ``clean_df`` or non-numeric; an unknown ``method``; a
+            non-unique index; NaN in the trait columns (the message points to
+            ``clean_traits_for_analysis``); or a detector failure (rather than
+            silently reporting zero outliers).
+        OutlierRemovalError: A ``ValueError`` subclass, raised when trimming leaves
+            fewer than ``MIN_SAMPLES_FOR_ANALYSIS`` samples or no non-constant
+            trait. It carries the ``outlier_report`` as an attribute.
+    """
+    # (1) Empty input -> our own message before delegating.
+    if clean_df is None or clean_df.shape[0] == 0:
+        raise ValueError(
+            "remove_outlier_samples: input table has no rows; nothing to trim."
+        )
+
+    # (2) Duplicate column names make trait selection ambiguous.
+    if clean_df.columns.duplicated().any():
+        dups = sorted(set(clean_df.columns[clean_df.columns.duplicated()]))
+        raise ValueError(
+            f"remove_outlier_samples: duplicate column names in input: {dups}. "
+            "Deduplicate columns before trimming."
+        )
+
+    # (3) Validate explicit trait_cols up front (actionable, not a bare KeyError).
+    if trait_cols is not None:
+        missing = [c for c in trait_cols if c not in clean_df.columns]
+        if missing:
+            raise ValueError(
+                f"remove_outlier_samples: trait_cols not found in dataframe: "
+                f"{missing}."
+            )
+        non_numeric = [
+            c for c in trait_cols if not pd.api.types.is_numeric_dtype(clean_df[c])
+        ]
+        if non_numeric:
+            raise ValueError(
+                "remove_outlier_samples: trait_cols must be numeric; non-numeric "
+                f"columns passed: {non_numeric}."
+            )
+
+    # (4) Unknown method -> fail fast, naming the supported set.
+    if method not in _DETECTORS:
+        raise ValueError(
+            f"remove_outlier_samples: unknown method {method!r}. Supported methods: "
+            f"{sorted(_DETECTORS)}."
+        )
+
+    # (5) Unique index -> label-based removal would otherwise mis-drop rows.
+    if not clean_df.index.is_unique:
+        raise ValueError(
+            "remove_outlier_samples: input index must be unique (label-based outlier "
+            "removal would otherwise mis-drop rows sharing a flagged label). Reset "
+            "the index before trimming."
+        )
+
+    # (6) Resolve trait columns if not supplied (same ergonomics as the sibling).
+    if trait_cols is None:
+        trait_cols = get_trait_columns(
+            clean_df,
+            barcode_col=barcode_col,
+            genotype_col=genotype_col,
+            replicate_col=replicate_col,
+        )
+    if not trait_cols:
+        raise ValueError(
+            "remove_outlier_samples: no trait columns found to trim. Pass trait_cols "
+            "explicitly or check the metadata column names."
+        )
+
+    # (7) Clean-input precondition: trait columns must be NaN-free. Wrap the shared
+    # validator's message (which names the traits but not this entry point) to add
+    # the pointer to clean_traits_for_analysis.
+    try:
+        validate_clean_traits(clean_df, trait_cols)
+    except ValueError as exc:
+        raise ValueError(
+            f"{exc} Run clean_traits_for_analysis first to produce a NaN-free, "
+            "analysis-ready frame before remove_outlier_samples."
+        ) from exc
+
+    # (8) Detect with the single selected method. Record the effective per-method
+    # params from the detector's (import-bound) signature: caller override or the
+    # detector's own default. The actual call goes through the module-level names
+    # (not the _DETECTORS dict) so a test can monkeypatch
+    # ``outlier_removal.detect_outliers_*`` to exercise the composition / failure path.
+    method_params = {
+        name: detect_kwargs.get(name, param.default)
+        for name, param in inspect.signature(_DETECTORS[method]).parameters.items()
+        if name not in ("data", "random_state")
+        and param.kind
+        not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+    }
+    if method == "mahalanobis":
+        detect_result = detect_outliers_mahalanobis(
+            clean_df[trait_cols], random_state=random_state, **detect_kwargs
+        )
+    else:  # "isolation_forest" — the only other key validated above.
+        detect_result = detect_outliers_isolation_forest(
+            clean_df[trait_cols], random_state=random_state, **detect_kwargs
+        )
+
+    # Surface a detector failure rather than treating "no indices" as "no outliers".
+    if "error" in detect_result or "outlier_indices" not in detect_result:
+        raise ValueError(
+            "remove_outlier_samples: outlier detection failed: "
+            f"{detect_result.get('error', 'detector returned no outlier_indices')}"
+        )
+    outlier_indices = detect_result["outlier_indices"]
+
+    # (9) Remove the flagged rows (keep_metadata=True preserves Barcode/geno/rep).
+    trimmed_df, outlier_df = remove_outliers_from_data(
+        clean_df, outlier_indices, keep_metadata=True, return_outliers=True
+    )
+
+    # (10) Assemble the auditable report. Method-dependent keys are absent from the
+    # isolation-forest detector dict, so ``.get`` yields ``None`` for it.
+    n_input = len(clean_df)
+    n_output = len(trimmed_df)
+    n_outliers = n_input - n_output
+    outlier_barcodes = (
+        outlier_df[barcode_col].tolist() if barcode_col in clean_df.columns else None
+    )
+    outlier_report: Dict[str, Any] = {
+        "method": method,
+        "method_params": method_params,
+        "random_state": random_state,
+        "n_input_samples": n_input,
+        "n_outliers": n_outliers,
+        "n_output_samples": n_output,
+        "removal_fraction": (n_outliers / n_input) if n_input else 0.0,
+        "outlier_indices": outlier_indices,
+        "outlier_barcodes": outlier_barcodes,
+        "threshold_type": detect_result.get("threshold_type"),
+        "threshold_value": detect_result.get("threshold_value"),
+        "n_components": detect_result.get("n_components"),
+        "variance_threshold": detect_result.get("variance_threshold"),
+        "goodness_of_fit": detect_result.get("goodness_of_fit"),
+    }
+    # Cast every value to plain Python types (numpy scalars/arrays -> int/float/list,
+    # nested goodness_of_fit included) so json.dumps(outlier_report) succeeds. Large
+    # per-sample arrays were never copied in, so the report stays compact.
+    outlier_report = convert_to_json_serializable(outlier_report)
+
+    # (11) Over-removal rail BEFORE the readiness gates, so the warning that points
+    # at the over-removal is observable even when the same trim then fails a gate.
+    if outlier_report["removal_fraction"] > _OVER_REMOVAL_GUARD:
+        warnings.warn(
+            f"remove_outlier_samples: removed {n_outliers}/{n_input} samples "
+            f"({outlier_report['removal_fraction']:.1%}); a large removal fraction "
+            "usually means a mis-set contamination/threshold rather than that many "
+            "real outliers. Check the detection parameters.",
+            stacklevel=2,
+        )
+
+    # (12) Output readiness gates (raise OutlierRemovalError carrying the report).
+    _assert_output_analysis_ready(trimmed_df, trait_cols, outlier_report)
+
+    # (13) p > n warning: trimming shrinks n, so an n > p frame can become p > n.
+    if n_output < len(trait_cols):
+        warnings.warn(
+            f"remove_outlier_samples: {n_output} samples < {len(trait_cols)} traits "
+            "(p > n) after trimming; multivariate analysis results will be "
+            "statistically unreliable. Consider more samples or fewer traits.",
+            stacklevel=2,
+        )
+
+    return trimmed_df, outlier_report

--- a/src/sleap_roots_analyze/outlier_removal.py
+++ b/src/sleap_roots_analyze/outlier_removal.py
@@ -54,6 +54,10 @@ _DETECTORS: Dict[str, Callable[..., Dict[str, Any]]] = {
 # contamination/threshold rather than that many real outliers -> UserWarning.
 _OVER_REMOVAL_GUARD = 0.5
 
+# Below this sample count the Mahalanobis path's chi-squared tail / covariance
+# estimate is statistically fragile, so the default trim deserves a UserWarning.
+_SMALL_N_MAHALANOBIS = 30
+
 
 class OutlierRemovalError(ValueError):
     """Raised when the outlier-trimmed frame is not analysis-ready.
@@ -173,7 +177,10 @@ def remove_outlier_samples(
     ``UserWarning`` when the removed fraction is large (> 0.5, before the readiness
     gates — the signature of a mis-set ``contamination``/threshold) and another in
     the ``p > n`` regime (surviving traits outnumber samples), matching
-    ``clean_traits_for_analysis``.
+    ``clean_traits_for_analysis``. On the Mahalanobis path it additionally warns when
+    the sample count is small (< 30 — fragile chi-squared tail / covariance) and when
+    the detector's chi-squared goodness-of-fit reports the distributional assumption
+    is violated (so the percentile threshold's meaning is questionable).
 
     Determinism: ``random_state`` is threaded into the detector and recorded in the
     report; the same ``clean_df`` + ``method`` + ``random_state`` + per-method
@@ -225,8 +232,10 @@ def remove_outlier_samples(
 
     Raises:
         ValueError: On empty input; duplicate column names; explicit ``trait_cols``
-            missing from ``clean_df`` or non-numeric; an unknown ``method``; a
-            non-unique index; NaN in the trait columns (the message points to
+            missing from ``clean_df`` or non-numeric; an unknown ``method``; unknown
+            or cross-method ``**detect_kwargs`` for the chosen detector (the message
+            names the unrecognized keys and the supported set); a non-unique index;
+            NaN in the trait columns (the message points to
             ``clean_traits_for_analysis``); or a detector failure (rather than
             silently reporting zero outliers).
         OutlierRemovalError: A ``ValueError`` subclass, raised when trimming leaves
@@ -316,6 +325,18 @@ def remove_outlier_samples(
         and param.kind
         not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
     }
+    # Reject unknown / cross-method detect_kwargs up front with an actionable error,
+    # mirroring the unknown-method guard. The detectors take fixed signatures (no
+    # **kwargs), so an unrecognized key (a typo, or an isolation-forest knob passed
+    # to the default Mahalanobis method) would otherwise be silently absent from
+    # method_params and then raise a bare TypeError leaking the detector's name.
+    unknown_kwargs = set(detect_kwargs) - set(method_params)
+    if unknown_kwargs:
+        raise ValueError(
+            f"remove_outlier_samples: unknown detect_kwargs for method {method!r}: "
+            f"{sorted(unknown_kwargs)}. Supported for this method: "
+            f"{sorted(method_params)}."
+        )
     if method == "mahalanobis":
         detect_result = detect_outliers_mahalanobis(
             clean_df[trait_cols], random_state=random_state, **detect_kwargs
@@ -342,7 +363,15 @@ def remove_outlier_samples(
     # isolation-forest detector dict, so ``.get`` yields ``None`` for it.
     n_input = len(clean_df)
     n_output = len(trimmed_df)
+    # Derive the count from the trimmed-frame delta (what remove_outliers_from_data
+    # actually dropped after its own valid-index filter) rather than trusting
+    # len(outlier_indices). The NaN-free + unique-index preconditions guarantee the
+    # two agree, so assert it to keep the invariant self-checking.
     n_outliers = n_input - n_output
+    assert n_outliers == len(outlier_indices), (
+        f"outlier count mismatch: trimmed {n_outliers} rows but detector flagged "
+        f"{len(outlier_indices)} labels (precondition violated?)"
+    )
     outlier_barcodes = (
         outlier_df[barcode_col].tolist() if barcode_col in clean_df.columns else None
     )
@@ -377,6 +406,34 @@ def remove_outlier_samples(
             "real outliers. Check the detection parameters.",
             stacklevel=2,
         )
+
+    # (11b) Mahalanobis quality signals (also before the readiness gates, so they
+    # are observable even when an aggressive trim then fails a gate). The percentile
+    # threshold's meaning rests on the chi-squared fit, which degrades on small n and
+    # when the squared-distance distribution does not match chi-squared; the default
+    # ~2.5% trim of genuinely-clean data otherwise passes with no signal.
+    if method == "mahalanobis":
+        if n_input < _SMALL_N_MAHALANOBIS:
+            warnings.warn(
+                f"remove_outlier_samples: only {n_input} samples on the Mahalanobis "
+                f"path (< {_SMALL_N_MAHALANOBIS}); the chi-squared tail and covariance "
+                "estimate are statistically fragile at this size, so the flagged "
+                "outliers may be unreliable. Inspect the result or use a larger sample.",
+                stacklevel=2,
+            )
+        gof = outlier_report.get("goodness_of_fit")
+        if (
+            isinstance(gof, dict)
+            and gof.get("distributional_assumption_valid") is False
+        ):
+            warnings.warn(
+                "remove_outlier_samples: the squared Mahalanobis distances do not "
+                f"fit the chi-squared assumption (goodness-of-fit: "
+                f"{gof.get('fit_quality')!r}), so the chi2_percentile threshold's "
+                "meaning is questionable; treat the flagged outliers with caution or "
+                "use method='isolation_forest' with an explicit contamination.",
+                stacklevel=2,
+            )
 
     # (12) Output readiness gates (raise OutlierRemovalError carrying the report).
     _assert_output_analysis_ready(trimmed_df, trait_cols, outlier_report)

--- a/tests/reproducibility_cases.py
+++ b/tests/reproducibility_cases.py
@@ -18,7 +18,13 @@ from typing import Callable, List
 import numpy as np
 import pandas as pd
 
-from sleap_roots_analyze import clustering, outlier_detection, pca, umap
+from sleap_roots_analyze import (
+    clustering,
+    outlier_detection,
+    outlier_removal,
+    pca,
+    umap,
+)
 
 # Tolerance for floating-point arrays. Within a single machine the outputs are
 # bit-identical; rtol=1e-6 leaves headroom for cross-platform BLAS differences
@@ -146,6 +152,14 @@ def _compare_mahalanobis(a, b):
     _close(dist_a, dist_b, "distances")
     _close(mean_a, mean_b, "mean")
     _close(cov_a, cov_b, "covariance")
+
+
+def _compare_remove_outlier_samples(a, b):
+    """Compare ``remove_outlier_samples``: (trimmed_df, outlier_report)."""
+    (df_a, report_a) = a
+    (df_b, report_b) = b
+    _exact(report_a["outlier_indices"], report_b["outlier_indices"], "outlier_indices")
+    pd.testing.assert_frame_equal(df_a, df_b)
 
 
 def _silence(fn):
@@ -304,6 +318,17 @@ CASES: List[Case] = [
             )
         ),
         _compare_mahalanobis,
+    ),
+    Case(
+        # Public outlier-removal entry point (#165). Seeds the detector and returns
+        # the trimmed frame + report; the default Mahalanobis path is deterministic
+        # under exact SVD, but the function is caller-seedable (and isolation_forest
+        # makes the seed load-bearing), so the sweep keeps it covered.
+        outlier_removal.remove_outlier_samples,
+        lambda ctx, seed: _silence(
+            lambda: outlier_removal.remove_outlier_samples(ctx.df, random_state=seed)
+        ),
+        _compare_remove_outlier_samples,
     ),
 ]
 

--- a/tests/test_remove_outlier_samples.py
+++ b/tests/test_remove_outlier_samples.py
@@ -153,6 +153,25 @@ def test_unknown_method_rejected_before_detection(clean_frame, no_detect):
         remove_outlier_samples(clean_frame, method="not_a_method")
 
 
+def test_unknown_detect_kwarg_rejected_before_detection(clean_frame, no_detect):
+    """An unknown / cross-method detect_kwarg raises a prefixed ValueError.
+
+    Not a bare TypeError — the message names the unrecognized key and the supported
+    set, and ``no_detect`` proves the guard fires before any detector runs.
+    """
+    # isolation-forest-only knob passed to the default Mahalanobis method
+    with pytest.raises(ValueError, match=r"unknown detect_kwargs.*contamination"):
+        remove_outlier_samples(clean_frame, contamination=0.2)
+    # Mahalanobis knob passed to isolation forest
+    with pytest.raises(ValueError, match=r"unknown detect_kwargs.*chi2_percentile"):
+        remove_outlier_samples(
+            clean_frame, method="isolation_forest", chi2_percentile=99.0
+        )
+    # a plain typo is caught too (and the supported set is named)
+    with pytest.raises(ValueError, match=r"unknown detect_kwargs.*chi2_percentil\b"):
+        remove_outlier_samples(clean_frame, chi2_percentil=99.0)
+
+
 # ---------------------------------------------------------------------------
 # 1.6 — clean-input precondition (NaN-free, wrapped message)
 # ---------------------------------------------------------------------------
@@ -231,17 +250,20 @@ def test_constant_trait_alongside_varying_passes(clean_frame):
 # ---------------------------------------------------------------------------
 # 1.9 — p > n warning
 # ---------------------------------------------------------------------------
-def test_p_greater_than_n_warns_and_returns():
-    """Trimming into the p > n regime warns and still returns."""
-    frame = _build_outlier_frame(n=8, inject=(), sd=0.0)
-    with pytest.warns(UserWarning, match=r"p > n"):
-        trimmed, _ = remove_outlier_samples(
-            frame,
-            method="mahalanobis",
-            use_chi_squared=False,
-            distance_threshold=2.0,
-        )
-    assert len(trimmed) < len(TRAITS)  # survivors fewer than traits
+def test_p_greater_than_n_warns_without_over_removal():
+    """Trimming into p > n warns specifically about p > n, not via over-removal.
+
+    The input is already p > n (6 samples, 8 traits) and clean, so the default trim
+    removes ~0 rows — the p > n warning fires while the over-removal rail does not, so
+    the assertion cannot pass on the wrong warning.
+    """
+    frame = _build_outlier_frame(n=6, n_traits=8, inject=())
+    with pytest.warns(UserWarning) as record:
+        trimmed, _ = remove_outlier_samples(frame)
+    msgs = [str(w.message) for w in record]
+    assert any("p > n" in m for m in msgs)
+    assert not any("large removal fraction" in m for m in msgs)
+    assert len(trimmed) < 8  # survivors fewer than traits
 
 
 # ---------------------------------------------------------------------------
@@ -271,6 +293,43 @@ def test_over_removal_warning_precedes_readiness_failure(clean_frame):
                 use_chi_squared=False,
                 distance_threshold=0.0,
             )
+
+
+# ---------------------------------------------------------------------------
+# Mahalanobis scientific-quality signals (small-n, goodness-of-fit)
+# ---------------------------------------------------------------------------
+def test_small_n_mahalanobis_warns():
+    """The Mahalanobis path warns when the sample count is small (< 30)."""
+    frame = _build_outlier_frame(n=20, inject=())  # clean, 5 traits, n < 30
+    with pytest.warns(UserWarning, match=r"statistically fragile at this size"):
+        trimmed, _ = remove_outlier_samples(frame)
+    assert len(trimmed) >= 2
+
+
+def test_goodness_of_fit_violation_warns():
+    """A poor chi-squared fit (heavy-tailed data) warns about the assumption.
+
+    n=50 keeps it off the small-n path, isolating the goodness-of-fit signal: the
+    squared Mahalanobis distances of exp^2 data do not match a chi-squared tail, so
+    the detector reports ``distributional_assumption_valid=False`` and the entry
+    point surfaces it rather than trimming ~2.5% silently.
+    """
+    rng = np.random.RandomState(1)
+    df = pd.DataFrame({f"trait_{j}": rng.exponential(2.0, 50) ** 2 for j in range(4)})
+    df.insert(0, "Barcode", [f"BC{i:03d}" for i in range(50)])
+    with pytest.warns(UserWarning, match=r"chi-squared assumption"):
+        trimmed, _ = remove_outlier_samples(df, replicate_col=None)
+    assert len(trimmed) >= 2
+
+
+def test_no_quality_warnings_on_clean_large_sample(clean_frame):
+    """A clean n=40 frame trims without any small-n / goodness-of-fit warning."""
+    with warnings.catch_warnings(record=True) as record:
+        warnings.simplefilter("always")
+        remove_outlier_samples(clean_frame)
+    msgs = [str(w.message) for w in record]
+    assert not any("statistically fragile" in m for m in msgs)
+    assert not any("chi-squared assumption" in m for m in msgs)
 
 
 # ---------------------------------------------------------------------------
@@ -442,6 +501,34 @@ def test_composes_detect_and_remove_primitives(clean_frame, monkeypatch):
     remove_outlier_samples(clean_frame)
     assert calls["detect"] == 1
     assert calls["remove"] == 1
+
+
+def test_detector_receives_trait_subframe_and_forwarded_kwargs(
+    clean_frame, monkeypatch
+):
+    """The detector is invoked on exactly clean_df[trait_cols] with forwarded kwargs.
+
+    A spy on the call args (not just the echoed method_params, which would look right
+    even if the kwarg were dropped before the call) confirms the trait subframe and
+    the threaded random_state actually reach the detector.
+    """
+    captured: dict = {}
+    real = outlier_removal.detect_outliers_mahalanobis
+
+    def spy(data, **kwargs):
+        captured["columns"] = list(data.columns)
+        captured["index"] = data.index
+        captured["kwargs"] = dict(kwargs)
+        return real(data, **kwargs)
+
+    monkeypatch.setattr(outlier_removal, "detect_outliers_mahalanobis", spy)
+    remove_outlier_samples(clean_frame, chi2_percentile=99.0, random_state=7)
+    # Detection operates over exactly the trait columns (no metadata), same index.
+    assert captured["columns"] == TRAITS
+    assert captured["index"].equals(clean_frame.index)
+    # The forwarded kwarg and the threaded seed reach the detector unchanged.
+    assert captured["kwargs"]["chi2_percentile"] == 99.0
+    assert captured["kwargs"]["random_state"] == 7
 
 
 def test_source_has_no_independent_thresholding_logic():

--- a/tests/test_remove_outlier_samples.py
+++ b/tests/test_remove_outlier_samples.py
@@ -1,0 +1,478 @@
+"""Tests for the public outlier-removal entry point ``remove_outlier_samples``.
+
+Covers the composition (detect -> remove), the clean-input + unique-index
+preconditions, the analysis-readiness gates and warnings, the auditable
+JSON-serializable report, determinism, and the public API surface. See OpenSpec
+change ``add-outlier-removal-entry-point`` (issue #165).
+
+Fixture note: the canonical fixture (``clean_frame``) is pinned so that the default
+``detect_outliers_mahalanobis(chi2_percentile=97.5)`` flags *exactly* the injected
+indices — verified during authoring against the real detector (deterministic,
+exact-SVD path). The distance-threshold constants used by the readiness /
+over-removal / p>n fixtures were likewise tuned against the real detector.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import typing
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import sleap_roots_analyze as sra
+from sleap_roots_analyze import outlier_removal
+from sleap_roots_analyze.outlier_removal import (
+    OutlierRemovalError,
+    _assert_output_analysis_ready,
+    remove_outlier_samples,
+)
+from sleap_roots_analyze.pca import perform_pca_analysis
+
+TRAITS = [f"trait_{j}" for j in range(5)]
+INJECTED = [5, 17, 28]  # the indices pushed far out in the canonical fixture
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+def _build_outlier_frame(
+    n=40,
+    n_traits=5,
+    inject=(5, 17, 28),
+    sd=8.0,
+    n_inject_traits=3,
+    seed=42,
+):
+    """Build a clean (NaN-free) trait frame with a few injected outlier rows.
+
+    Args:
+        n: Number of samples.
+        n_traits: Number of numeric trait columns.
+        inject: Row indices to push out as outliers.
+        sd: Standard-deviation offset applied to injected rows.
+        n_inject_traits: How many leading traits to perturb per injected row.
+        seed: RNG seed (deterministic, exact).
+
+    Returns:
+        A DataFrame with Barcode/geno/rep metadata plus ``n_traits`` numeric
+        traits, default RangeIndex.
+    """
+    rng = np.random.RandomState(seed)
+    df = pd.DataFrame({f"trait_{j}": rng.randn(n) for j in range(n_traits)})
+    for idx in inject:
+        for j in range(n_inject_traits):
+            df.loc[idx, f"trait_{j}"] += sd
+    df.insert(0, "Barcode", [f"BC{i:03d}" for i in range(n)])
+    df.insert(1, "geno", ["G1"] * (n // 2) + ["G2"] * (n - n // 2))
+    df.insert(2, "rep", list(range(1, n // 2 + 1)) * 2)
+    return df
+
+
+@pytest.fixture
+def clean_frame():
+    """Canonical 40-sample frame; default Mahalanobis flags exactly INJECTED."""
+    return _build_outlier_frame()
+
+
+@pytest.fixture
+def no_detect(monkeypatch):
+    """Make both detectors explode if reached (proves a guard fired first)."""
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("detector should not run; a guard must fire first")
+
+    monkeypatch.setattr(outlier_removal, "detect_outliers_mahalanobis", _boom)
+    monkeypatch.setattr(outlier_removal, "detect_outliers_isolation_forest", _boom)
+
+
+# ---------------------------------------------------------------------------
+# 1.2 / 1.3 / 1.4 — composition, return shape, alignment
+# ---------------------------------------------------------------------------
+def test_returns_tuple_and_drops_rows_not_columns(clean_frame):
+    """Returns (trimmed_df, report); rows dropped by n_outliers, columns intact."""
+    trimmed, report = remove_outlier_samples(clean_frame)
+    assert isinstance(trimmed, pd.DataFrame)
+    assert isinstance(report, dict)
+    assert len(trimmed) == len(clean_frame) - report["n_outliers"]
+    # Outlier removal drops rows, never columns.
+    assert list(trimmed.columns) == list(clean_frame.columns)
+
+
+def test_default_mahalanobis_flags_exact_injected(clean_frame):
+    """Default Mahalanobis removes exactly the injected rows."""
+    trimmed, report = remove_outlier_samples(clean_frame)
+    assert sorted(report["outlier_indices"]) == sorted(INJECTED)
+    assert not set(INJECTED) & set(trimmed.index)
+
+
+def test_isolation_forest_is_superset_not_exact(clean_frame):
+    """Isolation forest (a contamination quota) flags at least the injected rows."""
+    _, report = remove_outlier_samples(clean_frame, method="isolation_forest")
+    assert set(INJECTED) <= set(report["outlier_indices"])
+
+
+def test_indices_align_with_index_and_barcodes(clean_frame):
+    """Every flagged label is in the input index; barcodes list removed rows."""
+    _, report = remove_outlier_samples(clean_frame)
+    assert all(label in clean_frame.index for label in report["outlier_indices"])
+    expected_barcodes = clean_frame.loc[report["outlier_indices"], "Barcode"].tolist()
+    assert report["outlier_barcodes"] == expected_barcodes
+
+
+# ---------------------------------------------------------------------------
+# 1.5 — method selection
+# ---------------------------------------------------------------------------
+def test_default_method_is_mahalanobis(clean_frame):
+    """The dispatch key recorded for the default path is 'mahalanobis'."""
+    _, report = remove_outlier_samples(clean_frame)
+    assert report["method"] == "mahalanobis"
+
+
+def test_isolation_forest_dispatch_key_and_params(clean_frame):
+    """Method is the dispatch key (not 'IsolationForest'); params echo contamination."""
+    _, report = remove_outlier_samples(
+        clean_frame, method="isolation_forest", contamination=0.2
+    )
+    assert report["method"] == "isolation_forest"
+    assert report["method_params"]["contamination"] == 0.2
+
+
+def test_mahalanobis_kwargs_echoed(clean_frame):
+    """A forwarded Mahalanobis kwarg is recorded in method_params."""
+    _, report = remove_outlier_samples(clean_frame, chi2_percentile=99.0)
+    assert report["method_params"]["chi2_percentile"] == 99.0
+
+
+def test_unknown_method_rejected_before_detection(clean_frame, no_detect):
+    """An unknown method raises (naming the supported set) before any detection."""
+    with pytest.raises(ValueError, match=r"mahalanobis.*isolation_forest|unknown"):
+        remove_outlier_samples(clean_frame, method="not_a_method")
+
+
+# ---------------------------------------------------------------------------
+# 1.6 — clean-input precondition (NaN-free, wrapped message)
+# ---------------------------------------------------------------------------
+def test_nan_input_rejected_with_pointer(clean_frame, no_detect):
+    """A NaN in a trait raises, naming the trait AND pointing to the sibling."""
+    dirty = clean_frame.copy()
+    dirty.loc[0, "trait_1"] = np.nan
+    with pytest.raises(ValueError, match=r"clean_traits_for_analysis") as exc:
+        remove_outlier_samples(dirty)
+    assert "trait_1" in str(exc.value)  # wrapped validator message names the trait
+
+
+# ---------------------------------------------------------------------------
+# 1.7 — unique-index precondition
+# ---------------------------------------------------------------------------
+def test_non_unique_index_rejected_before_detection(clean_frame, no_detect):
+    """A duplicate-label index raises, before any detector runs."""
+    dup = clean_frame.copy()
+    dup.index = [0] * len(dup)
+    with pytest.raises(ValueError, match=r"unique"):
+        remove_outlier_samples(dup)
+
+
+def test_default_rangeindex_accepted(clean_frame):
+    """A default unique RangeIndex passes the uniqueness check."""
+    trimmed, _ = remove_outlier_samples(clean_frame)
+    assert len(trimmed) == len(clean_frame) - len(INJECTED)
+
+
+# ---------------------------------------------------------------------------
+# 1.8 — output analysis-readiness
+# ---------------------------------------------------------------------------
+def test_readiness_under_two_samples_raises_and_carries_report(clean_frame):
+    """<2 survivors raises, names the count, and the error carries the report."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")  # over-removal warning also fires here
+        with pytest.raises(OutlierRemovalError, match=r"only 0 sample") as exc:
+            remove_outlier_samples(
+                clean_frame,
+                method="mahalanobis",
+                use_chi_squared=False,
+                distance_threshold=0.0,
+            )
+    assert hasattr(exc.value, "outlier_report")
+    assert exc.value.outlier_report["n_outliers"] == len(clean_frame)
+
+
+def test_readiness_constant_trait_gate_whitebox():
+    """White-box: the constant-only branch of the readiness helper raises.
+
+    A "trait varies in clean_df but is constant only after the detector removes
+    exactly the varying rows" fixture is not reliably achievable through real
+    detection, so the gate is exercised directly on the helper.
+    """
+    const_only = pd.DataFrame({"trait_a": [5.0, 5.0, 5.0]})
+    with pytest.raises(ValueError, match=r"non-constant"):
+        _assert_output_analysis_ready(const_only, ["trait_a"], {"n_outliers": 0})
+
+
+def test_trimmed_frame_runs_pca_without_dropping_rows(clean_frame):
+    """The trimmed frame flows straight into PCA with no row loss."""
+    trimmed, _ = remove_outlier_samples(clean_frame)
+    result = perform_pca_analysis(trimmed[TRAITS])
+    assert result["data_processed"].shape[0] == len(trimmed)
+
+
+def test_constant_trait_alongside_varying_passes(clean_frame):
+    """A constant trait surviving with a varying one does not fail the gate."""
+    frame = clean_frame.copy()
+    frame["trait_const"] = 5.0
+    trimmed, _ = remove_outlier_samples(frame, trait_cols=TRAITS + ["trait_const"])
+    assert "trait_const" in trimmed.columns
+    assert len(trimmed) == len(clean_frame) - len(INJECTED)
+
+
+# ---------------------------------------------------------------------------
+# 1.9 — p > n warning
+# ---------------------------------------------------------------------------
+def test_p_greater_than_n_warns_and_returns():
+    """Trimming into the p > n regime warns and still returns."""
+    frame = _build_outlier_frame(n=8, inject=(), sd=0.0)
+    with pytest.warns(UserWarning, match=r"p > n"):
+        trimmed, _ = remove_outlier_samples(
+            frame,
+            method="mahalanobis",
+            use_chi_squared=False,
+            distance_threshold=2.0,
+        )
+    assert len(trimmed) < len(TRAITS)  # survivors fewer than traits
+
+
+# ---------------------------------------------------------------------------
+# 1.10 — over-removal safety rail
+# ---------------------------------------------------------------------------
+def test_over_removal_warns_and_still_returns():
+    """>50% removed (>=2 survive) warns about the large removal fraction, returns."""
+    frame = _build_outlier_frame(n=30)
+    with pytest.warns(UserWarning, match=r"large removal fraction"):
+        trimmed, report = remove_outlier_samples(
+            frame,
+            method="mahalanobis",
+            use_chi_squared=False,
+            distance_threshold=1.1,
+        )
+    assert report["removal_fraction"] > 0.5
+    assert len(trimmed) >= 2
+
+
+def test_over_removal_warning_precedes_readiness_failure(clean_frame):
+    """When over-removal also breaches readiness, BOTH warn and raise occur."""
+    with pytest.warns(UserWarning, match=r"large removal fraction"):
+        with pytest.raises(OutlierRemovalError):
+            remove_outlier_samples(
+                clean_frame,
+                method="mahalanobis",
+                use_chi_squared=False,
+                distance_threshold=0.0,
+            )
+
+
+# ---------------------------------------------------------------------------
+# 1.11 — report schema + JSON adversarial
+# ---------------------------------------------------------------------------
+def test_report_counts_and_fraction_consistent(clean_frame):
+    """Counts reconcile and removal_fraction matches n_outliers / n_input."""
+    _, report = remove_outlier_samples(clean_frame)
+    assert (
+        report["n_input_samples"] == report["n_outliers"] + report["n_output_samples"]
+    )
+    assert report["removal_fraction"] == pytest.approx(
+        report["n_outliers"] / report["n_input_samples"]
+    )
+
+
+def test_mahalanobis_report_threshold_fields_populated(clean_frame):
+    """Mahalanobis report carries threshold / n_components / goodness-of-fit."""
+    _, report = remove_outlier_samples(clean_frame)
+    assert report["threshold_type"] is not None
+    assert report["threshold_value"] is not None
+    assert report["n_components"] is not None
+    assert report["goodness_of_fit"] is not None
+
+
+def test_isolation_forest_report_threshold_fields_none(clean_frame):
+    """Isolation forest has no distance threshold -> those four fields are None."""
+    _, report = remove_outlier_samples(clean_frame, method="isolation_forest")
+    assert report["threshold_type"] is None
+    assert report["threshold_value"] is None
+    assert report["n_components"] is None
+    assert report["goodness_of_fit"] is None
+
+
+def test_outlier_barcodes_none_without_barcode_column(clean_frame):
+    """outlier_barcodes is None when the frame has no barcode column."""
+    no_bc = clean_frame.drop(columns=["Barcode"])
+    _, report = remove_outlier_samples(no_bc)
+    assert report["outlier_barcodes"] is None
+
+
+def test_report_is_json_serializable_with_plain_types(clean_frame):
+    """JSON adversarial: plain int/str indices, float threshold, json.dumps works."""
+    _, report = remove_outlier_samples(clean_frame)
+    assert all(type(i) in (int, str) for i in report["outlier_indices"])
+    assert type(report["threshold_value"]) is float
+    assert json.dumps(report)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# 1.12 — determinism
+# ---------------------------------------------------------------------------
+def test_mahalanobis_deterministic_records_seed(clean_frame):
+    """Two seeded Mahalanobis runs are identical; the seed is recorded."""
+    t1, r1 = remove_outlier_samples(clean_frame, random_state=7)
+    t2, r2 = remove_outlier_samples(clean_frame, random_state=7)
+    assert r1["outlier_indices"] == r2["outlier_indices"]
+    pd.testing.assert_frame_equal(t1, t2)
+    assert r1["random_state"] == 7
+
+
+def test_isolation_forest_seed_is_load_bearing(clean_frame):
+    """The seed is actually threaded: same seed -> identical indices (IF path)."""
+    _, a = remove_outlier_samples(
+        clean_frame, method="isolation_forest", random_state=3
+    )
+    _, b = remove_outlier_samples(
+        clean_frame, method="isolation_forest", random_state=3
+    )
+    assert a["outlier_indices"] == b["outlier_indices"]
+
+
+# ---------------------------------------------------------------------------
+# 1.13 — detector-failure surfacing
+# ---------------------------------------------------------------------------
+def test_detector_error_is_surfaced_not_swallowed(clean_frame, monkeypatch):
+    """A detector returning an error raises, not a silent (clean_df, n_outliers=0)."""
+    monkeypatch.setattr(
+        outlier_removal,
+        "detect_outliers_mahalanobis",
+        lambda *a, **k: {"method": "Mahalanobis", "error": "degenerate PCA"},
+    )
+    with pytest.raises(ValueError, match=r"degenerate PCA|detection failed"):
+        remove_outlier_samples(clean_frame)
+
+
+def test_detector_missing_indices_is_surfaced(clean_frame, monkeypatch):
+    """A detector result lacking outlier_indices raises rather than swallowing."""
+    monkeypatch.setattr(
+        outlier_removal,
+        "detect_outliers_mahalanobis",
+        lambda *a, **k: {"method": "Mahalanobis"},
+    )
+    with pytest.raises(ValueError, match=r"detection failed|no outlier_indices"):
+        remove_outlier_samples(clean_frame)
+
+
+# ---------------------------------------------------------------------------
+# 1.14 — input misuse diagnostics
+# ---------------------------------------------------------------------------
+def test_empty_input_rejected(no_detect):
+    """An empty table raises an actionable error before delegating."""
+    with pytest.raises(ValueError, match=r"no rows"):
+        remove_outlier_samples(pd.DataFrame())
+
+
+def test_duplicate_column_names_rejected(no_detect):
+    """Duplicate column names raise a clear error."""
+    df = pd.DataFrame(
+        [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]], columns=["trait_a", "trait_a", "geno"]
+    )
+    with pytest.raises(ValueError, match=r"duplicate column names"):
+        remove_outlier_samples(df)
+
+
+def test_explicit_missing_trait_col_rejected(clean_frame, no_detect):
+    """An explicit trait_cols name absent from the frame raises (not KeyError)."""
+    with pytest.raises(ValueError, match=r"not found in dataframe"):
+        remove_outlier_samples(clean_frame, trait_cols=["trait_0", "nope"])
+
+
+def test_explicit_non_numeric_trait_col_rejected(clean_frame, no_detect):
+    """A non-numeric explicit trait column raises."""
+    with pytest.raises(ValueError, match=r"must be numeric"):
+        remove_outlier_samples(clean_frame, trait_cols=["trait_0", "geno"])
+
+
+# ---------------------------------------------------------------------------
+# 1.15 — trait_cols / replicate_col ergonomics
+# ---------------------------------------------------------------------------
+def test_explicit_trait_cols_bypass_inference(clean_frame, monkeypatch):
+    """Explicit trait_cols bypass get_trait_columns entirely."""
+
+    def _boom(*args, **kwargs):
+        raise AssertionError("get_trait_columns must not run when trait_cols given")
+
+    monkeypatch.setattr(outlier_removal, "get_trait_columns", _boom)
+    trimmed, _ = remove_outlier_samples(clean_frame, trait_cols=TRAITS)
+    assert len(trimmed) == len(clean_frame) - len(INJECTED)
+
+
+def test_replicate_col_none_on_frame_without_replicate():
+    """replicate_col=None is honored on a frame that has no replicate column."""
+    frame = _build_outlier_frame().drop(columns=["rep"])
+    trimmed, report = remove_outlier_samples(frame, replicate_col=None)
+    assert report["n_outliers"] == len(INJECTED)
+    assert "rep" not in trimmed.columns
+
+
+# ---------------------------------------------------------------------------
+# 1.16 — single source of truth
+# ---------------------------------------------------------------------------
+def test_composes_detect_and_remove_primitives(clean_frame, monkeypatch):
+    """The entry point calls the public detect + remove primitives."""
+    calls = {"detect": 0, "remove": 0}
+    real_detect = outlier_removal.detect_outliers_mahalanobis
+    real_remove = outlier_removal.remove_outliers_from_data
+
+    def spy_detect(*args, **kwargs):
+        calls["detect"] += 1
+        return real_detect(*args, **kwargs)
+
+    def spy_remove(*args, **kwargs):
+        calls["remove"] += 1
+        return real_remove(*args, **kwargs)
+
+    monkeypatch.setattr(outlier_removal, "detect_outliers_mahalanobis", spy_detect)
+    monkeypatch.setattr(outlier_removal, "remove_outliers_from_data", spy_remove)
+    remove_outlier_samples(clean_frame)
+    assert calls["detect"] == 1
+    assert calls["remove"] == 1
+
+
+def test_source_has_no_independent_thresholding_logic():
+    """The source defines no alternative distance/score thresholding of its own."""
+    src = inspect.getsource(remove_outlier_samples)
+    for forbidden in (
+        "calculate_mahalanobis_distances",
+        "IsolationForest(",
+        "chi2.ppf",
+        "np.percentile",
+    ):
+        assert forbidden not in src
+
+
+# ---------------------------------------------------------------------------
+# 1.17 — public API surface
+# ---------------------------------------------------------------------------
+def test_public_api_surface():
+    """Importable, in __all__ once, identity-equal, type-hints resolve."""
+    assert "remove_outlier_samples" in sra.__all__
+    assert sra.__all__.count("remove_outlier_samples") == 1
+    assert sra.remove_outlier_samples is remove_outlier_samples
+    typing.get_type_hints(remove_outlier_samples)
+
+
+def test_composed_primitives_still_exported():
+    """The composed primitives remain in __all__ (no duplicate entries)."""
+    for name in (
+        "detect_outliers_mahalanobis",
+        "detect_outliers_isolation_forest",
+        "remove_outliers_from_data",
+    ):
+        assert name in sra.__all__
+        assert sra.__all__.count(name) == 1

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -45,6 +45,7 @@ EXPECTED_QUALNAMES = frozenset(
         "sleap_roots_analyze.outlier_detection.detect_outliers_mahalanobis",
         "sleap_roots_analyze.outlier_detection.detect_outliers_pca",
         "sleap_roots_analyze.pca.calculate_mahalanobis_distances",
+        "sleap_roots_analyze.outlier_removal.remove_outlier_samples",
     }
 )
 


### PR DESCRIPTION
## Summary

Adds the public **`remove_outlier_samples`** entry point — the quality-step follow-up to `clean_traits_for_analysis` (#164). It takes a clean (NaN-free) trait table and detects + removes outlier **samples** so PCA / UMAP / clustering can optionally run on outlier-trimmed data.

It **composes the existing public primitives** — `detect_outliers_mahalanobis` / `detect_outliers_isolation_forest` for detection and `remove_outliers_from_data` for row removal — and defines no detection/removal logic of its own, so its semantics cannot drift from the QC pipeline outlier steps (the #116/#164 single-source-of-truth pattern).

Closes #165.

## What it does

`clean_traits_for_analysis` → **(optional)** `remove_outlier_samples` → `perform_pca_analysis` / UMAP / clustering.

- **Preconditions (before any detector runs):** NaN-free trait columns (wrapped error points to `clean_traits_for_analysis`) and a unique index — both correctness guards for one-to-one index alignment (the detectors run PCA which silently `dropna()`s rows; removal is label-based).
- **Method selection:** `method="mahalanobis"` (default, chi-squared threshold) or `"isolation_forest"`; unknown method fails fast. Per-method `**detect_kwargs` (`contamination`, `chi2_percentile`, …) are forwarded unchanged.
- **Output readiness:** re-applies the #164 gates (≥2 samples, ≥1 non-constant trait). On failure raises `OutlierRemovalError` (a `ValueError`) **carrying the report** so a caller can still inspect what would have been removed.
- **Warnings:** over-removal (> 50%, before the gates) and the `p > n` regime.
- **Returns** `(trimmed_df, outlier_report)` — an auditable, JSON-serializable dict (`method`, `method_params`, `random_state`, counts, `removal_fraction`, `outlier_indices`, `outlier_barcodes`, threshold/`n_components`/`goodness_of_fit` for Mahalanobis, `None` for isolation forest).

## Changes

- **New** `src/sleap_roots_analyze/outlier_removal.py` (composition + report + readiness guards), exported from `__all__`.
- **New** `tests/test_remove_outlier_samples.py` — 37 tests (composition, preconditions, readiness, report schema + JSON adversarial, determinism, detector-failure surfacing, misuse, single-source-of-truth, public API).
- `docs/API.md`: new entry + the two previously-undocumented composed primitives (`detect_outliers_isolation_forest`, `remove_outliers_from_data`).
- `docs/CHANGELOG.md`: `[Unreleased] → Added (#165)`.
- `tests/reproducibility_cases.py` + `tests/test_reproducibility.py`: registered the new `random_state` function (auto-discovered by the package-wide determinism sweep) and updated the pinned anchors.
- OpenSpec change `add-outlier-removal-entry-point` (proposal / design / tasks / spec).

**No behavior change** to any existing function or pipeline step (additive module + one `__all__` entry).

## Testing

- `tests/test_remove_outlier_samples.py`: **37 passed**. Fixtures were tuned against the real detector so default Mahalanobis flags *exactly* the injected outliers.
- `tests/test_reproducibility.py`: **35 passed** (new case swept + coverage guard).
- Full non-integration suite green after merging `main`.
- mypy baseline filter: **new: 0**. `black --check` + `ruff check` clean on all touched files.

> `main` (including #171 — the #167 cleanup-default alignment) is merged into this branch, so the PR is current. The `[Unreleased]` changelog carries both the #165 `Added` and the #167 `Changed` entries. The new code depends only on #164 helpers, not on the #171 default changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
