### PR TITLE
feat(#173): plot_outlier_analysis — public outlier-plotting entry point

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -992,8 +992,9 @@ remove_outlier_samples(
     genotype_col: str = "geno",
     replicate_col: Optional[str] = "rep",
     random_state: int = 42,
+    return_detector_result: bool = False,
     **detect_kwargs,
-) -> Tuple[pd.DataFrame, Dict]
+) -> Union[Tuple[pd.DataFrame, Dict], Tuple[pd.DataFrame, Dict, Dict]]
 ```
 
 Public outlier-removal entry point — the **quality**-step follow-up to
@@ -1027,18 +1028,25 @@ so the trimmed frame stays analysis-ready.
 - `barcode_col` / `genotype_col` / `replicate_col`: metadata columns excluded from
   inferred traits (`barcode_col` is also read to populate `outlier_barcodes`)
 - `random_state`: Seed forwarded to the detector for reproducibility (default: 42)
+- `return_detector_result`: When `True`, additionally return the **raw** detector result
+  dict (a third tuple element — the per-sample arrays the compact report omits) so a
+  consumer can detect once and feed it to
+  [`select_outlier_figures`](#select_outlier_figures) without a redundant second
+  detection. Default `False` preserves the 2-tuple compact-report contract.
 - `**detect_kwargs`: Per-method parameters forwarded to the chosen detector
   (`contamination` for isolation forest; `chi2_percentile`, `variance_threshold`,
   `use_chi_squared`, `distance_threshold`, `robust_covariance` for Mahalanobis)
 
 **Returns:**
-- `Tuple[pd.DataFrame, Dict]`: `(trimmed_df, outlier_report)`. `trimmed_df` is
-  `clean_df` with the flagged rows removed (all columns preserved). `outlier_report`
-  is an auditable, JSON-serializable dict: `method`, `method_params`, `random_state`,
-  `n_input_samples`, `n_outliers`, `n_output_samples`, `removal_fraction`,
-  `outlier_indices`, `outlier_barcodes`, `threshold_type`, `threshold_value`,
-  `n_components`, `variance_threshold`, `goodness_of_fit` (the last four are
-  populated for Mahalanobis and `None` for isolation forest).
+- `(trimmed_df, outlier_report)` — or `(trimmed_df, outlier_report, detector_result)`
+  when `return_detector_result=True`. `trimmed_df` is `clean_df` with the flagged rows
+  removed (all columns preserved). `outlier_report` is an auditable, JSON-serializable
+  dict: `method`, `method_params`, `random_state`, `n_input_samples`, `n_outliers`,
+  `n_output_samples`, `removal_fraction`, `outlier_indices`, `outlier_barcodes`,
+  `threshold_type`, `threshold_value`, `n_components`, `variance_threshold`,
+  `goodness_of_fit` (the last four are populated for Mahalanobis and `None` for
+  isolation forest). `detector_result` (when returned) is the unmodified
+  `detect_outliers_*` dict.
 
 **Warns:**
 - `UserWarning`: when the removed fraction exceeds 0.5 (likely mis-set
@@ -1385,8 +1393,9 @@ plt.show()
 ## `outlier_visualization` Module
 
 Outlier-detection figure composition. The `create_*_outlier` functions each render an
-individual figure; `plot_outlier_analysis` composes the method-appropriate set for a
-consumer (e.g. the bloom-mcp `remove_outliers` tool's optional plots).
+individual figure; `select_outlier_figures` selects the method-appropriate set from a
+pre-computed detector result, and `plot_outlier_analysis` re-detects and composes them
+for a consumer (e.g. the bloom-mcp `remove_outliers` tool's optional plots).
 
 ### Functions
 
@@ -1398,6 +1407,9 @@ plot_outlier_analysis(
     trait_cols: Optional[List[str]] = None,
     *,
     method: str = "mahalanobis",
+    barcode_col: str = "Barcode",
+    genotype_col: str = "geno",
+    replicate_col: Optional[str] = "rep",
     random_state: Optional[int] = 42,
     which: Optional[Union[str, List[str]]] = None,
     **detect_kwargs,
@@ -1411,13 +1423,18 @@ under the shared NaN-free + unique-index preconditions, it flags the same sample
 figure functions and returns the figures. **IO-free**: returns open `matplotlib`
 `Figure` objects; the caller saves/persists them. Covers the two `remove_outlier_samples`
 methods (`"mahalanobis"`, `"isolation_forest"`); the `detect_outliers_pca`/`_kmeans`/
-`_gmm`/`_hierarchical` plots stay pipeline-only.
+`_gmm`/`_hierarchical` plots stay pipeline-only. Pass the **same** metadata-column
+arguments used with `remove_outlier_samples` so the plotted outlier set matches the
+trimmed one.
 
 **Parameters:**
 - `clean_df`: Clean (NaN-free in trait columns), unique-indexed wide trait table.
 - `trait_cols`: Trait columns to score; inferred via `get_trait_columns` if `None`.
 - `method`: `"mahalanobis"` (default) or `"isolation_forest"`; unknown raises.
-- `random_state`: Seed forwarded to the detector (default 42; accepts `None`).
+- `barcode_col` / `genotype_col` / `replicate_col`: metadata columns excluded from
+  inferred traits (defaults `"Barcode"` / `"geno"` / `"rep"`); `genotype_col` also
+  drives the per-genotype figure when present.
+- `random_state`: Seed forwarded to the detector (default 42; `None` = no fixed seed).
 - `which`: Figure-key string or list of keys to return; `None` returns the full set. An
   unavailable key raises.
 - `**detect_kwargs`: Per-method detector parameters; unknown/cross-method keys raise.
@@ -1428,12 +1445,51 @@ methods (`"mahalanobis"`, `"isolation_forest"`); the `detect_outliers_pca`/`_kme
   `"isolation_forest"`,
   [`create_isolation_forest_plots`](#create_isolation_forest_plots); plus
   [`create_outliers_per_genotype_plot`](#create_outliers_per_genotype_plot) (key
-  `outliers_per_genotype`) when a `geno` column is present.
+  `outliers_per_genotype`) when the `genotype_col` column is present. The figures are
+  open and **owned by the caller** — `plt.close(fig)` the ones you do not retain to
+  avoid memory growth / `max_open_warning` in a long-running process.
 
 **Raises:**
 - `ValueError`: on empty input; duplicate columns; invalid `trait_cols`; unknown
   `method`; a non-unique index; NaN traits (points to `clean_traits_for_analysis`);
   unknown `detect_kwargs`; an unavailable `which` key; or a detector failure.
+
+#### `select_outlier_figures`
+
+```python
+select_outlier_figures(
+    df: pd.DataFrame,
+    results: Dict[str, Dict],
+    method: str,
+    which: Optional[Union[str, List[str]]] = None,
+    genotype_col: Optional[str] = None,
+) -> Dict[str, plt.Figure]
+```
+
+The lower-level, **no-detection** figure-selection layer shared by
+[`plot_outlier_analysis`](#plot_outlier_analysis) and the pipeline's
+`VisualizeOutliersStep`. Dispatches a **pre-computed** detector result
+(`results[method]`) to the method-appropriate `create_*` figures. Public so a consumer
+that already holds a detector result — e.g. from
+[`remove_outlier_samples(..., return_detector_result=True)`](#remove_outlier_samples) —
+can plot **without a redundant second detection**. Figures excluded by `which` are
+closed (no leak); the returned figures are owned by the caller.
+
+**Parameters:**
+- `df`: The trait frame the figures are drawn over.
+- `results`: Mapping of method name → that method's detector result dict; `results[method]`
+  is drawn (e.g. `{"mahalanobis": det}`).
+- `method`: `"mahalanobis"` or `"isolation_forest"`.
+- `which`: Figure-key string or list to return; `None` returns the method's full set.
+- `genotype_col`: When present in `df`, add the per-genotype figure over the full
+  `results` dict; `None` (default) omits it.
+
+**Returns:**
+- `Dict[str, plt.Figure]`: stable figure key → figure.
+
+**Raises:**
+- `ValueError`: on an unknown `method`, or a `which` key not available for the
+  method/frame.
 
 #### `create_mahalanobis_outlier_plots`
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -9,6 +9,7 @@ Complete API documentation for `sleap-roots-analyze`.
 - [data_utils](#data_utils-module)
 - [pca](#pca-module)
 - [outlier_detection](#outlier_detection-module)
+- [outlier_visualization](#outlier_visualization-module)
 - [visualization](#visualization-module)
 
 ---
@@ -1378,6 +1379,91 @@ ax2.legend()
 plt.tight_layout()
 plt.show()
 ```
+
+---
+
+## `outlier_visualization` Module
+
+Outlier-detection figure composition. The `create_*_outlier` functions each render an
+individual figure; `plot_outlier_analysis` composes the method-appropriate set for a
+consumer (e.g. the bloom-mcp `remove_outliers` tool's optional plots).
+
+### Functions
+
+#### `plot_outlier_analysis`
+
+```python
+plot_outlier_analysis(
+    clean_df: pd.DataFrame,
+    trait_cols: Optional[List[str]] = None,
+    *,
+    method: str = "mahalanobis",
+    random_state: Optional[int] = 42,
+    which: Optional[Union[str, List[str]]] = None,
+    **detect_kwargs,
+) -> Dict[str, plt.Figure]
+```
+
+The plotting sibling of [`remove_outlier_samples`](#remove_outlier_samples) (#173).
+**Re-detects** outliers with the same detector, seed, and per-method parameters — so,
+under the shared NaN-free + unique-index preconditions, it flags the same samples
+`remove_outlier_samples` removes — then composes the existing public `create_*_outlier`
+figure functions and returns the figures. **IO-free**: returns open `matplotlib`
+`Figure` objects; the caller saves/persists them. Covers the two `remove_outlier_samples`
+methods (`"mahalanobis"`, `"isolation_forest"`); the `detect_outliers_pca`/`_kmeans`/
+`_gmm`/`_hierarchical` plots stay pipeline-only.
+
+**Parameters:**
+- `clean_df`: Clean (NaN-free in trait columns), unique-indexed wide trait table.
+- `trait_cols`: Trait columns to score; inferred via `get_trait_columns` if `None`.
+- `method`: `"mahalanobis"` (default) or `"isolation_forest"`; unknown raises.
+- `random_state`: Seed forwarded to the detector (default 42; accepts `None`).
+- `which`: Figure-key string or list of keys to return; `None` returns the full set. An
+  unavailable key raises.
+- `**detect_kwargs`: Per-method detector parameters; unknown/cross-method keys raise.
+
+**Returns:**
+- `Dict[str, plt.Figure]`: stable figure key → figure. For `"mahalanobis"`, the
+  [`create_mahalanobis_outlier_plots`](#create_mahalanobis_outlier_plots) figures; for
+  `"isolation_forest"`,
+  [`create_isolation_forest_plots`](#create_isolation_forest_plots); plus
+  [`create_outliers_per_genotype_plot`](#create_outliers_per_genotype_plot) (key
+  `outliers_per_genotype`) when a `geno` column is present.
+
+**Raises:**
+- `ValueError`: on empty input; duplicate columns; invalid `trait_cols`; unknown
+  `method`; a non-unique index; NaN traits (points to `clean_traits_for_analysis`);
+  unknown `detect_kwargs`; an unavailable `which` key; or a detector failure.
+
+#### `create_mahalanobis_outlier_plots`
+
+```python
+create_mahalanobis_outlier_plots(df: pd.DataFrame, mahal_results: Dict) -> Dict[str, plt.Figure]
+```
+
+Render the Mahalanobis outlier figures (`mahalanobis_outlier_detection`,
+`mahalanobis_pc_analysis`, `mahalanobis_threshold_analysis`) from a
+`detect_outliers_mahalanobis` result. Returns `{}` on an `error` result.
+
+#### `create_isolation_forest_plots`
+
+```python
+create_isolation_forest_plots(df: pd.DataFrame, iso_results: Dict) -> Dict[str, plt.Figure]
+```
+
+Render the isolation-forest outlier figure (`isolation_forest_analysis`) from a
+`detect_outliers_isolation_forest` result. Returns `{}` on an `error` result.
+
+#### `create_outliers_per_genotype_plot`
+
+```python
+create_outliers_per_genotype_plot(
+    df: pd.DataFrame, all_outlier_results: Dict, genotype_col: str = "geno"
+) -> plt.Figure
+```
+
+Render a per-genotype outlier bar chart (absolute counts and proportions) across the
+methods present in `all_outlier_results`.
 
 ---
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Public outlier-plotting entry point `plot_outlier_analysis` (#173): the
+  **plotting** sibling of `remove_outlier_samples`. Importable from
+  `sleap_roots_analyze`, it **re-detects** outliers with the same detector, seed, and
+  per-method parameters (so, under the shared NaN-free + unique-index preconditions,
+  it flags the same samples `remove_outlier_samples` removes), then composes the
+  existing public `create_*_outlier` figure functions and returns a
+  `Dict[str, plt.Figure]` — **IO-free** (the caller saves/persists). Covers the two
+  `remove_outlier_samples` methods (`mahalanobis`, `isolation_forest`); the
+  `detect_outliers_pca`/`_kmeans`/`_gmm`/`_hierarchical` plots stay pipeline-only. A
+  `which` selector narrows the returned figures. The pipeline's `VisualizeOutliersStep`
+  now shares the same private figure-selection helper on its own pre-computed results
+  (no behavior change).
 - Public outlier-removal entry point `remove_outlier_samples` (#165): the
   **quality**-step follow-up to `clean_traits_for_analysis`. Takes a clean
   (NaN-free) trait table and detects + removes outlier samples so PCA/UMAP/

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,9 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Dict[str, plt.Figure]` — **IO-free** (the caller saves/persists). Covers the two
   `remove_outlier_samples` methods (`mahalanobis`, `isolation_forest`); the
   `detect_outliers_pca`/`_kmeans`/`_gmm`/`_hierarchical` plots stay pipeline-only. A
-  `which` selector narrows the returned figures. The pipeline's `VisualizeOutliersStep`
-  now shares the same private figure-selection helper on its own pre-computed results
-  (no behavior change).
+  `which` selector narrows the returned figures, and metadata-column args
+  (`barcode_col`/`genotype_col`/`replicate_col`) mirror `remove_outlier_samples` so the
+  plotted set matches the trimmed one. The pipeline's `VisualizeOutliersStep` shares the
+  selection via the public `select_outlier_figures(df, results, method, ...)` helper on
+  its own pre-computed results (no behavior change).
+- `select_outlier_figures` (#173): public no-detection figure-selection layer (used by
+  both `plot_outlier_analysis` and the pipeline), so a consumer holding a detector
+  result can plot without re-detecting.
+- `remove_outlier_samples` gains an additive `return_detector_result=False` flag (#173):
+  when `True` it also returns the raw detector dict, so a consumer (the bloom-mcp
+  `remove_outliers` tool) detects once and feeds both the trim and the plots. Default
+  preserves the compact-report 2-tuple contract.
 - Public outlier-removal entry point `remove_outlier_samples` (#165): the
   **quality**-step follow-up to `clean_traits_for_analysis`. Takes a clean
   (NaN-free) trait table and detects + removes outlier samples so PCA/UMAP/

--- a/openspec/changes/add-outlier-plotting-entry-point/design.md
+++ b/openspec/changes/add-outlier-plotting-entry-point/design.md
@@ -29,10 +29,10 @@ Two facts constrain the design (both verified against the real code during revie
 
 ### D1 — Re-detect inside the entry point, under the sibling's preconditions
 
-`plot_outlier_analysis(clean_df, trait_cols=None, *, method="mahalanobis", random_state=42,
-which=None, **detect_kwargs)` (no `genotype_col` param — it uses `"geno"` internally, matching the
-#173 signature) re-runs the selected detector internally, and
-**enforces the same NaN-free + unique-index preconditions as `remove_outlier_samples`**
+`plot_outlier_analysis(clean_df, trait_cols=None, *, method="mahalanobis", barcode_col="Barcode",
+genotype_col="geno", replicate_col="rep", random_state=42, which=None, **detect_kwargs)` re-runs the
+selected detector internally, and **enforces the same NaN-free + unique-index preconditions as
+`remove_outlier_samples`**
 (`validate_clean_traits` + `index.is_unique`), plus the same input-misuse guards (empty frame,
 duplicate columns, non-numeric explicit `trait_cols`).
 
@@ -63,13 +63,13 @@ pipeline's already-computed `outlier_results[method]` (built from `config.outlie
 risking drift and a redundant in-pipeline detector run. `CleanupTraitsStep → clean_traits_for_analysis`
 is not a perfect mirror because cleanup has no upstream pre-computed detector state to preserve.
 
-**Decision:** extract `_select_outlier_figures(df, results, method, which=None, genotype_col=None)
--> dict[str, plt.Figure]` (private) as the one place mapping a method + its pre-computed
+**Decision:** extract `select_outlier_figures(df, results, method, which=None, genotype_col=None)
+-> dict[str, plt.Figure]` (**public** — see D6) as the one place mapping a method + its pre-computed
 detector-result dict to the method's `create_*` figures (and, when `genotype_col` is present in
 `df`, the per-genotype figure over the full `results` dict):
-- `plot_outlier_analysis` = validate + preconditions → re-detect → `_select_outlier_figures(clean_df,
+- `plot_outlier_analysis` = validate + preconditions → re-detect → `select_outlier_figures(clean_df,
   {method: result}, method, which=which, genotype_col="geno")` (per-genotype single-method).
-- `VisualizeOutliersStep` calls `_select_outlier_figures(df, outlier_results, method)` (default
+- `VisualizeOutliersStep` calls `select_outlier_figures(df, outlier_results, method)` (default
   `genotype_col=None` → core figures only) with its **pre-computed** results for `mahalanobis` /
   `isolation_forest`, then `savefig`s under its existing filenames. It does **not** call
   `plot_outlier_analysis`, does **not** re-detect, and keeps its own cross-method per-genotype block.
@@ -88,7 +88,7 @@ this design (shared helper on the step's own pre-computed results).
 | `isolation_forest` (+ genotype) | `outliers_per_genotype` | `create_outliers_per_genotype_plot` (**bare Figure** — composer-assigned key) |
 
 The dict-returning functions contribute their own keys unprefixed; the bare-`Figure` per-genotype
-function gets a composer-assigned key (`outliers_per_genotype`). `_select_outlier_figures` adds the
+function gets a composer-assigned key (`outliers_per_genotype`). `select_outlier_figures` adds the
 per-genotype figure only when `genotype_col` is present in `df` — the entry point passes
 `genotype_col="geno"`, the step passes `genotype_col=None`. So for the step the helper is a pure
 extraction of its per-method `create_*` calls (no per-genotype) → byte-identical step output, and
@@ -125,6 +125,28 @@ Figures the sweep can't compare). Because the entry point is `EXCLUDED` (not add
 `EXPECTED_QUALNAMES` / `len(CASES)` anchors are unchanged; `test_excluded_set_is_consistent` verifies
 the excluded name is a discoverable `random_state` function disjoint from `CASES`.
 
+### D6 — PR #175 review follow-ups (single-detection reuse, figure lifecycle, metadata cols)
+
+Elizabeth's PR #175 review surfaced that the #173 shape sets up a redundant computation for the #378
+`remove_outliers` consumer (which detects via `remove_outlier_samples` first — discarding the raw
+result — then would re-detect to plot). Resolved here, before the a4 public API locks:
+
+- **Public `select_outlier_figures`** (was private): a consumer holding a detector result selects
+  figures with no second detection. (D3's helper, promoted + in `__all__`.)
+- **`remove_outlier_samples(return_detector_result=True)`**: additive flag returning the raw detector
+  dict as a 3rd tuple element (default preserves the compact 2-tuple). #378 detects once and feeds the
+  result to both the trim and `select_outlier_figures`. Rejected a `results=` param on
+  `plot_outlier_analysis` (would make `random_state`/`detect_kwargs` silently ignored, and does not
+  fix #378 since the result is discarded before plotting).
+- **Metadata-column params** on `plot_outlier_analysis` (`barcode_col`/`genotype_col`/`replicate_col`)
+  matching `remove_outlier_samples` — a caller passing non-default metadata columns to removal but not
+  here would otherwise score a different trait set and plot a diverging outlier set (correctness).
+- **Figure lifecycle**: `select_outlier_figures` closes figures excluded by `which` (and skips the
+  per-genotype render when not requested), so a narrowed call leaks no figures in a long-running
+  server. `random_state: Optional[int]` (matches docs/tests); the seed reaches the detector via a
+  `Dict[str, Any]` splat so the detectors' narrower `int` annotation is not tripped — widening the pca
+  chain was out of scope.
+
 ## Risks / Trade-offs
 
 - **B1 overrules the original #173 figure list** → mitigated by the `mahalanobis_pc_analysis` figure
@@ -155,7 +177,7 @@ commit (the step's pre-refactor per-method blocks restored; no data/format chang
 
 - **Q1 — B1 ratified:** `create_pca_outlier_plot` (and pca/kmeans/gmm/hierarchical plots) stay
   pipeline-only; the entry point covers `mahalanobis` + `isolation_forest`.
-- **Q2 — D3 ratified:** the step delegates to `_select_outlier_figures` with its own pre-computed
+- **Q2 — D3 ratified:** the step delegates to `select_outlier_figures` with its own pre-computed
   results; it does not call `plot_outlier_analysis`.
 - **Q3 — reproducibility registry:** implemented as `EXCLUDED`-with-reason (the function returns
   Figures and adds no new stochastic step over the already-swept detectors).

--- a/openspec/changes/add-outlier-plotting-entry-point/design.md
+++ b/openspec/changes/add-outlier-plotting-entry-point/design.md
@@ -1,0 +1,161 @@
+## Context
+
+`remove_outlier_samples` (#165/#172) is a pure, IO-free composition returning `(trimmed_df,
+outlier_report)`; it discards the detector's per-sample arrays and draws no figures. Issue #173
+asks for the plotting sibling: a public, IO-free function returning the method-appropriate outlier
+figures so the bloom-mcp `remove_outliers` tool can offer optional plots without re-stitching
+pipeline internals.
+
+Two facts constrain the design (both verified against the real code during review):
+
+1. The nine `create_*_outlier` figure functions exist and are public. Their return shapes differ:
+   `create_mahalanobis_outlier_plots` and `create_isolation_forest_plots` return
+   `Dict[str, plt.Figure]`; `create_pca_outlier_plot` and `create_outliers_per_genotype_plot`
+   return a **bare `plt.Figure`**. Each reads specific detector-result keys.
+2. `VisualizeOutliersStep` already encodes "which figures per method," but coupled to `run_dir`,
+   `savefig`, `config`, and pre-computed `prev_result.metadata["outlier_results"]`, spanning six
+   methods plus cross-method comparison and per-genotype figures.
+
+## Goals / Non-Goals
+
+- **Goals:** one public IO-free `plot_outlier_analysis` returning `{name: Figure}`; deterministic
+  figures matching what `remove_outlier_samples` trims (under the same preconditions); a single
+  source of truth for the per-method figure selection shared with the pipeline step; zero behavior
+  change to `remove_outlier_samples` and to the step's rendered output.
+- **Non-Goals:** new/restyled plots; file IO; clustering-method or multi-method-comparison figures
+  in the entry point; changing the detectors or the report schema.
+
+## Decisions
+
+### D1 — Re-detect inside the entry point, under the sibling's preconditions
+
+`plot_outlier_analysis(clean_df, trait_cols=None, *, method="mahalanobis", random_state=42,
+which=None, **detect_kwargs)` (no `genotype_col` param — it uses `"geno"` internally, matching the
+#173 signature) re-runs the selected detector internally, and
+**enforces the same NaN-free + unique-index preconditions as `remove_outlier_samples`**
+(`validate_clean_traits` + `index.is_unique`), plus the same input-misuse guards (empty frame,
+duplicate columns, non-numeric explicit `trait_cols`).
+
+- **Why re-detect:** #173 mandates a plain-data-in signature so an external consumer needs only the
+  frame it has; deterministic detection reproduces the exact set `remove_outlier_samples` removed.
+- **Why the preconditions are load-bearing (not defense):** the detectors run PCA that silently
+  `dropna()`s and report `outlier_indices` against the post-`dropna` frame; removal and
+  `create_outliers_per_genotype_plot`'s `df.loc[idx, genotype_col]` are label-based. On a
+  NaN-carrying or duplicate-indexed frame the re-detected set can diverge from removal (which would
+  have *rejected* that frame) and the per-genotype figure mis-indexes. So the "figures match the
+  trimmed table" guarantee holds precisely on the inputs both functions share.
+- **Alternatives rejected:** adding raw detector arrays to `remove_outlier_samples`'s report
+  (touches the #165 public API + its compact-report invariant); accepting a pre-computed
+  detector-result dict as the public input (pushes the re-stitching #173 removes back on the
+  consumer — it survives only as the *internal* helper input, see D3).
+
+### D2 — Return `Figure` objects; the caller owns all IO
+
+Returns `Dict[str, plt.Figure]`; never writes files, never calls `plt.close`. The step `savefig`s +
+closes with its `config`; bloom-mcp persists via `ResultStore`. Stable dict keys are the contract.
+
+### D3 — Single source of truth = a shared per-method **selection** helper (RATIFIED in #173)
+
+#173 says "refactor `VisualizeOutliersStep` to call **this function** … behavior unchanged … keeps
+its configured [detector] params." Those two clauses are **mutually incompatible**: if the step
+called `plot_outlier_analysis` it would **re-detect** with the entry point's params, discarding the
+pipeline's already-computed `outlier_results[method]` (built from `config.outlier_detection.*`) —
+risking drift and a redundant in-pipeline detector run. `CleanupTraitsStep → clean_traits_for_analysis`
+is not a perfect mirror because cleanup has no upstream pre-computed detector state to preserve.
+
+**Decision:** extract `_select_outlier_figures(df, results, method, which=None, genotype_col=None)
+-> dict[str, plt.Figure]` (private) as the one place mapping a method + its pre-computed
+detector-result dict to the method's `create_*` figures (and, when `genotype_col` is present in
+`df`, the per-genotype figure over the full `results` dict):
+- `plot_outlier_analysis` = validate + preconditions → re-detect → `_select_outlier_figures(clean_df,
+  {method: result}, method, which=which, genotype_col="geno")` (per-genotype single-method).
+- `VisualizeOutliersStep` calls `_select_outlier_figures(df, outlier_results, method)` (default
+  `genotype_col=None` → core figures only) with its **pre-computed** results for `mahalanobis` /
+  `isolation_forest`, then `savefig`s under its existing filenames. It does **not** call
+  `plot_outlier_analysis`, does **not** re-detect, and keeps its own cross-method per-genotype block.
+
+Consequence accepted: `plot_outlier_analysis` is covered only by its own unit tests, not the
+pipeline path — the accepted cost of preserving configured detector params. The updated #173 states
+this design (shared helper on the step's own pre-computed results).
+
+### D4 — Method → figure-key map (corrected; B1 RATIFIED in #173)
+
+| `method` | figure keys returned | source (return shape) |
+|---|---|---|
+| `mahalanobis` | `mahalanobis_outlier_detection`, `mahalanobis_pc_analysis`, `mahalanobis_threshold_analysis` | `create_mahalanobis_outlier_plots` (**dict** — its own keys) |
+| `mahalanobis` (+ genotype) | `outliers_per_genotype` | `create_outliers_per_genotype_plot` (**bare Figure** — key assigned by the composer) |
+| `isolation_forest` | `isolation_forest_analysis` | `create_isolation_forest_plots` (**dict** — its own key) |
+| `isolation_forest` (+ genotype) | `outliers_per_genotype` | `create_outliers_per_genotype_plot` (**bare Figure** — composer-assigned key) |
+
+The dict-returning functions contribute their own keys unprefixed; the bare-`Figure` per-genotype
+function gets a composer-assigned key (`outliers_per_genotype`). `_select_outlier_figures` adds the
+per-genotype figure only when `genotype_col` is present in `df` — the entry point passes
+`genotype_col="geno"`, the step passes `genotype_col=None`. So for the step the helper is a pure
+extraction of its per-method `create_*` calls (no per-genotype) → byte-identical step output, and
+the step keeps drawing its own cross-method per-genotype figure separately.
+
+**Decision B1 — drop `create_pca_outlier_plot` from the Mahalanobis set.** #173 listed it, but
+`create_pca_outlier_plot` reads `reconstruction_errors` / `cumulative_variance` /
+`explained_variance_threshold` — keys produced by `detect_outliers_pca`, **not** by
+`detect_outliers_mahalanobis` (which has `mahalanobis_distances`, `cumulative_variance_explained`,
+`feature_fraction_explained`, `degrees_of_freedom`). Feeding a Mahalanobis result raises `KeyError`
+/ yields a blank figure, the pipeline never makes this pairing (it draws `create_pca_outlier_plot`
+only under a separate `method=="pca"` branch), and `remove_outlier_samples` never runs
+`detect_outliers_pca` — so there is no PCA outlier set to match the trimmed table. The Mahalanobis
+PCA **projection** view is already in `create_mahalanobis_outlier_plots` (`mahalanobis_pc_analysis`).
+Options were: (a) drop it [chosen]; (b) run a second `detect_outliers_pca` under the hood — rejected
+(new detection scope; its outlier set ≠ the trimmed Mahalanobis set, breaking "figures match");
+(c) key-adapt the Mahalanobis dict — rejected (it lacks the reconstruction data the plot needs, not
+just renamed keys). The updated #173 adopts (a): those plots stay pipeline-only.
+
+### D5 — Reproducibility-gate registration returns indices, not Figures
+
+The sweep auto-discovers any public `random_state`-bearing function, so the coverage guard breaks
+the moment `plot_outlier_analysis` lands — registration must ship in the **same commit**. The `Case`
+comparator cannot compare `Figure`s. Two acceptable forms:
+- **CASES with an indices adapter:** `run` re-detects and returns the `outlier_indices`; `compare`
+  is exact on those (mirrors `_compare_remove_outlier_samples`). The `run` must avoid leaking
+  figures (return before rendering).
+- **EXCLUDED with reason:** "determinism is fully delegated to the already-swept `detect_outliers_*`;
+  `plot_outlier_analysis` adds no new stochastic step (Figure composition is deterministic given the
+  detected set)." Honest, since the registered CASES form would only re-exercise the detector.
+
+**Implemented as EXCLUDED-with-reason** (truthful; the function adds no new randomness and returns
+Figures the sweep can't compare). Because the entry point is `EXCLUDED` (not added to `CASES`), the
+`EXPECTED_QUALNAMES` / `len(CASES)` anchors are unchanged; `test_excluded_set_is_consistent` verifies
+the excluded name is a discoverable `random_state` function disjoint from `CASES`.
+
+## Risks / Trade-offs
+
+- **B1 overrules the original #173 figure list** → mitigated by the `mahalanobis_pc_analysis` figure
+  already covering the PCA projection; ratified in the updated #173.
+- **D3 leaves `plot_outlier_analysis` outside the pipeline path** → its determinism/validation/`which`
+  logic has only unit-test coverage; accepted to preserve configured detector params.
+- **Per-genotype figure differs step vs entry point** (multi-method grouping in the step;
+  single-method in the entry point) → it is deliberately **not** shared; the step's cross-method
+  block is untouched, and the entry point composes its own single-method version. Documented so MCP
+  consumers don't expect the multi-method view.
+- **`genotype_col` handling:** the entry point uses `"geno"` internally (matching
+  `remove_outlier_samples`) and passes it to the helper; the step passes `genotype_col=None` so the
+  helper draws no per-genotype figure, and the step keeps its own per-genotype block using its
+  `column_mapping.get("genotype", "Genotype")` column. So the helper's per-genotype path is
+  entry-point-only and the step's genotype column name is unchanged — no divergence in behavior.
+- **Re-detection cost:** one extra detector run when a consumer calls both functions — cheap and
+  deterministic.
+- **`which` against a guarded-out key** → actionable `ValueError` naming the keys available for that
+  frame+method (not a silent empty dict).
+
+## Migration Plan
+
+Additive: new public function + one `__all__` entry + a transparent step refactor. No consumer
+migration. Ships in `0.1.0a4` alongside #165; `[Unreleased]` until then. Rollback = revert the
+commit (the step's pre-refactor per-method blocks restored; no data/format change).
+
+## Resolved (updated #173, 2026-07-01)
+
+- **Q1 — B1 ratified:** `create_pca_outlier_plot` (and pca/kmeans/gmm/hierarchical plots) stay
+  pipeline-only; the entry point covers `mahalanobis` + `isolation_forest`.
+- **Q2 — D3 ratified:** the step delegates to `_select_outlier_figures` with its own pre-computed
+  results; it does not call `plot_outlier_analysis`.
+- **Q3 — reproducibility registry:** implemented as `EXCLUDED`-with-reason (the function returns
+  Figures and adds no new stochastic step over the already-swept detectors).

--- a/openspec/changes/add-outlier-plotting-entry-point/proposal.md
+++ b/openspec/changes/add-outlier-plotting-entry-point/proposal.md
@@ -33,7 +33,7 @@ Tracked by [talmolab/sleap-roots-analyze#173](https://github.com/talmolab/sleap-
 > #173 (2026-07-01):** (1) **B1** — `create_pca_outlier_plot` and the pca/kmeans/gmm/hierarchical
 > plots stay pipeline-only; the public entry point covers only `mahalanobis` + `isolation_forest`
 > (the original mapping was not buildable against the real code — see design.md "Decision B1");
-> (2) **D3** — the pipeline step delegates to a *shared selection helper* (`_select_outlier_figures`)
+> (2) **D3** — the pipeline step delegates to a *shared selection helper* (`select_outlier_figures`)
 > with its own pre-computed results rather than calling `plot_outlier_analysis` (see design.md
 > "Decision D3"). The updated #173 states both explicitly.
 
@@ -91,11 +91,12 @@ Add public **`plot_outlier_analysis`** in `src/sleap_roots_analyze/outlier_visua
 
 ### Refactor `VisualizeOutliersStep` to the single source of truth (B3 → `visualization-pipeline`)
 
-Extract the per-method **figure-selection** into a shared private helper
-`_select_outlier_figures(df, results, method, which=None, genotype_col=None)` that dispatches the
-pre-computed `results[method]` to that method's `create_*` figure function(s) and, when
-`genotype_col` is present in `df`, adds the per-genotype figure over the full `results` dict. Both
-the new entry point and the pipeline step call it:
+Extract the per-method **figure-selection** into a shared **public** helper (PR #175 review)
+`select_outlier_figures(df, results, method, which=None, genotype_col=None)` (in `__all__`) that
+dispatches the pre-computed `results[method]` to that method's `create_*` figure function(s) and,
+when `genotype_col` is present in `df`, adds the per-genotype figure over the full `results` dict.
+Public so a consumer holding a detector result can select figures without a redundant re-detection.
+Both the new entry point and the pipeline step call it:
 
 - `plot_outlier_analysis` re-detects, then calls the helper with `results={method: <result>}` and
   `genotype_col="geno"` (so the per-genotype figure, when drawn, is single-method).
@@ -115,7 +116,21 @@ its `Outlier Method Comparison Summary` requirement), the step-refactor requirem
 
 Note: `plot_outlier_analysis` is therefore exercised only by its own unit tests, not by the
 pipeline path (the step shares only the helper). This is the accepted cost of preserving the
-pipeline's configured detector params. *(D3 — PENDING RATIFICATION.)*
+pipeline's configured detector params. *(D3 — ratified in updated #173.)*
+
+### PR #175 review follow-ups (single-detection reuse, correctness, lifecycle)
+
+Landed in response to Elizabeth's PR #175 review, before the a4 public API locks (see design.md D6):
+
+- **Public `select_outlier_figures`** (in `__all__`) + **`remove_outlier_samples(return_detector_result=True)`**
+  (additive; default keeps the compact 2-tuple) so the #378 `remove_outliers` consumer detects **once**
+  and feeds the raw result to both the trim and the plots — no redundant second detection.
+- **Metadata-column params** on `plot_outlier_analysis` (`barcode_col`/`genotype_col`/`replicate_col`)
+  matching `remove_outlier_samples`, so the plotted trait/outlier set cannot silently diverge from the
+  trimmed one (a correctness fix; also removes the hardcoded `"geno"`).
+- **Figure lifecycle**: a `which`-narrowed call closes the figures it excluded (and skips the
+  per-genotype render when not requested) — no figure leak in a long-running server.
+  `random_state` is `Optional[int]` (matches docs/tests).
 
 ### Public API + docs
 
@@ -158,7 +173,8 @@ optional `include_plots` delegates to this function so removal and plots come fr
 
 ### Out of scope (explicitly)
 
-- **Any change to `remove_outlier_samples`** — it stays plot-free.
+- **Plotting logic inside `remove_outlier_samples`** — it stays plot-free (the only change is the
+  additive, opt-in `return_detector_result` flag; the default return is unchanged).
 - **New plot types / restyling** the existing `create_*` figures. This composes them as-is.
 - **`create_pca_outlier_plot`** (a `detect_outliers_pca`-fed figure) — excluded per B1.
 - **File / format / saving** — returns `Figure` objects; the caller writes files.
@@ -180,22 +196,24 @@ optional `include_plots` delegates to this function so removal and plots come fr
     function must be registered (no new requirement, satisfied by registration).
   - **public-api-introspection** — existing gate; new `__all__` entry + docstring audit.
 - Affected code:
-  - `src/sleap_roots_analyze/outlier_visualization.py` — new public `plot_outlier_analysis` +
-    the extracted `_select_outlier_figures` helper (both fully type-annotated).
+  - `src/sleap_roots_analyze/outlier_visualization.py` — new public `plot_outlier_analysis` + public
+    `select_outlier_figures` helper (both fully type-annotated).
+  - `src/sleap_roots_analyze/outlier_removal.py` — additive `return_detector_result` flag on
+    `remove_outlier_samples` (default 2-tuple unchanged; PR #175 review).
   - `src/sleap_roots_analyze/pipeline/steps/visualize_outliers.py` — the two shared methods' blocks
     delegate to the helper (behavior unchanged; pca/clustering/comparison/cross-method-genotype
     retained).
-  - `src/sleap_roots_analyze/__init__.py` — import + `__all__` entry for `plot_outlier_analysis`.
-  - `docs/API.md` — `plot_outlier_analysis` + backfill of the composed `create_*` figure functions;
-    `docs/CHANGELOG.md` — `[Unreleased]` entry; `docs/public_api_audit_2026.md` — count update.
-  - `tests/test_plot_outlier_analysis.py` (new) — TDD coverage.
-  - `tests/test_step_visualize_outliers.py` — pinned pre-refactor filename/count baseline for the
-    two methods (built fresh; the current step tests use placeholder dicts that draw no mahal/IF
-    figures).
-  - `tests/reproducibility_cases.py` + `tests/test_reproducibility.py` — register the new
-    `random_state` function and update the pinned anchors (same commit as the implementation).
-- **No behavior change** to `remove_outlier_samples`, the detectors, or `VisualizeOutliersStep`'s
-  output. The step refactor is transparent; the rest is additive.
+  - `src/sleap_roots_analyze/__init__.py` — import + `__all__` entries for `plot_outlier_analysis`
+    and `select_outlier_figures`.
+  - `docs/API.md` — `plot_outlier_analysis`, `select_outlier_figures`, `return_detector_result`, +
+    backfill of the composed `create_*` figure functions; `docs/CHANGELOG.md` — `[Unreleased]` entry.
+  - `tests/test_plot_outlier_analysis.py` (new) — TDD coverage (incl. figure-leak + metadata-col +
+    single-detection-reuse follow-ups).
+  - `tests/test_step_visualize_outliers.py` — pinned filename/count baseline for the two methods.
+  - `tests/test_remove_outlier_samples.py` — `return_detector_result` 3-tuple coverage.
+  - `tests/reproducibility_cases.py` — register the new `random_state` function (`EXCLUDED`).
+- **No behavior change** to `remove_outlier_samples`'s default return, the detectors, or
+  `VisualizeOutliersStep`'s output. The step refactor is transparent; the rest is additive.
 - **Depends on #165** (`remove_outlier_samples`, the detectors, the `create_*` exports) — on
   `main` via #172, **not yet on PyPI**.
 - **Release coupling:** rides the same next `analyze` pre-release as #165 (`0.1.0a4`); `[Unreleased]`

--- a/openspec/changes/add-outlier-plotting-entry-point/proposal.md
+++ b/openspec/changes/add-outlier-plotting-entry-point/proposal.md
@@ -1,0 +1,202 @@
+# Proposal: Public Outlier-Plotting Entry Point — `plot_outlier_analysis`
+
+## Why
+
+`remove_outlier_samples` (#165, landed on `main` via #172) gives downstream consumers a tested,
+IO-free way to **trim** outlier samples — but it **explicitly deferred plots** ("outlier
+visualization dashboards … unless cheap to include" was an out-of-scope item). It is now cheap:
+the figures already exist and are already public. What is missing is the **orchestration** — the
+mapping from a detection `method` to *which* figures to draw, fed the right detector inputs.
+
+The nine `create_*_outlier` figure functions are public in `__all__`
+(`src/sleap_roots_analyze/__init__.py:305-313`), but the composition that decides *which* figures
+belong to *which* method lives **only inside `VisualizeOutliersStep`**
+(`src/sleap_roots_analyze/pipeline/steps/visualize_outliers.py`), coupled to a pipeline `run_dir`
++ `savefig` and to upstream pipeline metadata (`prev_result.metadata["outlier_results"]`,
+`config.visualization.*`). `create_comprehensive_outlier_comparison` is just one cross-method
+comparison figure, not an umbrella that draws a method's full figure set.
+
+So an external consumer that wants "give me the figures for this method" today must either fake a
+`StepResult` + pipeline `config` + `run_dir` and then scrape PNGs off disk by filename, or
+re-stitch the per-method `create_*` calls by hand — **untested, duplicated** outside `analyze`,
+the same re-stitching trap #164/#165 removed for cleanup and trimming.
+
+This adds **one public, tested, IO-free entry point** that *imports and composes those
+already-public figure functions* — introducing **no new plotting** — mirroring the #164/#165
+pattern. It is the plotting sibling of `remove_outlier_samples`, and the immediate consumer is the
+bloom-mcp `remove_outliers` tool's optional `include_plots`.
+
+Tracked by [talmolab/sleap-roots-analyze#173](https://github.com/talmolab/sleap-roots-analyze/issues/173)
+(follow-up to #165).
+
+> **Two decisions here reinterpret the original #173 and were RATIFIED by Elizabeth in the updated
+> #173 (2026-07-01):** (1) **B1** — `create_pca_outlier_plot` and the pca/kmeans/gmm/hierarchical
+> plots stay pipeline-only; the public entry point covers only `mahalanobis` + `isolation_forest`
+> (the original mapping was not buildable against the real code — see design.md "Decision B1");
+> (2) **D3** — the pipeline step delegates to a *shared selection helper* (`_select_outlier_figures`)
+> with its own pre-computed results rather than calling `plot_outlier_analysis` (see design.md
+> "Decision D3"). The updated #173 states both explicitly.
+
+## What Changes
+
+### Add the entry point that composes the existing figure functions
+
+Add public **`plot_outlier_analysis`** in `src/sleap_roots_analyze/outlier_visualization.py`
+(alongside the `create_*` functions it composes) that:
+
+1. **Re-detects deterministically, under the same preconditions as `remove_outlier_samples`.**
+   Takes the clean (NaN-free) trait frame and the same `method` / `random_state` / per-method
+   `**detect_kwargs`, and re-runs the **same** detector (`detect_outliers_mahalanobis` /
+   `detect_outliers_isolation_forest`). To make "the figures match the trimmed table" a sound
+   guarantee — and to keep the per-sample index alignment the figures rely on — it enforces the
+   **same two preconditions `remove_outlier_samples` enforces**: NaN-free trait columns (via
+   `validate_clean_traits`, error pointing to `clean_traits_for_analysis`) and a **unique index**.
+   Without these, the detectors' PCA silently `dropna()`s and reports indices against the
+   post-`dropna` frame, and `create_outliers_per_genotype_plot`'s `df.loc[idx, genotype_col]`
+   mis-indexes on a duplicate label. The signature is plain-data-in — no `run_dir`, `config`, or
+   pipeline context.
+2. **Selects the method-appropriate figure set** (small — not all nine `create_*`):
+   - `method="mahalanobis"` → `create_mahalanobis_outlier_plots` (its
+     `mahalanobis_outlier_detection` / `mahalanobis_pc_analysis` / `mahalanobis_threshold_analysis`
+     figures), plus — when a genotype column is present — `create_outliers_per_genotype_plot`.
+   - `method="isolation_forest"` → `create_isolation_forest_plots` (`isolation_forest_analysis`),
+     plus — when a genotype column is present — `create_outliers_per_genotype_plot`.
+
+   **It does NOT draw `create_pca_outlier_plot`.** #173's suggested mapping listed it under
+   `mahalanobis`, but that function consumes a `detect_outliers_pca` **reconstruction** result
+   (keys `reconstruction_errors`, `cumulative_variance`, …) that a Mahalanobis result does not
+   contain — feeding it a Mahalanobis result raises `KeyError` / yields a blank figure, and
+   `remove_outlier_samples` never runs `detect_outliers_pca`, so no matching PCA outlier set exists
+   under the determinism contract. The Mahalanobis PCA **projection** view is already drawn by
+   `create_mahalanobis_outlier_plots` (`mahalanobis_pc_analysis`). *(B1 — ratified in updated #173.)*
+3. **Filters by `which`.** An optional `which` selector (a single figure-key string **or** a list
+   of keys; `None` = the method's full available set) narrows the returned figures, mapping 1:1 to
+   the bloom-mcp tool's `plots` parameter. An unrecognized key — or a key guarded out for this
+   frame (e.g. `outliers_per_genotype` with no genotype column) — is rejected with an actionable
+   `ValueError` naming the keys **actually available** for this method and frame (fail-fast,
+   mirroring `remove_outlier_samples`'s unknown-`method` / unknown-`detect_kwargs` guards).
+4. **Returns a `{stable_name: plt.Figure}` dict** and performs **no IO** — it never writes files,
+   picks a format/DPI, or closes the figures. The **caller** does all IO: the pipeline step
+   `savefig`s with its `config`; bloom-mcp persists via its `ResultStore`. The dict keys are stable
+   identifiers suitable as artifact names / filename stems (the pipeline maps them onto its
+   existing *prefixed* filenames — `outliers_mahal_*`, `outliers_if_*` — so they are stable but not
+   byte-identical to the pipeline stems).
+5. **Surfaces a detector failure up front.** It raises a `ValueError` on a detector `error` key /
+   missing `outlier_indices` **before delegating**, because the composed `create_*` figure
+   functions silently return `{}` on such input — so the raise must happen on the detector result,
+   not be inferred from an empty figure dict.
+6. **Rejects malformed input** (empty frame, duplicate column names, explicit `trait_cols` missing
+   or non-numeric) with actionable `ValueError`s up front — mirroring `remove_outlier_samples`'s
+   "Input Misuse Diagnostics".
+
+### Refactor `VisualizeOutliersStep` to the single source of truth (B3 → `visualization-pipeline`)
+
+Extract the per-method **figure-selection** into a shared private helper
+`_select_outlier_figures(df, results, method, which=None, genotype_col=None)` that dispatches the
+pre-computed `results[method]` to that method's `create_*` figure function(s) and, when
+`genotype_col` is present in `df`, adds the per-genotype figure over the full `results` dict. Both
+the new entry point and the pipeline step call it:
+
+- `plot_outlier_analysis` re-detects, then calls the helper with `results={method: <result>}` and
+  `genotype_col="geno"` (so the per-genotype figure, when drawn, is single-method).
+- `VisualizeOutliersStep`'s `mahalanobis` / `isolation_forest` blocks call the helper with their
+  **already-computed** `outlier_results` and `genotype_col=None` (no re-detection, no per-genotype
+  from the helper — the step keeps its own cross-method per-genotype block), `savefig`ing under the
+  existing filenames.
+
+The step **retains unchanged**: its `pca` block, its `kmeans`/`gmm`/`hierarchical` blocks, its
+`len(methods_run) > 1` comparison figures, and its **cross-method** per-genotype block (which passes
+the full multi-method `outlier_results`, one bar-group per method — structurally different from the
+entry point's single-method per-genotype figure, so that figure is **not** part of the shared
+helper). Its rendered output — figures, filenames, count — is **byte-for-byte unchanged**. Because
+the requirement constrains the existing `visualization-pipeline` capability's step (co-located with
+its `Outlier Method Comparison Summary` requirement), the step-refactor requirement lives in a
+`visualization-pipeline` spec delta, not in the new `outlier-visualization` capability.
+
+Note: `plot_outlier_analysis` is therefore exercised only by its own unit tests, not by the
+pipeline path (the step shares only the helper). This is the accepted cost of preserving the
+pipeline's configured detector params. *(D3 — PENDING RATIFICATION.)*
+
+### Public API + docs
+
+7. **Export `plot_outlier_analysis`** from `__init__.py` / `__all__`, with a Google-style docstring
+   (Args/Returns/Raises) and `typing.get_type_hints()`-resolvable hints (the #116 acceptance bar
+   enforced by the `test_public_api_docs` audit). If `**detect_kwargs` is annotated (`: Any`),
+   `Any` MUST be imported, since `get_type_hints()` evaluates stringized annotations under
+   `from __future__ import annotations` (the #117 `NameError: 'Any'` class of failure). The nine
+   composed `create_*` functions are already in `__all__`, so no new figure function is exported.
+8. **Backfill `docs/API.md`.** `docs/API.md` currently has **no `outlier_visualization` section**
+   — none of the composed `create_*` figure functions are documented. Mirroring #165's backfill of
+   its cross-referenced primitives, add `plot_outlier_analysis` **and** the figure functions it
+   composes (`create_mahalanobis_outlier_plots`, `create_isolation_forest_plots`,
+   `create_outliers_per_genotype_plot`) so the new entry's references resolve. Add a
+   `docs/CHANGELOG.md` `[Unreleased] → Added` entry with the `(#173)` suffix. Update the stale
+   `__all__` count in `docs/public_api_audit_2026.md` (currently "112", now 114 with #165 + this).
+9. **Register for the reproducibility gate.** Because `plot_outlier_analysis` exposes
+   `random_state`, the package-wide sweep (`tests/test_reproducibility.py`) auto-discovers it and
+   the coverage guard goes **red the moment the function lands** — so registration MUST land in the
+   **same commit** as the implementation. Register it in `tests/reproducibility_cases.py` either as
+   a `CASES` entry whose `run` returns the **re-detected `outlier_indices`** (the `Case` comparator
+   cannot compare `Figure`s) and whose `compare` is exact on those indices, **or** as an `EXCLUDED`
+   entry with the documented reason that determinism is fully delegated to the already-swept
+   `detect_outliers_*` (the function adds no new stochastic step). Update the pinned
+   `EXPECTED_QUALNAMES` / case-count anchors in `tests/test_reproducibility.py` in lockstep.
+
+### What "single source of truth" means here
+
+The entry point and the pipeline step call the **same per-method figure-selection helper** for the
+two detect-methods, so the "which `create_*` figures for this method" mapping cannot drift. It does
+**not** promise byte-identical rendered pixels, nor does it share the cross-method comparison /
+per-genotype figures (those stay in the step). The shared truth is the per-method **selection**.
+
+### Composition
+
+`clean_traits_for_analysis` → (optional) `remove_outlier_samples` (report) → (optional)
+**`plot_outlier_analysis`** (figures) → caller persists. The bloom-mcp `remove_outliers` tool's
+optional `include_plots` delegates to this function so removal and plots come from **one pinned
+`analyze` version**.
+
+### Out of scope (explicitly)
+
+- **Any change to `remove_outlier_samples`** — it stays plot-free.
+- **New plot types / restyling** the existing `create_*` figures. This composes them as-is.
+- **`create_pca_outlier_plot`** (a `detect_outliers_pca`-fed figure) — excluded per B1.
+- **File / format / saving** — returns `Figure` objects; the caller writes files.
+- **Clustering-method figures** (`kmeans`/`gmm`/`hierarchical`) and **multi-method comparison**
+  figures — the step keeps drawing these.
+- **Interactive / HTML dashboards.**
+- **Provenance payload** (returning the re-detected `outlier_indices` / effective params alongside
+  the figures for auditability) — a reasonable follow-up (would also make the reproducibility case
+  genuine), but out of scope here to keep the surface minimal.
+- The downstream **bloom-mcp** `remove_outliers` tool — consumes this function; not built here.
+
+## Impact
+
+- Affected specs:
+  - **outlier-visualization** — new capability (the `plot_outlier_analysis` entry point).
+  - **visualization-pipeline** — ADDED requirement for the shared per-method selection helper the
+    step delegates to (behavior unchanged).
+  - **reproducibility-gates / stochastic-determinism** — existing gates; the new `random_state`
+    function must be registered (no new requirement, satisfied by registration).
+  - **public-api-introspection** — existing gate; new `__all__` entry + docstring audit.
+- Affected code:
+  - `src/sleap_roots_analyze/outlier_visualization.py` — new public `plot_outlier_analysis` +
+    the extracted `_select_outlier_figures` helper (both fully type-annotated).
+  - `src/sleap_roots_analyze/pipeline/steps/visualize_outliers.py` — the two shared methods' blocks
+    delegate to the helper (behavior unchanged; pca/clustering/comparison/cross-method-genotype
+    retained).
+  - `src/sleap_roots_analyze/__init__.py` — import + `__all__` entry for `plot_outlier_analysis`.
+  - `docs/API.md` — `plot_outlier_analysis` + backfill of the composed `create_*` figure functions;
+    `docs/CHANGELOG.md` — `[Unreleased]` entry; `docs/public_api_audit_2026.md` — count update.
+  - `tests/test_plot_outlier_analysis.py` (new) — TDD coverage.
+  - `tests/test_step_visualize_outliers.py` — pinned pre-refactor filename/count baseline for the
+    two methods (built fresh; the current step tests use placeholder dicts that draw no mahal/IF
+    figures).
+  - `tests/reproducibility_cases.py` + `tests/test_reproducibility.py` — register the new
+    `random_state` function and update the pinned anchors (same commit as the implementation).
+- **No behavior change** to `remove_outlier_samples`, the detectors, or `VisualizeOutliersStep`'s
+  output. The step refactor is transparent; the rest is additive.
+- **Depends on #165** (`remove_outlier_samples`, the detectors, the `create_*` exports) — on
+  `main` via #172, **not yet on PyPI**.
+- **Release coupling:** rides the same next `analyze` pre-release as #165 (`0.1.0a4`); `[Unreleased]`
+  until then.

--- a/openspec/changes/add-outlier-plotting-entry-point/specs/outlier-visualization/spec.md
+++ b/openspec/changes/add-outlier-plotting-entry-point/specs/outlier-visualization/spec.md
@@ -1,0 +1,291 @@
+## ADDED Requirements
+
+### Requirement: Outlier-Plotting Entry Point
+
+The system SHALL provide a single public function `plot_outlier_analysis` that returns the
+method-appropriate outlier-detection **figures** for a clean, analysis-ready trait table by
+**importing and composing** the existing public `create_*_outlier` figure functions — introducing
+no new plotting logic. It SHALL return a `dict` mapping stable string keys to
+`matplotlib.figure.Figure` objects, and SHALL perform no file IO (it returns figures; the caller
+writes them).
+
+#### Scenario: Returns a dict of named figures for a clean trait table
+
+- **WHEN** `plot_outlier_analysis(clean_df)` is called on a clean (NaN-free) trait table containing
+  injected outlier rows
+- **THEN** trait columns are resolved via `get_trait_columns` when not explicitly passed
+- **AND** the return value is a `dict` whose values are all `matplotlib.figure.Figure` objects
+- **AND** the function writes no files and closes no figures (the caller owns IO)
+
+#### Scenario: Delegates to the public figure functions
+
+- **WHEN** `plot_outlier_analysis(clean_df, method="mahalanobis")` runs with
+  `create_mahalanobis_outlier_plots` replaced by a test double (monkeypatch)
+- **THEN** the test double SHALL be invoked with the frame and the Mahalanobis detector result
+- **AND** the function SHALL define no alternative figure-drawing logic of its own
+
+### Requirement: Method-Appropriate Figure Set
+
+`plot_outlier_analysis` SHALL draw a small, method-appropriate set of figures for a single detection
+`method`, defaulting to `"mahalanobis"` and also supporting `"isolation_forest"` — the two methods
+`remove_outlier_samples` supports. For `"mahalanobis"` the set SHALL be the figures from
+`create_mahalanobis_outlier_plots`. For `"isolation_forest"` the set SHALL be the figure from
+`create_isolation_forest_plots`. For either method, the per-genotype figure
+(`create_outliers_per_genotype_plot`, drawn for the single selected method) SHALL be included when a
+genotype column is present. The entry point SHALL NOT draw `create_pca_outlier_plot` (which consumes
+a `detect_outliers_pca` reconstruction result absent from a Mahalanobis result), the clustering-method
+figures (`kmeans`/`gmm`/`hierarchical`), or the multi-method comparison figures.
+
+#### Scenario: Mahalanobis method returns its figure set
+
+- **WHEN** `plot_outlier_analysis(clean_df, method="mahalanobis")` is called on a frame with a
+  genotype column
+- **THEN** the returned dict SHALL include the figure keys produced by
+  `create_mahalanobis_outlier_plots` and a per-genotype figure key
+- **AND** it SHALL NOT include a `create_pca_outlier_plot` figure
+
+#### Scenario: Isolation-forest method returns its figure set
+
+- **WHEN** `plot_outlier_analysis(clean_df, method="isolation_forest")` is called on a frame with a
+  genotype column
+- **THEN** the returned dict SHALL include the isolation-forest figure key from
+  `create_isolation_forest_plots` and a per-genotype figure key
+- **AND** it SHALL NOT include Mahalanobis figure keys
+
+#### Scenario: Genotype figure included only when the column is present
+
+- **WHEN** `plot_outlier_analysis` is called on a frame that has no genotype column
+- **THEN** the returned dict SHALL omit the per-genotype figure key
+- **AND** all other method-appropriate figure keys SHALL still be present
+
+### Requirement: Method Selection Guard
+
+`plot_outlier_analysis` SHALL reject an unknown `method` with an actionable `ValueError` naming the
+supported methods (`"mahalanobis"`, `"isolation_forest"`) before any detection runs, and SHALL
+reject unknown or cross-method `**detect_kwargs` (e.g. `contamination` with `method="mahalanobis"`)
+with a `ValueError` naming the unrecognized key(s) and the supported set for that method — mirroring
+`remove_outlier_samples`.
+
+#### Scenario: Unknown method is rejected
+
+- **WHEN** `plot_outlier_analysis(clean_df, method="not_a_method")` is called
+- **THEN** a `ValueError` naming the supported methods SHALL be raised before any detection runs
+
+#### Scenario: Unknown or cross-method detect_kwargs are rejected
+
+- **WHEN** a `**detect_kwargs` key is not a parameter of the chosen detector
+- **THEN** a `ValueError` naming the unrecognized key(s) and the supported set SHALL be raised
+  before any detection runs
+
+### Requirement: Figure Selection via `which`
+
+`plot_outlier_analysis` SHALL accept an optional `which` selector — a single figure-key string **or**
+a list of keys — that narrows the returned dict to exactly those keys; `which=None` (default) SHALL
+return the method's full available set. A requested key that is not available for the given method
+and frame SHALL be rejected with an actionable `ValueError` naming the keys that are available (not
+silently dropped and not an empty dict). The selectable keys SHALL be the stable dict keys the
+function otherwise returns, so a consumer's selection maps 1:1 to the returned figures.
+
+#### Scenario: which narrows the returned figures
+
+- **WHEN** `plot_outlier_analysis(clean_df, method="mahalanobis", which=["mahalanobis_outlier_detection"])`
+  is called and that key is available
+- **THEN** the returned dict SHALL contain exactly that one figure and no other keys
+
+#### Scenario: which accepts a single string key
+
+- **WHEN** `which` is a bare string naming an available key (not a list)
+- **THEN** the returned dict SHALL contain exactly that one figure (the string SHALL NOT be iterated
+  character-by-character)
+
+#### Scenario: None returns the full method set
+
+- **WHEN** `plot_outlier_analysis(clean_df, method="mahalanobis", which=None)` is called
+- **THEN** the returned dict SHALL contain the method's full available figure set
+
+#### Scenario: Unavailable which key is rejected
+
+- **WHEN** `which` requests a key not available for that method/frame (e.g. `outliers_per_genotype`
+  on a frame with no genotype column, or a misspelled key)
+- **THEN** a `ValueError` naming the keys available for that method and frame SHALL be raised
+
+### Requirement: Deterministic Re-Detection Matching Removal
+
+`plot_outlier_analysis` SHALL re-detect outliers by calling the same public detector
+(`detect_outliers_mahalanobis` / `detect_outliers_isolation_forest`) that `remove_outlier_samples`
+uses, threading the same `random_state` (default `42`) and per-method `**detect_kwargs`. Given equal
+inputs, `method`, `random_state`, and params — **and the shared NaN-free + unique-index
+preconditions both functions enforce** — the detected outlier **index set** SHALL be identical to the
+set `remove_outlier_samples` removes, so the figures depict the same samples that were trimmed. The
+determinism guarantee is scoped to the integer `outlier_indices` (exact), not to float score arrays
+(which are reproducible only within tolerance). The function SHALL take plain data in (a trait frame,
+no `run_dir` / pipeline `config` / `StepResult`) and SHALL accept `random_state=None` without raising.
+
+#### Scenario: Re-detected outliers match remove_outlier_samples
+
+- **WHEN** `remove_outlier_samples(clean_df, method=m, random_state=s, **kw)` and
+  `plot_outlier_analysis(clean_df, method=m, random_state=s, **kw)` run on the same clean,
+  unique-indexed frame for `m` in {`"mahalanobis"`, `"isolation_forest"`}
+- **THEN** the outlier index set `plot_outlier_analysis` re-detects SHALL equal
+  `outlier_report["outlier_indices"]` from the removal call
+
+#### Scenario: Repeated calls with the same seed are identical
+
+- **WHEN** `plot_outlier_analysis(clean_df, random_state=7)` is called twice on the same frame
+- **THEN** both calls SHALL re-detect the identical outlier index set and return the same figure keys
+
+#### Scenario: Accepts random_state=None
+
+- **WHEN** `plot_outlier_analysis(clean_df, random_state=None)` is called on a valid clean frame
+- **THEN** the call SHALL return a figure dict without raising
+
+### Requirement: Clean-Input Precondition
+
+`plot_outlier_analysis` SHALL require a NaN-free input in the trait columns and SHALL verify this via
+`validate_clean_traits` before detecting, raising an actionable `ValueError` that names the affected
+traits and directs the caller to run `clean_traits_for_analysis` first. This is a correctness guard:
+the detectors run PCA that silently drops NaN rows and reports `outlier_indices` against the
+post-`dropna` frame, so a NaN-carrying input would misalign the indices the figures (notably
+`create_outliers_per_genotype_plot`'s `df.loc[idx, genotype_col]`) index by, and would diverge from
+the set `remove_outlier_samples` — which rejects such input — would remove.
+
+#### Scenario: NaN-carrying input is rejected with guidance
+
+- **WHEN** `plot_outlier_analysis` is called on a frame whose trait columns still contain NaN
+- **THEN** a `ValueError` naming the affected traits AND mentioning `clean_traits_for_analysis` SHALL
+  be raised before any detector runs
+
+### Requirement: Unique Sample Index Required
+
+`plot_outlier_analysis` SHALL require the input frame to have a unique index and SHALL raise an
+actionable `ValueError` when it does not, before any detector runs. The per-sample figures index the
+frame by re-detected label (`df.loc[idx, ...]`), so a duplicate label would select multiple rows and
+mis-draw the per-genotype figure; a unique index makes the one-to-one alignment sound (matching
+`remove_outlier_samples`).
+
+#### Scenario: Non-unique index is rejected
+
+- **WHEN** `plot_outlier_analysis` is called on a frame whose index has duplicate labels
+- **THEN** a `ValueError` stating the index must be unique SHALL be raised before any detector runs
+
+#### Scenario: Default RangeIndex input is accepted
+
+- **WHEN** `plot_outlier_analysis` is called on a frame with a unique (e.g. default `RangeIndex`)
+  index
+- **THEN** the uniqueness check SHALL pass and processing SHALL proceed
+
+### Requirement: Input Misuse Diagnostics
+
+`plot_outlier_analysis` SHALL reject malformed input up front with an actionable `ValueError` rather
+than a bare pandas error: empty input, duplicate column names, and explicit `trait_cols` that are
+missing from the dataframe or non-numeric.
+
+#### Scenario: Empty input is rejected before delegating
+
+- **WHEN** `plot_outlier_analysis` is called on a table with no rows
+- **THEN** a `ValueError` with an actionable message SHALL be raised before any detector runs
+
+#### Scenario: Explicit trait_cols not in the dataframe are rejected
+
+- **WHEN** an explicit `trait_cols` entry is not a column of `clean_df`
+- **THEN** a `ValueError` naming the missing columns SHALL be raised (not a bare `KeyError`)
+
+### Requirement: IO-Free Figure Return
+
+`plot_outlier_analysis` SHALL return `matplotlib` `Figure` objects and SHALL NOT write files, choose
+a file format or DPI, or close the figures. All persistence SHALL be the caller's responsibility (the
+pipeline step `savefig`s with its `config`; an MCP consumer persists via its own store). The returned
+dict keys SHALL be stable identifiers suitable for use as filename stems or artifact names.
+
+#### Scenario: No files are written
+
+- **WHEN** `plot_outlier_analysis(clean_df)` is called
+- **THEN** no image files SHALL be created by the call
+- **AND** every returned value SHALL be an open `matplotlib.figure.Figure`
+
+### Requirement: Detector-Failure Surfacing
+
+`plot_outlier_analysis` SHALL surface a detector failure by raising a `ValueError` **on the detector
+result, before delegating to the figure functions**. When the chosen detector returns a result
+carrying an `error` key or lacking `outlier_indices` (e.g. degenerate PCA, empty/all-NaN data), the
+function SHALL raise, rather than pass the result to the `create_*` functions — which silently return
+an empty figure dict on such input, masking the failure.
+
+#### Scenario: Detector error is raised, not silently swallowed
+
+- **WHEN** the chosen detector (monkeypatched) returns a result containing an `error` key or no
+  `outlier_indices`
+- **THEN** `plot_outlier_analysis` SHALL raise a `ValueError` surfacing that error before any
+  `create_*` figure function is called
+
+### Requirement: Reproducibility-Gate Registration
+
+This change SHALL register `plot_outlier_analysis` in the package reproducibility registry so the
+stochastic-determinism sweep continues to pass. Because `plot_outlier_analysis` exposes a
+`random_state` parameter, the package-wide sweep (`tests/test_reproducibility.py`) auto-discovers it
+and the coverage guard fails until it is registered — so registration SHALL land in the same commit
+as the implementation. Registration SHALL be either a `tests/reproducibility_cases.py` `CASES` entry
+whose comparable is the re-detected `outlier_indices` (the `Case` comparator cannot compare
+`Figure`s) compared exactly, or an `EXCLUDED` entry with the documented reason that determinism is
+delegated to the already-swept `detect_outliers_*`. The pinned `EXPECTED_QUALNAMES` / case-count
+anchors in `tests/test_reproducibility.py` SHALL be updated in lockstep.
+
+#### Scenario: Reproducibility sweep covers the new function
+
+- **WHEN** `tests/test_reproducibility.py`'s package-wide coverage sweep runs
+- **THEN** `plot_outlier_analysis` SHALL be present in `CASES` (comparable on `outlier_indices`) or
+  in `EXCLUDED` with a reason
+- **AND** the suite (including the `EXPECTED_QUALNAMES` / count anchors) SHALL pass
+
+### Requirement: Public API Surface
+
+The package SHALL export `plot_outlier_analysis` from the top-level `sleap_roots_analyze` namespace
+and list it in `__all__`, with a Google-style docstring (Args/Returns/Raises) and type hints
+resolvable by `typing.get_type_hints()`. If `**detect_kwargs` is annotated, the annotation SHALL be
+importable (e.g. `Any` imported) so `get_type_hints()` does not raise under
+`from __future__ import annotations`. The `create_*_outlier` figure functions it composes are already
+exported and SHALL remain exported.
+
+#### Scenario: Entry point is importable from the package root
+
+- **WHEN** a consumer runs `from sleap_roots_analyze import plot_outlier_analysis`
+- **THEN** the import SHALL succeed
+- **AND** the imported object SHALL be identity-equal (`is`) to the function defined in
+  `sleap_roots_analyze.outlier_visualization`
+
+#### Scenario: Entry point is listed in `__all__` without duplicates
+
+- **WHEN** `sleap_roots_analyze.__all__` is inspected
+- **THEN** it SHALL contain `plot_outlier_analysis`
+- **AND** SHALL contain no duplicate entries
+
+#### Scenario: Public function satisfies the package API-docs audit
+
+- **WHEN** `typing.get_type_hints(plot_outlier_analysis)` is called and the package
+  `test_public_api_docs` audit runs
+- **THEN** `get_type_hints` SHALL return without raising `NameError`
+- **AND** the docstring SHALL include populated Args, Returns, and Raises sections in Google style
+
+### Requirement: API Reference and Changelog Documentation
+
+The project documentation SHALL list the new public function and record it in the changelog, keeping
+the hand-maintained reference in sync. Because the new API.md entry cross-references the composed
+figure functions, any of those currently absent from `docs/API.md`
+(`create_mahalanobis_outlier_plots`, `create_isolation_forest_plots`,
+`create_outliers_per_genotype_plot` — the `outlier_visualization` module has no API.md section
+today) SHALL be added so the references resolve.
+
+#### Scenario: API reference lists the new public function and resolvable cross-references
+
+- **WHEN** `docs/API.md` is viewed
+- **THEN** it SHALL include a reference entry for `plot_outlier_analysis` with a signature matching
+  the code
+- **AND** the composed `create_*_outlier` figure functions it references SHALL each have an API.md
+  entry
+
+#### Scenario: Changelog records the new public API
+
+- **WHEN** `docs/CHANGELOG.md` `[Unreleased]` section is viewed
+- **THEN** it SHALL include an `### Added` entry noting `plot_outlier_analysis` is importable from
+  `sleap_roots_analyze` as the outlier-plotting sibling of `remove_outlier_samples`, with a `(#173)`
+  issue suffix

--- a/openspec/changes/add-outlier-plotting-entry-point/specs/outlier-visualization/spec.md
+++ b/openspec/changes/add-outlier-plotting-entry-point/specs/outlier-visualization/spec.md
@@ -193,15 +193,25 @@ missing from the dataframe or non-numeric.
 ### Requirement: IO-Free Figure Return
 
 `plot_outlier_analysis` SHALL return `matplotlib` `Figure` objects and SHALL NOT write files, choose
-a file format or DPI, or close the figures. All persistence SHALL be the caller's responsibility (the
-pipeline step `savefig`s with its `config`; an MCP consumer persists via its own store). The returned
-dict keys SHALL be stable identifiers suitable for use as filename stems or artifact names.
+a file format or DPI, or close the **returned** figures. All persistence SHALL be the caller's
+responsibility (the pipeline step `savefig`s with its `config`; an MCP consumer persists via its own
+store). The returned dict keys SHALL be stable identifiers suitable for use as filename stems or
+artifact names. When a `which` selection narrows the result, any figure that was built but excluded
+SHALL be closed so a narrowed call leaves no orphaned figures in matplotlib's global registry (no
+unbounded figure growth in a long-running process).
 
 #### Scenario: No files are written
 
 - **WHEN** `plot_outlier_analysis(clean_df)` is called
 - **THEN** no image files SHALL be created by the call
 - **AND** every returned value SHALL be an open `matplotlib.figure.Figure`
+
+#### Scenario: A which-narrowed call leaves no orphaned figures
+
+- **WHEN** `plot_outlier_analysis(clean_df, method="mahalanobis", which="mahalanobis_outlier_detection")`
+  returns one figure
+- **THEN** the number of open figures in matplotlib's registry SHALL equal the number returned
+  (the figures built but excluded by `which` SHALL have been closed)
 
 ### Requirement: Detector-Failure Surfacing
 
@@ -217,6 +227,51 @@ an empty figure dict on such input, masking the failure.
   `outlier_indices`
 - **THEN** `plot_outlier_analysis` SHALL raise a `ValueError` surfacing that error before any
   `create_*` figure function is called
+
+### Requirement: Metadata-Column Parameters Match Removal
+
+`plot_outlier_analysis` SHALL accept the same metadata-column parameters as `remove_outlier_samples`
+— `barcode_col` (default `"Barcode"`), `genotype_col` (default `"geno"`), and `replicate_col`
+(default `"rep"`) — and SHALL forward them to `get_trait_columns` when inferring traits and use
+`genotype_col` for the per-genotype figure. This keeps the re-detected trait set (and therefore the
+plotted outlier set) aligned with a `remove_outlier_samples` call made with the same metadata columns,
+rather than silently diverging on a hardcoded default.
+
+#### Scenario: Metadata columns are forwarded to trait resolution
+
+- **WHEN** `plot_outlier_analysis` is called with explicit `barcode_col` / `genotype_col` /
+  `replicate_col` and no `trait_cols`
+- **THEN** those column names SHALL be passed to `get_trait_columns` for the trait inference
+
+#### Scenario: Per-genotype figure follows genotype_col
+
+- **WHEN** `plot_outlier_analysis(clean_df, genotype_col="Genotype")` is called on a frame whose
+  genotype column is named `"Genotype"` (not the default `"geno"`)
+- **THEN** the per-genotype figure SHALL be produced using the `"Genotype"` column
+
+### Requirement: Public Figure-Selection Layer and Single-Detection Reuse
+
+The no-detection figure-selection layer SHALL be public as `select_outlier_figures(df, results,
+method, which=None, genotype_col=None)` and listed in `__all__`, so a consumer that already holds a
+detector result can select figures without a redundant re-detection. To supply that result without
+re-stitching, `remove_outlier_samples` SHALL accept an additive `return_detector_result: bool = False`
+parameter that, when `True`, additionally returns the raw detector result dict (a third tuple
+element); the default `False` SHALL preserve the existing compact-report 2-tuple return contract.
+
+#### Scenario: Selection layer is public and detection-free
+
+- **WHEN** `select_outlier_figures(df, {method: detector_result}, method)` is called with a
+  pre-computed detector result
+- **THEN** it SHALL return the method-appropriate figures without running any detector
+
+#### Scenario: Removal can return the raw detector result for reuse
+
+- **WHEN** `remove_outlier_samples(clean_df, return_detector_result=True)` is called
+- **THEN** it SHALL return a 3-tuple `(trimmed_df, outlier_report, detector_result)` whose
+  `detector_result` feeds `select_outlier_figures` (via `{method: detector_result}`) to plot the
+  same outliers without a second detection
+- **WHEN** `return_detector_result` is `False` (default)
+- **THEN** it SHALL return the 2-tuple `(trimmed_df, outlier_report)` unchanged
 
 ### Requirement: Reproducibility-Gate Registration
 
@@ -239,12 +294,12 @@ anchors in `tests/test_reproducibility.py` SHALL be updated in lockstep.
 
 ### Requirement: Public API Surface
 
-The package SHALL export `plot_outlier_analysis` from the top-level `sleap_roots_analyze` namespace
-and list it in `__all__`, with a Google-style docstring (Args/Returns/Raises) and type hints
-resolvable by `typing.get_type_hints()`. If `**detect_kwargs` is annotated, the annotation SHALL be
-importable (e.g. `Any` imported) so `get_type_hints()` does not raise under
-`from __future__ import annotations`. The `create_*_outlier` figure functions it composes are already
-exported and SHALL remain exported.
+The package SHALL export both `plot_outlier_analysis` and `select_outlier_figures` from the top-level
+`sleap_roots_analyze` namespace and list them in `__all__`, with Google-style docstrings
+(Args/Returns/Raises) and type hints resolvable by `typing.get_type_hints()`. If `**detect_kwargs` is
+annotated, the annotation SHALL be importable (e.g. `Any` imported) so `get_type_hints()` does not
+raise under `from __future__ import annotations`. The `create_*_outlier` figure functions they compose
+are already exported and SHALL remain exported.
 
 #### Scenario: Entry point is importable from the package root
 
@@ -253,10 +308,10 @@ exported and SHALL remain exported.
 - **AND** the imported object SHALL be identity-equal (`is`) to the function defined in
   `sleap_roots_analyze.outlier_visualization`
 
-#### Scenario: Entry point is listed in `__all__` without duplicates
+#### Scenario: Entry point and selection layer are listed in `__all__` without duplicates
 
 - **WHEN** `sleap_roots_analyze.__all__` is inspected
-- **THEN** it SHALL contain `plot_outlier_analysis`
+- **THEN** it SHALL contain `plot_outlier_analysis` and `select_outlier_figures`
 - **AND** SHALL contain no duplicate entries
 
 #### Scenario: Public function satisfies the package API-docs audit

--- a/openspec/changes/add-outlier-plotting-entry-point/specs/visualization-pipeline/spec.md
+++ b/openspec/changes/add-outlier-plotting-entry-point/specs/visualization-pipeline/spec.md
@@ -4,7 +4,7 @@
 
 `VisualizeOutliersStep` SHALL obtain its `mahalanobis` and `isolation_forest` per-method figures via
 the same shared per-method selection helper that the public `plot_outlier_analysis` entry point uses
-(`_select_outlier_figures`), so the "which `create_*` figures for this method" mapping has a single
+(`select_outlier_figures`), so the "which `create_*` figures for this method" mapping has a single
 source of truth. The step SHALL pass its **already-computed** `outlier_results[method]` into the
 helper — it SHALL NOT re-detect and SHALL NOT call `plot_outlier_analysis` — thereby preserving the
 pipeline's configured detector parameters. This change SHALL NOT alter the step's rendered output:
@@ -22,7 +22,7 @@ point's single-method per-genotype figure and therefore not part of the shared h
 - **THEN** the set of figure filenames and the figure count SHALL be identical to the pre-change
   behavior for each case
 - **AND** the step SHALL obtain the `mahalanobis` / `isolation_forest` figures via
-  `_select_outlier_figures` using its pre-computed `outlier_results`, without re-running detection
+  `select_outlier_figures` using its pre-computed `outlier_results`, without re-running detection
 
 #### Scenario: Existing step and detection suites are unaffected
 

--- a/openspec/changes/add-outlier-plotting-entry-point/specs/visualization-pipeline/spec.md
+++ b/openspec/changes/add-outlier-plotting-entry-point/specs/visualization-pipeline/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Shared Per-Method Outlier-Figure Selection
+
+`VisualizeOutliersStep` SHALL obtain its `mahalanobis` and `isolation_forest` per-method figures via
+the same shared per-method selection helper that the public `plot_outlier_analysis` entry point uses
+(`_select_outlier_figures`), so the "which `create_*` figures for this method" mapping has a single
+source of truth. The step SHALL pass its **already-computed** `outlier_results[method]` into the
+helper — it SHALL NOT re-detect and SHALL NOT call `plot_outlier_analysis` — thereby preserving the
+pipeline's configured detector parameters. This change SHALL NOT alter the step's rendered output:
+the figures it writes, their filenames, and their count SHALL be unchanged, and the step SHALL keep
+drawing its `pca`, `kmeans`, `gmm`, and `hierarchical` method figures, its multi-method comparison
+figures (including the `Outlier Method Comparison Summary` bar chart), and its cross-method
+per-genotype figure (which passes the full multi-method `outlier_results`, distinct from the entry
+point's single-method per-genotype figure and therefore not part of the shared helper).
+
+#### Scenario: Step output is byte-identical after delegating selection
+
+- **WHEN** the QC pipeline runs `VisualizeOutliersStep` after this change on a fixture exercising a
+  single method (`mahalanobis`) and on one exercising multiple methods (`mahalanobis` +
+  `isolation_forest`), each with and without a genotype column
+- **THEN** the set of figure filenames and the figure count SHALL be identical to the pre-change
+  behavior for each case
+- **AND** the step SHALL obtain the `mahalanobis` / `isolation_forest` figures via
+  `_select_outlier_figures` using its pre-computed `outlier_results`, without re-running detection
+
+#### Scenario: Existing step and detection suites are unaffected
+
+- **WHEN** the existing pipeline-step and outlier-detection test suites run after this change
+- **THEN** their outcomes SHALL be unchanged

--- a/openspec/changes/add-outlier-plotting-entry-point/tasks.md
+++ b/openspec/changes/add-outlier-plotting-entry-point/tasks.md
@@ -1,0 +1,72 @@
+# Tasks: Public Outlier-Plotting Entry Point — `plot_outlier_analysis`
+
+TDD order: behavior/oracle tests first (red), implement to green, then the transparent step
+refactor, then docs/gates. B1 + D3 ratified in the updated #173 (2026-07-01).
+
+## 1. Behavior tests (`tests/test_plot_outlier_analysis.py`)
+
+- [x] 1.1 Clean, unique-indexed trait fixture with injected outliers + `geno` column (mirrors #165).
+- [x] 1.2 Returns `dict[str, plt.Figure]`; mahalanobis keys + `outliers_per_genotype`, no
+      `pca_outlier`; isolation_forest key + per-genotype, no mahalanobis keys.
+- [x] 1.3 Determinism/match: re-detected `outlier_indices` (captured via a wrapped `create_*` spy)
+      equal `remove_outlier_samples`'s, for both `mahalanobis` and the seed-load-bearing
+      `isolation_forest`.
+- [x] 1.4 `which`: list narrows; bare string works; `None` = full set; unavailable/misspelled key
+      raises naming the available keys; per-genotype key rejected when no genotype column.
+- [x] 1.5 No IO (no files written; figures returned open).
+- [x] 1.6 Per-genotype figure present only when a genotype column exists.
+- [x] 1.7 Preconditions/misuse: NaN → error mentioning `clean_traits_for_analysis`; non-unique index;
+      empty frame; missing `trait_cols`; unknown `method`; cross-method `detect_kwargs`;
+      `random_state=None` accepted.
+- [x] 1.8 Detector-failure: raises before any `create_*` is called (spied).
+- [x] 1.9 Public API: importable, in `__all__` once, `get_type_hints` resolves, Google
+      Args/Returns/Raises; `test_public_api_docs` audit passes.
+- [x] 1.10 Lower-level helper returns core-only figures when `genotype_col` is not given.
+
+## 2. Implementation (`outlier_visualization.py`)
+
+- [x] 2.1 `_select_outlier_figures(df, results, method, which=None, genotype_col=None)` — the single
+      per-method selection: dispatch `results[method]` to `create_mahalanobis_outlier_plots` /
+      `create_isolation_forest_plots`; add `outliers_per_genotype` (over full `results`) when
+      `genotype_col` present; filter by `which`. Fully type-annotated.
+- [x] 2.2 `plot_outlier_analysis(clean_df, trait_cols=None, *, method="mahalanobis",
+      random_state=42, which=None, **detect_kwargs)`: misuse + NaN + unique-index +
+      unknown-`method`/`detect_kwargs` guards; re-detect; raise on detector error before delegating;
+      `_select_outlier_figures(clean_df, {method: result}, method, which=which, genotype_col="geno")`.
+- [x] 2.3 Google docstring; `**detect_kwargs: Any` with `Any` imported (guards the `get_type_hints`
+      `NameError`). `random_state: int = 42` (matching the sibling; accepts `None` at runtime).
+
+## 3. Single-source-of-truth step refactor (transparent)
+
+- [x] 3.1 Regression test in `tests/test_step_visualize_outliers.py` with **realistic** detector
+      output: asserts the step's `mahalanobis`/`isolation_forest` filenames equal the `create_*`
+      keys (prefixed as before), and that comparison + a single cross-method per-genotype figure are
+      unchanged.
+- [x] 3.2 Step's `mahalanobis` / `isolation_forest` blocks call
+      `_select_outlier_figures(df, outlier_results, method)` (no re-detection); `pca`, `kmeans`,
+      `gmm`, `hierarchical`, comparison, and cross-method per-genotype blocks unchanged.
+
+## 4. Public API + docs
+
+- [x] 4.1 Import + `__all__` entry for `plot_outlier_analysis` (no dup; `create_*` stay exported).
+- [x] 4.2 `docs/API.md`: new `outlier_visualization` section for `plot_outlier_analysis` **and**
+      backfill of `create_mahalanobis_outlier_plots` / `create_isolation_forest_plots` /
+      `create_outliers_per_genotype_plot` (module had no section); TOC entry added.
+- [x] 4.3 `docs/CHANGELOG.md` `[Unreleased] → Added` entry with the `(#173)` suffix.
+- [~] 4.4 `docs/public_api_audit_2026.md` count left as-is — it is a dated point-in-time #117 audit
+      snapshot (no test/spec asserts the number); rewriting its measured counts would misrepresent
+      the historical audit. Noted rather than edited.
+
+## 5. Reproducibility gate
+
+- [x] 5.1 `plot_outlier_analysis` added to `tests/reproducibility_cases.py` `EXCLUDED` with the reason
+      "composes figures over already-swept `detect_outliers_*`; adds no new stochastic step and
+      returns Figures (not sweep-comparable)". `EXPECTED_QUALNAMES` / `len(CASES)` unchanged (it is
+      `EXCLUDED`, not `CASES`); `test_excluded_set_is_consistent` covers it.
+
+## 6. Verification
+
+- [x] 6.1 `openspec validate add-outlier-plotting-entry-point --strict` — valid.
+- [x] 6.2 `uv run pytest` green for the affected suites (plot, step, reproducibility,
+      public_api_docs, public_api, remove_outlier_samples) — 173 passed.
+- [x] 6.3 `uv run black --check` + `uv run ruff check` clean; mypy baseline delta 0 (`new: 0`).

--- a/openspec/changes/add-outlier-plotting-entry-point/tasks.md
+++ b/openspec/changes/add-outlier-plotting-entry-point/tasks.md
@@ -25,16 +25,18 @@ refactor, then docs/gates. B1 + D3 ratified in the updated #173 (2026-07-01).
 
 ## 2. Implementation (`outlier_visualization.py`)
 
-- [x] 2.1 `_select_outlier_figures(df, results, method, which=None, genotype_col=None)` — the single
+- [x] 2.1 `select_outlier_figures(df, results, method, which=None, genotype_col=None)` — the single
       per-method selection: dispatch `results[method]` to `create_mahalanobis_outlier_plots` /
       `create_isolation_forest_plots`; add `outliers_per_genotype` (over full `results`) when
       `genotype_col` present; filter by `which`. Fully type-annotated.
 - [x] 2.2 `plot_outlier_analysis(clean_df, trait_cols=None, *, method="mahalanobis",
-      random_state=42, which=None, **detect_kwargs)`: misuse + NaN + unique-index +
-      unknown-`method`/`detect_kwargs` guards; re-detect; raise on detector error before delegating;
-      `_select_outlier_figures(clean_df, {method: result}, method, which=which, genotype_col="geno")`.
+      barcode_col="Barcode", genotype_col="geno", replicate_col="rep", random_state=42, which=None,
+      **detect_kwargs)`: misuse + NaN + unique-index + unknown-`method`/`detect_kwargs` guards;
+      re-detect; raise on detector error before delegating; `select_outlier_figures(clean_df,
+      {method: result}, method, which=which, genotype_col=genotype_col)`.
 - [x] 2.3 Google docstring; `**detect_kwargs: Any` with `Any` imported (guards the `get_type_hints`
-      `NameError`). `random_state: int = 42` (matching the sibling; accepts `None` at runtime).
+      `NameError`). `random_state: Optional[int] = 42` (matches docs/tests; the seed reaches the
+      detector via a `Dict[str, Any]` splat so the detectors' `int` annotation is not tripped).
 
 ## 3. Single-source-of-truth step refactor (transparent)
 
@@ -43,7 +45,7 @@ refactor, then docs/gates. B1 + D3 ratified in the updated #173 (2026-07-01).
       keys (prefixed as before), and that comparison + a single cross-method per-genotype figure are
       unchanged.
 - [x] 3.2 Step's `mahalanobis` / `isolation_forest` blocks call
-      `_select_outlier_figures(df, outlier_results, method)` (no re-detection); `pca`, `kmeans`,
+      `select_outlier_figures(df, outlier_results, method)` (no re-detection); `pca`, `kmeans`,
       `gmm`, `hierarchical`, comparison, and cross-method per-genotype blocks unchanged.
 
 ## 4. Public API + docs
@@ -70,3 +72,21 @@ refactor, then docs/gates. B1 + D3 ratified in the updated #173 (2026-07-01).
 - [x] 6.2 `uv run pytest` green for the affected suites (plot, step, reproducibility,
       public_api_docs, public_api, remove_outlier_samples) — 173 passed.
 - [x] 6.3 `uv run black --check` + `uv run ruff check` clean; mypy baseline delta 0 (`new: 0`).
+
+## 7. PR #175 review follow-ups (single-detection reuse, correctness, lifecycle)
+
+- [x] 7.1 Promote the selection helper to **public** `select_outlier_figures` + add to `__all__`;
+      neutral `select_outlier_figures:` error prefix (not `plot_outlier_analysis:`).
+- [x] 7.2 Fix the `which`-narrow figure leak: skip the per-genotype render when not requested and
+      `plt.close` any built-but-excluded figures (and close all before raising on a missing key).
+      Regression test: `len(plt.get_fignums()) == len(returned)` after a narrowed call.
+- [x] 7.3 `plot_outlier_analysis` `random_state -> Optional[int] = 42` (matches docs/tests).
+- [x] 7.4 Add `barcode_col`/`genotype_col`/`replicate_col` to `plot_outlier_analysis`, forwarded to
+      `get_trait_columns` and used for the per-genotype figure (drop hardcoded `"geno"`). Tests:
+      metadata cols forwarded; custom `genotype_col` drives the per-genotype figure.
+- [x] 7.5 `remove_outlier_samples(return_detector_result=False)` additive flag → 3-tuple when `True`;
+      default 2-tuple unchanged. Tests: flag returns raw dict; it feeds `select_outlier_figures`.
+- [x] 7.6 Edge-case tests: duplicate columns, non-numeric explicit `trait_cols`, all-NaN column.
+- [x] 7.7 Reword "byte-identical" → "same figure keys/filenames" (step test + `visualize_outliers.py`
+      comments). Document the figure lifecycle in `docs/API.md`; document `select_outlier_figures` +
+      `return_detector_result` in API.md/CHANGELOG.

--- a/src/sleap_roots_analyze/__init__.py
+++ b/src/sleap_roots_analyze/__init__.py
@@ -132,6 +132,7 @@ from sleap_roots_analyze.outlier_visualization import (
     create_kmeans_outlier_plots,
     create_gmm_outlier_plots,
     create_hierarchical_outlier_plots,
+    plot_outlier_analysis,
 )
 
 from sleap_roots_analyze.cross_experiment_analysis import (
@@ -311,6 +312,7 @@ __all__ = [
     "create_kmeans_outlier_plots",
     "create_gmm_outlier_plots",
     "create_hierarchical_outlier_plots",
+    "plot_outlier_analysis",
     # Cross-experiment analysis functions
     "load_and_align_experiments",
     "calculate_genotype_means",

--- a/src/sleap_roots_analyze/__init__.py
+++ b/src/sleap_roots_analyze/__init__.py
@@ -133,6 +133,7 @@ from sleap_roots_analyze.outlier_visualization import (
     create_gmm_outlier_plots,
     create_hierarchical_outlier_plots,
     plot_outlier_analysis,
+    select_outlier_figures,
 )
 
 from sleap_roots_analyze.cross_experiment_analysis import (
@@ -313,6 +314,7 @@ __all__ = [
     "create_gmm_outlier_plots",
     "create_hierarchical_outlier_plots",
     "plot_outlier_analysis",
+    "select_outlier_figures",
     # Cross-experiment analysis functions
     "load_and_align_experiments",
     "calculate_genotype_means",

--- a/src/sleap_roots_analyze/outlier_removal.py
+++ b/src/sleap_roots_analyze/outlier_removal.py
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import inspect
 import warnings
-from typing import Any, Callable, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import pandas as pd
@@ -139,8 +139,12 @@ def remove_outlier_samples(
     genotype_col: str = "geno",
     replicate_col: Optional[str] = "rep",
     random_state: int = 42,
+    return_detector_result: bool = False,
     **detect_kwargs: Any,
-) -> Tuple[pd.DataFrame, Dict[str, Any]]:
+) -> Union[
+    Tuple[pd.DataFrame, Dict[str, Any]],
+    Tuple[pd.DataFrame, Dict[str, Any], Dict[str, Any]],
+]:
     """Detect and remove outlier samples from a clean, analysis-ready trait table.
 
     Quality-step follow-up to
@@ -211,6 +215,13 @@ def remove_outlier_samples(
         genotype_col: Genotype column to exclude when inferring traits.
         replicate_col: Replicate column to exclude if present (``None`` if absent).
         random_state: Seed forwarded to the detector for reproducibility.
+        return_detector_result: When ``True``, additionally return the **raw** detector
+            result dict (a third tuple element) — the full per-sample arrays the compact
+            ``outlier_report`` deliberately omits. Lets a consumer detect once and feed
+            the result to ``plot_outlier_analysis``'s selection layer
+            (:func:`~sleap_roots_analyze.outlier_visualization.select_outlier_figures`)
+            without a redundant second detection. Default ``False`` preserves the
+            compact-report, 2-tuple contract.
         **detect_kwargs: Per-method parameters forwarded to the chosen detector
             unchanged — ``contamination`` for ``"isolation_forest"``;
             ``chi2_percentile``, ``variance_threshold``, ``use_chi_squared``,
@@ -218,10 +229,11 @@ def remove_outlier_samples(
             Detector defaults apply for any not passed.
 
     Returns:
-        Tuple ``(trimmed_df, outlier_report)`` where ``trimmed_df`` is ``clean_df``
-        with the flagged outlier rows removed (all columns preserved — outlier
-        removal drops rows, never columns) and ``outlier_report`` is an auditable,
-        JSON-serializable dict with keys: ``method``, ``method_params``,
+        Tuple ``(trimmed_df, outlier_report)`` — or, when ``return_detector_result`` is
+        ``True``, ``(trimmed_df, outlier_report, detector_result)``. ``trimmed_df`` is
+        ``clean_df`` with the flagged outlier rows removed (all columns preserved —
+        outlier removal drops rows, never columns) and ``outlier_report`` is an
+        auditable, JSON-serializable dict with keys: ``method``, ``method_params``,
         ``random_state``, ``n_input_samples``, ``n_outliers``, ``n_output_samples``,
         ``removal_fraction``, ``outlier_indices``, ``outlier_barcodes``,
         ``threshold_type``, ``threshold_value``, ``n_components``,
@@ -229,6 +241,8 @@ def remove_outlier_samples(
         keys (``threshold_type``, ``threshold_value``, ``n_components``,
         ``goodness_of_fit``) are populated for Mahalanobis and ``None`` for
         isolation forest (whose control is ``contamination``, in ``method_params``).
+        ``detector_result`` (when returned) is the unmodified dict from the chosen
+        ``detect_outliers_*`` function.
 
     Raises:
         ValueError: On empty input; duplicate column names; explicit ``trait_cols``
@@ -447,4 +461,9 @@ def remove_outlier_samples(
             stacklevel=2,
         )
 
+    # Optionally hand back the raw detector result (with the per-sample arrays the
+    # compact report omits) so a consumer — e.g. the bloom-mcp remove_outliers tool —
+    # can feed it to plot_outlier_analysis's selection layer without a second detection.
+    if return_detector_result:
+        return trimmed_df, outlier_report, detect_result
     return trimmed_df, outlier_report

--- a/src/sleap_roots_analyze/outlier_visualization.py
+++ b/src/sleap_roots_analyze/outlier_visualization.py
@@ -1797,7 +1797,7 @@ def create_outlier_method_comparison_plot(
 _ENTRY_METHODS = ("mahalanobis", "isolation_forest")
 
 
-def _select_outlier_figures(
+def select_outlier_figures(
     df: pd.DataFrame,
     results: Dict[str, Dict[str, Any]],
     method: str,
@@ -1810,7 +1810,14 @@ def _select_outlier_figures(
     method", shared by :func:`plot_outlier_analysis` (which re-detects) and the
     pipeline's ``VisualizeOutliersStep`` (which passes its own pre-computed
     ``outlier_results``). It runs **no detection** — it only dispatches an existing
-    detector result to the existing figure functions.
+    detector result to the existing figure functions. Public so a consumer that
+    already holds a detector result (e.g. from
+    ``remove_outlier_samples(..., return_detector_result=True)``) can plot without a
+    redundant second detection.
+
+    Figure lifecycle: the returned figures are open and owned by the caller (close
+    them when done). Figures built but excluded by ``which`` are closed here, so a
+    narrowed call leaves no orphaned figures in matplotlib's registry.
 
     Args:
         df: The trait frame the figures are drawn over.
@@ -1832,33 +1839,47 @@ def _select_outlier_figures(
         ValueError: On an unknown ``method``, or a ``which`` key not available for
             the given method and frame (the message names the available keys).
     """
+    if method not in _ENTRY_METHODS:
+        raise ValueError(
+            f"select_outlier_figures: unknown method {method!r}. Supported: "
+            f"{list(_ENTRY_METHODS)}."
+        )
+
+    # Normalize the requested keys (a bare string is one key, not iterated by char).
+    requested: Optional[List[str]] = None
+    if which is not None:
+        requested = [which] if isinstance(which, str) else list(which)
+
+    # The per-genotype figure is drawn only when a genotype column is present AND it
+    # is wanted (unfiltered, or explicitly requested) — avoids a wasted render.
+    genotype_requested = requested is None or "outliers_per_genotype" in requested
+
     if method == "mahalanobis":
         figures: Dict[str, plt.Figure] = dict(
             create_mahalanobis_outlier_plots(df=df, mahal_results=results[method])
         )
-    elif method == "isolation_forest":
+    else:  # "isolation_forest" — the only other entry method, validated above.
         figures = dict(
             create_isolation_forest_plots(df=df, iso_results=results[method])
         )
-    else:
-        raise ValueError(
-            f"_select_outlier_figures: unknown method {method!r}. Supported: "
-            f"{list(_ENTRY_METHODS)}."
-        )
 
-    if genotype_col is not None and genotype_col in df.columns:
+    if genotype_requested and genotype_col is not None and genotype_col in df.columns:
         figures["outliers_per_genotype"] = create_outliers_per_genotype_plot(
             df=df, all_outlier_results=results, genotype_col=genotype_col
         )
 
-    if which is not None:
-        requested = [which] if isinstance(which, str) else list(which)
+    if requested is not None:
         missing = [key for key in requested if key not in figures]
         if missing:
+            for fig in figures.values():  # close everything before raising
+                plt.close(fig)
             raise ValueError(
-                f"plot_outlier_analysis: requested figure(s) {missing} not available "
+                f"select_outlier_figures: requested figure(s) {missing} not available "
                 f"for method {method!r}; available: {sorted(figures)}."
             )
+        for key, fig in figures.items():  # close the built-but-not-requested figures
+            if key not in requested:
+                plt.close(fig)
         figures = {key: figures[key] for key in requested}
 
     return figures
@@ -1869,7 +1890,10 @@ def plot_outlier_analysis(
     trait_cols: Optional[List[str]] = None,
     *,
     method: str = "mahalanobis",
-    random_state: int = 42,
+    barcode_col: str = "Barcode",
+    genotype_col: str = "geno",
+    replicate_col: Optional[str] = "rep",
+    random_state: Optional[int] = 42,
     which: Optional[Union[str, List[str]]] = None,
     **detect_kwargs: Any,
 ) -> Dict[str, plt.Figure]:
@@ -1892,8 +1916,8 @@ def plot_outlier_analysis(
     pipeline-only. For ``"mahalanobis"`` the figures are those of
     ``create_mahalanobis_outlier_plots`` (whose PC-projection view already covers the
     Mahalanobis PCA space); for ``"isolation_forest"``,
-    ``create_isolation_forest_plots``. For either, when a ``geno`` column is present,
-    the per-genotype figure (``create_outliers_per_genotype_plot``) is added.
+    ``create_isolation_forest_plots``. For either, when the ``genotype_col`` column is
+    present, the per-genotype figure (``create_outliers_per_genotype_plot``) is added.
 
     Preconditions (both enforced before detection, matching
     ``remove_outlier_samples``): the trait columns must be **NaN-free** and the index
@@ -1910,8 +1934,15 @@ def plot_outlier_analysis(
             :func:`~sleap_roots_analyze.data_cleanup.get_trait_columns`.
         method: ``"mahalanobis"`` (default) or ``"isolation_forest"``. An unknown
             value raises ``ValueError``.
+        barcode_col: Barcode/plant-ID column excluded from inferred traits (default
+            ``"Barcode"``). Pass the same value used with ``remove_outlier_samples`` so
+            the plotted outlier set matches the trimmed one.
+        genotype_col: Genotype column excluded from inferred traits and used for the
+            per-genotype figure when present (default ``"geno"``).
+        replicate_col: Replicate column excluded from inferred traits if present
+            (default ``"rep"``; ``None`` if absent).
         random_state: Seed forwarded to the detector for reproducibility (default
-            ``42``).
+            ``42``); ``None`` means no fixed seed.
         which: Optional figure-key string or list of keys to return; ``None``
             (default) returns the method's full available set. An unavailable key
             raises ``ValueError``.
@@ -1922,6 +1953,8 @@ def plot_outlier_analysis(
 
     Returns:
         Ordered mapping of stable figure key to :class:`matplotlib.figure.Figure`.
+        The figures are open and owned by the caller — ``plt.close(fig)`` the ones you
+        do not retain to avoid unbounded figure growth in a long-running process.
 
     Raises:
         ValueError: On empty input; duplicate column names; explicit ``trait_cols``
@@ -1968,9 +2001,15 @@ def plot_outlier_analysis(
             "plot_outlier_analysis: input index must be unique (per-sample figures "
             "index the frame by detected label). Reset the index before plotting."
         )
-    # (6) Resolve trait columns if not supplied.
+    # (6) Resolve trait columns if not supplied (same metadata-column exclusions as
+    # remove_outlier_samples, so an identical call scores an identical trait set).
     if trait_cols is None:
-        trait_cols = get_trait_columns(clean_df)
+        trait_cols = get_trait_columns(
+            clean_df,
+            barcode_col=barcode_col,
+            genotype_col=genotype_col,
+            replicate_col=replicate_col,
+        )
     if not trait_cols:
         raise ValueError(
             "plot_outlier_analysis: no trait columns found. Pass trait_cols "
@@ -2005,7 +2044,11 @@ def plot_outlier_analysis(
             f"{sorted(unknown_kwargs)}. Supported for this method: {sorted(allowed)}."
         )
     # (9) Re-detect with the same detector + seed remove_outlier_samples uses.
-    result = detector(clean_df[trait_cols], random_state=random_state, **detect_kwargs)
+    # random_state flows through a Dict[str, Any] splat so a None seed (valid at
+    # runtime — the detectors forward it to sklearn/numpy, exercised by the
+    # reproducibility sweep) does not trip the detectors' narrower ``int`` annotation.
+    detect_call: Dict[str, Any] = {"random_state": random_state, **detect_kwargs}
+    result = detector(clean_df[trait_cols], **detect_call)
     # (10) Surface a detector failure before delegating: the create_* functions
     # silently return {} on an error result, which would mask the failure.
     if "error" in result or "outlier_indices" not in result:
@@ -2013,7 +2056,8 @@ def plot_outlier_analysis(
             "plot_outlier_analysis: outlier detection failed: "
             f"{result.get('error', 'detector returned no outlier_indices')}"
         )
-    # (11) Compose the method-appropriate figures (single-method per-genotype).
-    return _select_outlier_figures(
-        clean_df, {method: result}, method, which=which, genotype_col="geno"
+    # (11) Compose the method-appropriate figures (single-method per-genotype, using
+    # the caller's genotype column rather than a hardcoded default).
+    return select_outlier_figures(
+        clean_df, {method: result}, method, which=which, genotype_col=genotype_col
     )

--- a/src/sleap_roots_analyze/outlier_visualization.py
+++ b/src/sleap_roots_analyze/outlier_visualization.py
@@ -2,16 +2,28 @@
 
 from __future__ import annotations
 
+import inspect
+
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
 import seaborn as sns
 from scipy.stats import chi2
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple, Union
 from matplotlib.patches import Patch
 from matplotlib.lines import Line2D
 from pathlib import Path
 from datetime import datetime
+
+# Imported as module-level names (not called via the ``outlier_detection`` /
+# ``data_cleanup`` module objects) so a test can monkeypatch
+# ``outlier_visualization.detect_outliers_*`` / ``create_*`` to assert the entry
+# point composes them / to exercise the detector-failure path.
+from sleap_roots_analyze.data_cleanup import get_trait_columns, validate_clean_traits
+from sleap_roots_analyze.outlier_detection import (
+    detect_outliers_isolation_forest,
+    detect_outliers_mahalanobis,
+)
 
 
 def create_isolation_forest_plots(
@@ -1774,3 +1786,234 @@ def create_outlier_method_comparison_plot(
 
     plt.tight_layout()
     return fig
+
+
+# ---------------------------------------------------------------------------
+# Public outlier-plotting entry point (#173) — composes the create_* figures.
+# ---------------------------------------------------------------------------
+
+# The two detection methods the public entry point (and remove_outlier_samples)
+# support. The standalone pca/kmeans/gmm/hierarchical plots stay pipeline-only.
+_ENTRY_METHODS = ("mahalanobis", "isolation_forest")
+
+
+def _select_outlier_figures(
+    df: pd.DataFrame,
+    results: Dict[str, Dict[str, Any]],
+    method: str,
+    which: Optional[Union[str, List[str]]] = None,
+    genotype_col: Optional[str] = None,
+) -> Dict[str, plt.Figure]:
+    """Select the method-appropriate outlier figures from pre-computed results.
+
+    The single source of truth for "which ``create_*`` figures belong to which
+    method", shared by :func:`plot_outlier_analysis` (which re-detects) and the
+    pipeline's ``VisualizeOutliersStep`` (which passes its own pre-computed
+    ``outlier_results``). It runs **no detection** — it only dispatches an existing
+    detector result to the existing figure functions.
+
+    Args:
+        df: The trait frame the figures are drawn over.
+        results: Mapping of method name to that method's detector result dict (e.g.
+            ``{"mahalanobis": <result>}`` for the entry point, or the pipeline's
+            full multi-method ``outlier_results``). ``results[method]`` is drawn.
+        method: ``"mahalanobis"`` or ``"isolation_forest"``.
+        which: Optional figure-key string or list of keys to return; ``None``
+            returns the method's full available set.
+        genotype_col: When given and present in ``df``, add the per-genotype figure
+            (``create_outliers_per_genotype_plot`` over the full ``results`` dict)
+            under the key ``"outliers_per_genotype"``. ``None`` (default) omits it —
+            the pipeline step draws its own cross-method per-genotype figure.
+
+    Returns:
+        Ordered mapping of stable figure key to :class:`matplotlib.figure.Figure`.
+
+    Raises:
+        ValueError: On an unknown ``method``, or a ``which`` key not available for
+            the given method and frame (the message names the available keys).
+    """
+    if method == "mahalanobis":
+        figures: Dict[str, plt.Figure] = dict(
+            create_mahalanobis_outlier_plots(df=df, mahal_results=results[method])
+        )
+    elif method == "isolation_forest":
+        figures = dict(
+            create_isolation_forest_plots(df=df, iso_results=results[method])
+        )
+    else:
+        raise ValueError(
+            f"_select_outlier_figures: unknown method {method!r}. Supported: "
+            f"{list(_ENTRY_METHODS)}."
+        )
+
+    if genotype_col is not None and genotype_col in df.columns:
+        figures["outliers_per_genotype"] = create_outliers_per_genotype_plot(
+            df=df, all_outlier_results=results, genotype_col=genotype_col
+        )
+
+    if which is not None:
+        requested = [which] if isinstance(which, str) else list(which)
+        missing = [key for key in requested if key not in figures]
+        if missing:
+            raise ValueError(
+                f"plot_outlier_analysis: requested figure(s) {missing} not available "
+                f"for method {method!r}; available: {sorted(figures)}."
+            )
+        figures = {key: figures[key] for key in requested}
+
+    return figures
+
+
+def plot_outlier_analysis(
+    clean_df: pd.DataFrame,
+    trait_cols: Optional[List[str]] = None,
+    *,
+    method: str = "mahalanobis",
+    random_state: int = 42,
+    which: Optional[Union[str, List[str]]] = None,
+    **detect_kwargs: Any,
+) -> Dict[str, plt.Figure]:
+    """Return the method-appropriate outlier-detection figures for a clean frame.
+
+    The plotting sibling of
+    :func:`~sleap_roots_analyze.outlier_removal.remove_outlier_samples` (#173): it
+    **re-detects** outliers with the same public detector, seed, and per-method
+    parameters — so, under the shared preconditions, it flags the same samples
+    ``remove_outlier_samples`` removes — then **composes the existing public
+    ``create_*_outlier`` figure functions** (introducing no new plotting) and returns
+    the figures. It performs **no file IO**: it returns open
+    :class:`matplotlib.figure.Figure` objects and the caller decides whether to save,
+    display, or persist them. The intended chain is ``clean_traits_for_analysis`` ->
+    (optional) ``remove_outlier_samples`` -> (optional) ``plot_outlier_analysis``.
+
+    It covers the two methods ``remove_outlier_samples`` supports — ``"mahalanobis"``
+    (default) and ``"isolation_forest"``. The standalone
+    ``detect_outliers_pca``/``_kmeans``/``_gmm``/``_hierarchical`` plots stay
+    pipeline-only. For ``"mahalanobis"`` the figures are those of
+    ``create_mahalanobis_outlier_plots`` (whose PC-projection view already covers the
+    Mahalanobis PCA space); for ``"isolation_forest"``,
+    ``create_isolation_forest_plots``. For either, when a ``geno`` column is present,
+    the per-genotype figure (``create_outliers_per_genotype_plot``) is added.
+
+    Preconditions (both enforced before detection, matching
+    ``remove_outlier_samples``): the trait columns must be **NaN-free** and the index
+    must be **unique**. The detectors run PCA that silently drops NaN rows and reports
+    indices against the post-``dropna`` frame, and the per-sample figures index the
+    frame by detected label — so a NaN-carrying or duplicate-indexed input would
+    misalign the figures and diverge from the set ``remove_outlier_samples`` (which
+    rejects such input) would remove.
+
+    Args:
+        clean_df: A clean (NaN-free in the trait columns), unique-indexed wide trait
+            table, e.g. the first element returned by ``clean_traits_for_analysis``.
+        trait_cols: Trait column names to score. If ``None``, resolved via
+            :func:`~sleap_roots_analyze.data_cleanup.get_trait_columns`.
+        method: ``"mahalanobis"`` (default) or ``"isolation_forest"``. An unknown
+            value raises ``ValueError``.
+        random_state: Seed forwarded to the detector for reproducibility (default
+            ``42``).
+        which: Optional figure-key string or list of keys to return; ``None``
+            (default) returns the method's full available set. An unavailable key
+            raises ``ValueError``.
+        **detect_kwargs: Per-method parameters forwarded to the chosen detector
+            unchanged (e.g. ``contamination`` for isolation forest;
+            ``chi2_percentile`` for Mahalanobis). Unknown or cross-method keys raise
+            ``ValueError``.
+
+    Returns:
+        Ordered mapping of stable figure key to :class:`matplotlib.figure.Figure`.
+
+    Raises:
+        ValueError: On empty input; duplicate column names; explicit ``trait_cols``
+            missing or non-numeric; an unknown ``method``; a non-unique index; NaN in
+            the trait columns (the message points to ``clean_traits_for_analysis``);
+            unknown/cross-method ``**detect_kwargs``; a ``which`` key not available for
+            the method/frame; or a detector failure (rather than an empty figure set).
+    """
+    # (1) Empty input.
+    if clean_df is None or clean_df.shape[0] == 0:
+        raise ValueError(
+            "plot_outlier_analysis: input table has no rows; nothing to plot."
+        )
+    # (2) Duplicate column names make trait selection ambiguous.
+    if clean_df.columns.duplicated().any():
+        dups = sorted(set(clean_df.columns[clean_df.columns.duplicated()]))
+        raise ValueError(
+            f"plot_outlier_analysis: duplicate column names in input: {dups}."
+        )
+    # (3) Validate explicit trait_cols up front (actionable, not a bare KeyError).
+    if trait_cols is not None:
+        missing = [c for c in trait_cols if c not in clean_df.columns]
+        if missing:
+            raise ValueError(
+                f"plot_outlier_analysis: trait_cols not found in dataframe: {missing}."
+            )
+        non_numeric = [
+            c for c in trait_cols if not pd.api.types.is_numeric_dtype(clean_df[c])
+        ]
+        if non_numeric:
+            raise ValueError(
+                "plot_outlier_analysis: trait_cols must be numeric; non-numeric "
+                f"columns passed: {non_numeric}."
+            )
+    # (4) Unknown method -> fail fast, naming the supported set.
+    if method not in _ENTRY_METHODS:
+        raise ValueError(
+            f"plot_outlier_analysis: unknown method {method!r}. Supported methods: "
+            f"{list(_ENTRY_METHODS)}."
+        )
+    # (5) Unique index -> per-sample figures index the frame by detected label.
+    if not clean_df.index.is_unique:
+        raise ValueError(
+            "plot_outlier_analysis: input index must be unique (per-sample figures "
+            "index the frame by detected label). Reset the index before plotting."
+        )
+    # (6) Resolve trait columns if not supplied.
+    if trait_cols is None:
+        trait_cols = get_trait_columns(clean_df)
+    if not trait_cols:
+        raise ValueError(
+            "plot_outlier_analysis: no trait columns found. Pass trait_cols "
+            "explicitly or check the metadata column names."
+        )
+    # (7) Clean-input precondition: trait columns must be NaN-free. Wrap the shared
+    # validator's message to add the pointer to clean_traits_for_analysis.
+    try:
+        validate_clean_traits(clean_df, trait_cols)
+    except ValueError as exc:
+        raise ValueError(
+            f"{exc} Run clean_traits_for_analysis first to produce a NaN-free, "
+            "analysis-ready frame before plot_outlier_analysis."
+        ) from exc
+    # (8) Validate detect_kwargs against the chosen detector's signature.
+    detector = (
+        detect_outliers_mahalanobis
+        if method == "mahalanobis"
+        else detect_outliers_isolation_forest
+    )
+    allowed = {
+        name
+        for name, param in inspect.signature(detector).parameters.items()
+        if name not in ("data", "random_state")
+        and param.kind
+        not in (inspect.Parameter.VAR_KEYWORD, inspect.Parameter.VAR_POSITIONAL)
+    }
+    unknown_kwargs = set(detect_kwargs) - allowed
+    if unknown_kwargs:
+        raise ValueError(
+            f"plot_outlier_analysis: unknown detect_kwargs for method {method!r}: "
+            f"{sorted(unknown_kwargs)}. Supported for this method: {sorted(allowed)}."
+        )
+    # (9) Re-detect with the same detector + seed remove_outlier_samples uses.
+    result = detector(clean_df[trait_cols], random_state=random_state, **detect_kwargs)
+    # (10) Surface a detector failure before delegating: the create_* functions
+    # silently return {} on an error result, which would mask the failure.
+    if "error" in result or "outlier_indices" not in result:
+        raise ValueError(
+            "plot_outlier_analysis: outlier detection failed: "
+            f"{result.get('error', 'detector returned no outlier_indices')}"
+        )
+    # (11) Compose the method-appropriate figures (single-method per-genotype).
+    return _select_outlier_figures(
+        clean_df, {method: result}, method, which=which, genotype_col="geno"
+    )

--- a/src/sleap_roots_analyze/pipeline/steps/visualize_outliers.py
+++ b/src/sleap_roots_analyze/pipeline/steps/visualize_outliers.py
@@ -9,12 +9,11 @@ from typing import Any, Optional
 import matplotlib.pyplot as plt
 
 from sleap_roots_analyze.outlier_visualization import (
+    _select_outlier_figures,
     create_comprehensive_outlier_comparison,
     create_gmm_outlier_plots,
     create_hierarchical_outlier_plots,
-    create_isolation_forest_plots,
     create_kmeans_outlier_plots,
-    create_mahalanobis_outlier_plots,
     create_outlier_method_comparison_plot,
     create_outlier_overlap_heatmap,
     create_outliers_per_genotype_plot,
@@ -121,7 +120,9 @@ class VisualizeOutliersStep(BaseStep):
                 files.append(fig_path)
 
             elif method == "isolation_forest":
-                figs = create_isolation_forest_plots(df=df, iso_results=result)
+                # Delegate figure selection to the shared helper (#173) using the
+                # step's own pre-computed results — no re-detection, byte-identical.
+                figs = _select_outlier_figures(df, outlier_results, method)
                 for fig_name, fig in figs.items():
                     fig_path = (
                         figures_dir
@@ -139,7 +140,9 @@ class VisualizeOutliersStep(BaseStep):
                     files.append(fig_path)
 
             elif method == "mahalanobis":
-                figs = create_mahalanobis_outlier_plots(df=df, mahal_results=result)
+                # Delegate figure selection to the shared helper (#173) using the
+                # step's own pre-computed results — no re-detection, byte-identical.
+                figs = _select_outlier_figures(df, outlier_results, method)
                 for fig_name, fig in figs.items():
                     fig_path = (
                         figures_dir

--- a/src/sleap_roots_analyze/pipeline/steps/visualize_outliers.py
+++ b/src/sleap_roots_analyze/pipeline/steps/visualize_outliers.py
@@ -9,7 +9,6 @@ from typing import Any, Optional
 import matplotlib.pyplot as plt
 
 from sleap_roots_analyze.outlier_visualization import (
-    _select_outlier_figures,
     create_comprehensive_outlier_comparison,
     create_gmm_outlier_plots,
     create_hierarchical_outlier_plots,
@@ -18,6 +17,7 @@ from sleap_roots_analyze.outlier_visualization import (
     create_outlier_overlap_heatmap,
     create_outliers_per_genotype_plot,
     create_pca_outlier_plot,
+    select_outlier_figures,
 )
 from sleap_roots_analyze.pipeline.core import BaseStep, StepResult
 
@@ -121,8 +121,9 @@ class VisualizeOutliersStep(BaseStep):
 
             elif method == "isolation_forest":
                 # Delegate figure selection to the shared helper (#173) using the
-                # step's own pre-computed results — no re-detection, byte-identical.
-                figs = _select_outlier_figures(df, outlier_results, method)
+                # step's own pre-computed results — no re-detection; same figure
+                # keys/filenames as before.
+                figs = select_outlier_figures(df, outlier_results, method)
                 for fig_name, fig in figs.items():
                     fig_path = (
                         figures_dir
@@ -141,8 +142,9 @@ class VisualizeOutliersStep(BaseStep):
 
             elif method == "mahalanobis":
                 # Delegate figure selection to the shared helper (#173) using the
-                # step's own pre-computed results — no re-detection, byte-identical.
-                figs = _select_outlier_figures(df, outlier_results, method)
+                # step's own pre-computed results — no re-detection; same figure
+                # keys/filenames as before.
+                figs = select_outlier_figures(df, outlier_results, method)
                 for fig_name, fig in figs.items():
                     fig_path = (
                         figures_dir

--- a/tests/reproducibility_cases.py
+++ b/tests/reproducibility_cases.py
@@ -39,10 +39,17 @@ N_FEATURES = 6
 # to the reason. A dict (not a bare set) so each exclusion documents *why* it is
 # safe to skip. Every key must still be a discoverable ``random_state`` function and
 # must not overlap the registry (enforced by ``test_excluded_set_is_consistent``).
-# Empty today: the approved scope covers every in-package stochastic function
-# directly — including the formerly seed-hardcoded ``calculate_mahalanobis_distances``
-# and ``detect_outliers_pca``, now caller-seedable and swept (#118).
-EXCLUDED: dict[str, str] = {}
+EXCLUDED: dict[str, str] = {
+    # Plotting composition over the already-swept ``detect_outliers_*`` detectors
+    # (#173). It exposes ``random_state`` only to thread it into those detectors and
+    # returns matplotlib Figures (not comparable by the determinism sweep); it runs
+    # no new stochastic step — figure selection/rendering is deterministic given the
+    # detected set — so its determinism is fully covered by the detector cases above.
+    "sleap_roots_analyze.outlier_visualization.plot_outlier_analysis": (
+        "Composes figures over the already-swept detect_outliers_* detectors; adds no "
+        "new stochastic step and returns Figures (not sweep-comparable)."
+    ),
+}
 
 
 @dataclass(frozen=True)

--- a/tests/test_plot_outlier_analysis.py
+++ b/tests/test_plot_outlier_analysis.py
@@ -28,7 +28,7 @@ import sleap_roots_analyze as sra  # noqa: E402
 from sleap_roots_analyze import outlier_visualization  # noqa: E402
 from sleap_roots_analyze.outlier_removal import remove_outlier_samples  # noqa: E402
 from sleap_roots_analyze.outlier_visualization import (  # noqa: E402
-    _select_outlier_figures,
+    select_outlier_figures,
     plot_outlier_analysis,
 )
 
@@ -300,7 +300,7 @@ def test_select_helper_core_only_without_genotype(clean_frame):
     from sleap_roots_analyze.outlier_detection import detect_outliers_mahalanobis
 
     result = detect_outliers_mahalanobis(clean_frame[[f"trait_{j}" for j in range(5)]])
-    figs = _select_outlier_figures(clean_frame, {"mahalanobis": result}, "mahalanobis")
+    figs = select_outlier_figures(clean_frame, {"mahalanobis": result}, "mahalanobis")
     assert MAHAL_KEYS <= set(figs)
     assert "outliers_per_genotype" not in figs
 
@@ -324,3 +324,107 @@ def test_docstring_has_google_sections():
     """Docstring has Args/Returns/Raises sections (API-docs audit bar)."""
     doc = inspect.getdoc(plot_outlier_analysis) or ""
     assert "Args:" in doc and "Returns:" in doc and "Raises:" in doc
+
+
+# ---------------------------------------------------------------------------
+# Figure lifecycle (no leaks) — pins the which-narrow close-dropped fix
+# ---------------------------------------------------------------------------
+def test_which_narrow_does_not_leak_figures(clean_frame):
+    """A which-narrowed call leaves no orphaned figures in matplotlib's registry."""
+    plt.close("all")
+    figs = plot_outlier_analysis(
+        clean_frame, method="mahalanobis", which="mahalanobis_outlier_detection"
+    )
+    assert len(figs) == 1
+    assert len(plt.get_fignums()) == len(figs)
+
+
+def test_which_missing_key_leaves_no_open_figures(clean_frame):
+    """An unavailable which key raises and closes everything it built."""
+    plt.close("all")
+    with pytest.raises(ValueError):
+        plot_outlier_analysis(clean_frame, method="mahalanobis", which=["not_a_figure"])
+    assert plt.get_fignums() == []
+
+
+# ---------------------------------------------------------------------------
+# Additional precondition/misuse edge cases
+# ---------------------------------------------------------------------------
+def test_duplicate_columns_rejected(clean_frame):
+    """Duplicate column names raise ValueError before detection."""
+    dup = clean_frame.copy()
+    cols = list(dup.columns)
+    cols[cols.index("trait_1")] = "trait_0"  # two 'trait_0' columns
+    dup.columns = cols
+    with pytest.raises(ValueError, match="duplicate"):
+        plot_outlier_analysis(dup)
+
+
+def test_non_numeric_explicit_trait_cols_rejected(clean_frame):
+    """Explicit non-numeric trait_cols raise ValueError (not a later opaque error)."""
+    with pytest.raises(ValueError, match="numeric"):
+        plot_outlier_analysis(clean_frame, trait_cols=["trait_0", "Barcode"])
+
+
+def test_all_nan_column_rejected(clean_frame):
+    """An all-NaN trait column trips the clean-input precondition."""
+    dirty = clean_frame.copy()
+    dirty["trait_0"] = np.nan
+    with pytest.raises(ValueError, match="clean_traits_for_analysis"):
+        plot_outlier_analysis(dirty)
+
+
+# ---------------------------------------------------------------------------
+# Metadata-column params (match remove_outlier_samples so the plotted set aligns)
+# ---------------------------------------------------------------------------
+def test_metadata_columns_forwarded_to_trait_resolution(clean_frame, monkeypatch):
+    """barcode/genotype/replicate cols are forwarded to get_trait_columns."""
+    captured = {}
+    real = outlier_visualization.get_trait_columns
+
+    def _spy(df, **kwargs):
+        captured.update(kwargs)
+        return real(df, **kwargs)
+
+    monkeypatch.setattr(outlier_visualization, "get_trait_columns", _spy)
+    plot_outlier_analysis(
+        clean_frame,
+        method="mahalanobis",
+        barcode_col="Barcode",
+        genotype_col="geno",
+        replicate_col="rep",
+    )
+    assert captured == {
+        "barcode_col": "Barcode",
+        "genotype_col": "geno",
+        "replicate_col": "rep",
+    }
+
+
+def test_custom_genotype_col_drives_per_genotype_figure(clean_frame):
+    """The per-genotype figure follows genotype_col, not a hardcoded 'geno'."""
+    renamed = clean_frame.rename(columns={"geno": "Genotype"})
+    with_col = plot_outlier_analysis(
+        renamed, method="mahalanobis", genotype_col="Genotype"
+    )
+    assert "outliers_per_genotype" in with_col
+    # Default genotype_col='geno' is now absent -> no per-genotype figure.
+    without_col = plot_outlier_analysis(renamed, method="mahalanobis")
+    assert "outliers_per_genotype" not in without_col
+
+
+# ---------------------------------------------------------------------------
+# Single-detection reuse: remove_outlier_samples(return_detector_result=True)
+# ---------------------------------------------------------------------------
+def test_detector_result_from_removal_feeds_selection(clean_frame):
+    """The raw detector dict from removal drives select_outlier_figures — no re-detect."""
+    trimmed, report, det = remove_outlier_samples(
+        clean_frame, method="mahalanobis", return_detector_result=True
+    )
+    assert isinstance(det, dict)
+    assert set(det["outlier_indices"]) == set(report["outlier_indices"])
+    figs = select_outlier_figures(
+        clean_frame, {"mahalanobis": det}, "mahalanobis", genotype_col="geno"
+    )
+    assert MAHAL_KEYS <= set(figs)
+    assert "outliers_per_genotype" in figs

--- a/tests/test_plot_outlier_analysis.py
+++ b/tests/test_plot_outlier_analysis.py
@@ -1,0 +1,326 @@
+"""Tests for the public outlier-plotting entry point ``plot_outlier_analysis``.
+
+Covers the composition over the existing ``create_*_outlier`` figure functions, the
+method-appropriate figure set (mahalanobis / isolation_forest only), ``which``
+selection, deterministic re-detection matching ``remove_outlier_samples``, the
+clean-input + unique-index preconditions, detector-failure surfacing, IO-freeness,
+and the public API surface. See OpenSpec change ``add-outlier-plotting-entry-point``
+(issue #173).
+
+The fixture mirrors ``tests/test_remove_outlier_samples.py`` so the default
+Mahalanobis re-detection flags exactly the injected indices.
+"""
+
+from __future__ import annotations
+
+import inspect
+import typing
+
+import matplotlib
+
+matplotlib.use("Agg")  # headless; no display needed for figure objects
+import matplotlib.pyplot as plt  # noqa: E402
+import numpy as np  # noqa: E402
+import pandas as pd  # noqa: E402
+import pytest  # noqa: E402
+
+import sleap_roots_analyze as sra  # noqa: E402
+from sleap_roots_analyze import outlier_visualization  # noqa: E402
+from sleap_roots_analyze.outlier_removal import remove_outlier_samples  # noqa: E402
+from sleap_roots_analyze.outlier_visualization import (  # noqa: E402
+    _select_outlier_figures,
+    plot_outlier_analysis,
+)
+
+INJECTED = [5, 17, 28]
+MAHAL_KEYS = {
+    "mahalanobis_outlier_detection",
+    "mahalanobis_pc_analysis",
+    "mahalanobis_threshold_analysis",
+}
+
+
+def _build_outlier_frame(n=40, n_traits=5, inject=(5, 17, 28), sd=8.0, seed=42):
+    """Clean (NaN-free) trait frame with injected outlier rows (mirrors #165)."""
+    rng = np.random.RandomState(seed)
+    df = pd.DataFrame({f"trait_{j}": rng.randn(n) for j in range(n_traits)})
+    for idx in inject:
+        for j in range(3):
+            df.loc[idx, f"trait_{j}"] += sd
+    df.insert(0, "Barcode", [f"BC{i:03d}" for i in range(n)])
+    df.insert(1, "geno", ["G1"] * (n // 2) + ["G2"] * (n - n // 2))
+    df.insert(2, "rep", list(range(1, n // 2 + 1)) * 2)
+    return df
+
+
+@pytest.fixture
+def clean_frame():
+    """Canonical 40-sample frame; default Mahalanobis flags exactly INJECTED."""
+    return _build_outlier_frame()
+
+
+@pytest.fixture(autouse=True)
+def _close_figs():
+    """Close any figures a test leaves open (tests own the returned figures)."""
+    yield
+    plt.close("all")
+
+
+# ---------------------------------------------------------------------------
+# Return shape / composition
+# ---------------------------------------------------------------------------
+def test_returns_dict_of_figures(clean_frame):
+    """Returns a dict of matplotlib Figures; writes no files."""
+    figs = plot_outlier_analysis(clean_frame)
+    assert isinstance(figs, dict)
+    assert figs, "expected a non-empty figure set"
+    assert all(isinstance(f, plt.Figure) for f in figs.values())
+
+
+def test_delegates_to_public_figure_function(clean_frame, monkeypatch):
+    """The composer invokes the public create_* function, not its own drawing."""
+    called = {}
+
+    def _spy(df, mahal_results):
+        called["hit"] = True
+        return {"mahalanobis_outlier_detection": plt.figure()}
+
+    monkeypatch.setattr(outlier_visualization, "create_mahalanobis_outlier_plots", _spy)
+    plot_outlier_analysis(clean_frame, method="mahalanobis", which=None)
+    assert called.get("hit") is True
+
+
+# ---------------------------------------------------------------------------
+# Method-appropriate figure set
+# ---------------------------------------------------------------------------
+def test_mahalanobis_figure_set(clean_frame):
+    """Mahalanobis returns its figures + per-genotype; no pca_outlier figure."""
+    figs = plot_outlier_analysis(clean_frame, method="mahalanobis")
+    assert MAHAL_KEYS <= set(figs)
+    assert "outliers_per_genotype" in figs
+    assert "pca_outlier" not in figs
+    assert "isolation_forest_analysis" not in figs
+
+
+def test_isolation_forest_figure_set(clean_frame):
+    """Isolation forest returns its figure + per-genotype; no mahalanobis keys."""
+    figs = plot_outlier_analysis(clean_frame, method="isolation_forest")
+    assert "isolation_forest_analysis" in figs
+    assert "outliers_per_genotype" in figs
+    assert not (MAHAL_KEYS & set(figs))
+
+
+def test_genotype_figure_only_when_column_present(clean_frame):
+    """The per-genotype figure is present only when a genotype column exists."""
+    no_geno = clean_frame.drop(columns=["geno"])
+    figs = plot_outlier_analysis(no_geno, method="mahalanobis")
+    assert "outliers_per_genotype" not in figs
+    assert MAHAL_KEYS <= set(figs)
+
+
+# ---------------------------------------------------------------------------
+# which selection
+# ---------------------------------------------------------------------------
+def test_which_list_narrows(clean_frame):
+    """A which list returns exactly those keys."""
+    figs = plot_outlier_analysis(
+        clean_frame, method="mahalanobis", which=["mahalanobis_outlier_detection"]
+    )
+    assert set(figs) == {"mahalanobis_outlier_detection"}
+
+
+def test_which_accepts_single_string(clean_frame):
+    """A bare string which returns exactly that one figure (not iterated by char)."""
+    figs = plot_outlier_analysis(
+        clean_frame, method="mahalanobis", which="mahalanobis_pc_analysis"
+    )
+    assert set(figs) == {"mahalanobis_pc_analysis"}
+
+
+def test_which_none_returns_full_set(clean_frame):
+    """which=None returns the method's full available set."""
+    figs = plot_outlier_analysis(clean_frame, method="mahalanobis", which=None)
+    assert MAHAL_KEYS <= set(figs)
+    assert "outliers_per_genotype" in figs
+
+
+def test_which_unavailable_key_raises(clean_frame):
+    """An unavailable which key raises ValueError naming the available keys."""
+    with pytest.raises(ValueError, match="mahalanobis_outlier_detection"):
+        plot_outlier_analysis(clean_frame, method="mahalanobis", which=["not_a_figure"])
+
+
+def test_which_genotype_key_rejected_without_column(clean_frame):
+    """Requesting the per-genotype key without a genotype column raises."""
+    no_geno = clean_frame.drop(columns=["geno"])
+    with pytest.raises(ValueError):
+        plot_outlier_analysis(
+            no_geno, method="mahalanobis", which=["outliers_per_genotype"]
+        )
+
+
+# ---------------------------------------------------------------------------
+# Deterministic re-detection matching removal
+# ---------------------------------------------------------------------------
+def test_redetection_matches_removal_mahalanobis(clean_frame):
+    """Re-detected set equals what remove_outlier_samples removes (mahalanobis)."""
+    _, report = remove_outlier_samples(clean_frame, method="mahalanobis")
+    captured = {}
+
+    def _spy(df, mahal_results):
+        captured["indices"] = list(mahal_results.get("outlier_indices", []))
+        return {"mahalanobis_outlier_detection": plt.figure()}
+
+    # Wrap to capture the detector result the composer feeds the figure function.
+    import functools
+
+    real = outlier_visualization.create_mahalanobis_outlier_plots
+
+    @functools.wraps(real)
+    def _wrap(df, mahal_results):
+        _spy(df, mahal_results)
+        return real(df=df, mahal_results=mahal_results)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(outlier_visualization, "create_mahalanobis_outlier_plots", _wrap)
+        plot_outlier_analysis(clean_frame, method="mahalanobis")
+    assert sorted(captured["indices"]) == sorted(report["outlier_indices"])
+
+
+def test_redetection_matches_removal_isolation_forest(clean_frame):
+    """Re-detected set equals removal's for the seed-load-bearing IF path."""
+    _, report = remove_outlier_samples(
+        clean_frame, method="isolation_forest", random_state=7
+    )
+    captured = {}
+    import functools
+
+    real = outlier_visualization.create_isolation_forest_plots
+
+    @functools.wraps(real)
+    def _wrap(df, iso_results):
+        captured["indices"] = list(iso_results.get("outlier_indices", []))
+        return real(df=df, iso_results=iso_results)
+
+    with pytest.MonkeyPatch.context() as mp:
+        mp.setattr(outlier_visualization, "create_isolation_forest_plots", _wrap)
+        plot_outlier_analysis(clean_frame, method="isolation_forest", random_state=7)
+    assert sorted(captured["indices"]) == sorted(report["outlier_indices"])
+
+
+def test_accepts_random_state_none(clean_frame):
+    """random_state=None is accepted without raising."""
+    figs = plot_outlier_analysis(clean_frame, random_state=None)
+    assert isinstance(figs, dict) and figs
+
+
+# ---------------------------------------------------------------------------
+# Preconditions / misuse
+# ---------------------------------------------------------------------------
+def test_nan_input_rejected_pointing_to_cleaner(clean_frame):
+    """NaN in traits raises ValueError mentioning clean_traits_for_analysis."""
+    dirty = clean_frame.copy()
+    dirty.loc[0, "trait_0"] = np.nan
+    with pytest.raises(ValueError, match="clean_traits_for_analysis"):
+        plot_outlier_analysis(dirty)
+
+
+def test_non_unique_index_rejected(clean_frame):
+    """A duplicate index raises ValueError before detection."""
+    dup = clean_frame.copy()
+    dup.index = [0] * len(dup)
+    with pytest.raises(ValueError, match="unique"):
+        plot_outlier_analysis(dup)
+
+
+def test_empty_input_rejected(clean_frame):
+    """An empty frame raises ValueError."""
+    with pytest.raises(ValueError):
+        plot_outlier_analysis(clean_frame.iloc[0:0])
+
+
+def test_unknown_method_rejected(clean_frame):
+    """An unknown method raises ValueError naming the supported methods."""
+    with pytest.raises(ValueError, match="mahalanobis"):
+        plot_outlier_analysis(clean_frame, method="not_a_method")
+
+
+def test_unknown_detect_kwarg_rejected(clean_frame):
+    """A cross-method detect_kwarg raises before detection."""
+    with pytest.raises(ValueError):
+        plot_outlier_analysis(clean_frame, method="mahalanobis", contamination=0.2)
+
+
+def test_missing_trait_cols_rejected(clean_frame):
+    """Explicit trait_cols not in the frame raise ValueError (not KeyError)."""
+    with pytest.raises(ValueError):
+        plot_outlier_analysis(clean_frame, trait_cols=["trait_0", "nope"])
+
+
+# ---------------------------------------------------------------------------
+# Detector-failure surfacing
+# ---------------------------------------------------------------------------
+def test_detector_error_raised_before_delegation(clean_frame, monkeypatch):
+    """A detector error raises before any create_* figure function is called."""
+    figure_called = {"hit": False}
+
+    def _boom_detect(*args, **kwargs):
+        return {"error": "degenerate PCA"}
+
+    def _mark(*args, **kwargs):
+        figure_called["hit"] = True
+        return {}
+
+    monkeypatch.setattr(
+        outlier_visualization, "detect_outliers_mahalanobis", _boom_detect
+    )
+    monkeypatch.setattr(
+        outlier_visualization, "create_mahalanobis_outlier_plots", _mark
+    )
+    with pytest.raises(ValueError, match="degenerate PCA"):
+        plot_outlier_analysis(clean_frame, method="mahalanobis")
+    assert figure_called["hit"] is False
+
+
+# ---------------------------------------------------------------------------
+# IO-freeness
+# ---------------------------------------------------------------------------
+def test_no_files_written(clean_frame, tmp_path, monkeypatch):
+    """The call writes no image files."""
+    monkeypatch.chdir(tmp_path)
+    plot_outlier_analysis(clean_frame)
+    assert not list(tmp_path.rglob("*.png"))
+
+
+# ---------------------------------------------------------------------------
+# Lower-level helper
+# ---------------------------------------------------------------------------
+def test_select_helper_core_only_without_genotype(clean_frame):
+    """The helper returns only core figures when genotype_col is not given."""
+    from sleap_roots_analyze.outlier_detection import detect_outliers_mahalanobis
+
+    result = detect_outliers_mahalanobis(clean_frame[[f"trait_{j}" for j in range(5)]])
+    figs = _select_outlier_figures(clean_frame, {"mahalanobis": result}, "mahalanobis")
+    assert MAHAL_KEYS <= set(figs)
+    assert "outliers_per_genotype" not in figs
+
+
+# ---------------------------------------------------------------------------
+# Public API surface
+# ---------------------------------------------------------------------------
+def test_importable_and_in_all():
+    """Importable from the package root and listed once in __all__."""
+    assert sra.plot_outlier_analysis is plot_outlier_analysis
+    assert "plot_outlier_analysis" in sra.__all__
+    assert sra.__all__.count("plot_outlier_analysis") == 1
+
+
+def test_type_hints_resolve():
+    """get_type_hints resolves (no NameError from **detect_kwargs: Any)."""
+    typing.get_type_hints(plot_outlier_analysis)
+
+
+def test_docstring_has_google_sections():
+    """Docstring has Args/Returns/Raises sections (API-docs audit bar)."""
+    doc = inspect.getdoc(plot_outlier_analysis) or ""
+    assert "Args:" in doc and "Returns:" in doc and "Raises:" in doc

--- a/tests/test_remove_outlier_samples.py
+++ b/tests/test_remove_outlier_samples.py
@@ -109,6 +109,22 @@ def test_default_mahalanobis_flags_exact_injected(clean_frame):
     assert not set(INJECTED) & set(trimmed.index)
 
 
+def test_return_detector_result_flag(clean_frame):
+    """return_detector_result=True adds the raw detector dict as a 3rd element."""
+    # Default contract: a 2-tuple with a compact report (no per-sample arrays).
+    two = remove_outlier_samples(clean_frame)
+    assert len(two) == 2
+    assert "mahalanobis_distances" not in two[1]
+
+    trimmed, report, detector_result = remove_outlier_samples(
+        clean_frame, return_detector_result=True
+    )
+    assert isinstance(detector_result, dict)
+    # The raw dict carries the per-sample arrays the compact report omits.
+    assert "mahalanobis_distances" in detector_result
+    assert set(detector_result["outlier_indices"]) == set(report["outlier_indices"])
+
+
 def test_isolation_forest_is_superset_not_exact(clean_frame):
     """Isolation forest (a contamination quota) flags at least the injected rows."""
     _, report = remove_outlier_samples(clean_frame, method="isolation_forest")

--- a/tests/test_step_visualize_outliers.py
+++ b/tests/test_step_visualize_outliers.py
@@ -227,3 +227,107 @@ class TestOutlierMethodComparisonBarChart:
             "Should NOT generate outlier_method_comparison when only 1 method run. "
             "Comparison chart only makes sense with 2+ methods."
         )
+
+
+class TestSharedSelectionRefactorUnchanged:
+    """Guard the #173 single-source refactor: the step's mahalanobis /
+    isolation_forest figures (now selected via the shared ``_select_outlier_figures``
+    helper on the step's own pre-computed results) are byte-identical to calling the
+    ``create_*`` functions directly, and the cross-method comparison + per-genotype
+    figures are unchanged.
+    """
+
+    TRAITS = [f"trait_{j}" for j in range(5)]
+
+    @pytest.fixture
+    def outlier_frame(self):
+        """40-sample, 5-trait clean frame with injected outliers and a geno column."""
+        rng = np.random.RandomState(42)
+        df = pd.DataFrame({f"trait_{j}": rng.randn(40) for j in range(5)})
+        for idx in (5, 17, 28):
+            for j in range(3):
+                df.loc[idx, f"trait_{j}"] += 8.0
+        df.insert(0, "Barcode", [f"BC{i:03d}" for i in range(40)])
+        df.insert(1, "geno", ["G1"] * 20 + ["G2"] * 20)
+        df.insert(2, "rep", list(range(1, 21)) * 2)
+        return df
+
+    def _prev_result(self, df):
+        from sleap_roots_analyze.outlier_detection import (
+            detect_outliers_isolation_forest,
+            detect_outliers_mahalanobis,
+        )
+
+        results = {
+            "mahalanobis": detect_outliers_mahalanobis(df[self.TRAITS]),
+            "isolation_forest": detect_outliers_isolation_forest(
+                df[self.TRAITS], random_state=42
+            ),
+        }
+        return (
+            StepResult(
+                data=df,
+                metadata={
+                    "valid_trait_names": self.TRAITS,
+                    "methods_run": ["mahalanobis", "isolation_forest"],
+                    "outlier_results": results,
+                    "samples": len(df),
+                    "column_mapping": {"genotype": "geno"},
+                },
+                files_generated=[],
+            ),
+            results,
+        )
+
+    def test_step_figures_match_direct_create_calls(
+        self, outlier_frame, config, tmp_path
+    ):
+        """Step mahal/IF filenames == the create_* keys, prefixed as before."""
+        from sleap_roots_analyze.outlier_visualization import (
+            create_isolation_forest_plots,
+            create_mahalanobis_outlier_plots,
+        )
+
+        prev_result, results = self._prev_result(outlier_frame)
+
+        expected_mahal = {
+            f"outliers_mahal_{k}"
+            for k in create_mahalanobis_outlier_plots(
+                df=outlier_frame, mahal_results=results["mahalanobis"]
+            )
+        }
+        expected_if = {
+            f"outliers_if_{k}"
+            for k in create_isolation_forest_plots(
+                df=outlier_frame, iso_results=results["isolation_forest"]
+            )
+        }
+        plt.close("all")
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = VisualizeOutliersStep().execute(
+                outlier_frame, config, tmp_path, prev_result
+            )
+
+        stems = {f.stem for f in result.files_generated}
+        # The mahalanobis / isolation_forest figures are exactly the create_* keys.
+        assert expected_mahal, "fixture should produce mahalanobis figures"
+        assert expected_mahal <= stems
+        assert expected_if <= stems
+        # Cross-method comparison figures (>1 method) and per-genotype are unchanged.
+        assert "outlier_comparison" in stems
+        assert "outlier_overlap_heatmap" in stems
+        assert "outlier_method_comparison" in stems
+        assert "outliers_per_genotype" in stems
+
+    def test_per_genotype_stays_cross_method(self, outlier_frame, config, tmp_path):
+        """Exactly one cross-method per-genotype figure (not one per method)."""
+        prev_result, _ = self._prev_result(outlier_frame)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            result = VisualizeOutliersStep().execute(
+                outlier_frame, config, tmp_path, prev_result
+            )
+        per_geno = [f for f in result.files_generated if "per_genotype" in f.name]
+        assert len(per_geno) == 1

--- a/tests/test_step_visualize_outliers.py
+++ b/tests/test_step_visualize_outliers.py
@@ -231,10 +231,10 @@ class TestOutlierMethodComparisonBarChart:
 
 class TestSharedSelectionRefactorUnchanged:
     """Guard the #173 single-source refactor: the step's mahalanobis /
-    isolation_forest figures (now selected via the shared ``_select_outlier_figures``
-    helper on the step's own pre-computed results) are byte-identical to calling the
-    ``create_*`` functions directly, and the cross-method comparison + per-genotype
-    figures are unchanged.
+    isolation_forest figures (now selected via the shared ``select_outlier_figures``
+    helper on the step's own pre-computed results) have the same figure keys /
+    filenames as calling the ``create_*`` functions directly, and the cross-method
+    comparison + per-genotype figures are unchanged.
     """
 
     TRAITS = [f"trait_{j}" for j in range(5)]


### PR DESCRIPTION
## Summary

Adds **`plot_outlier_analysis`**, the public IO-free **plotting** sibling of
`remove_outlier_samples` (#165) — the immediate consumer is the bloom-mcp `remove_outliers`
tool's optional `include_plots`. Follow-up to #165, which explicitly deferred plots. Rides
`0.1.0a4` (#174) alongside #165.

Closes #173.

## What it adds

- **`plot_outlier_analysis(clean_df, trait_cols=None, *, method="mahalanobis", random_state=42, which=None, **detect_kwargs) -> Dict[str, plt.Figure]`**
  — re-detects outliers deterministically (same detector/seed/params → the same set
  `remove_outlier_samples` removes), then composes the existing public `create_*_outlier` figure
  functions. **IO-free**: returns open `Figure`s; the caller saves/persists. Covers `mahalanobis`
  + `isolation_forest`; `which` (a key or list) narrows the returned figures.
- **`_select_outlier_figures(df, results, method, which=None, genotype_col=None)`** — the shared
  per-method figure-selection, the single source of truth used by both the entry point and the
  pipeline step.

## Ratified design decisions (updated #173)

- **B1** — `create_pca_outlier_plot` (and the pca/kmeans/gmm/hierarchical plots) stay
  **pipeline-only**. The original #173 mapping fed a *Mahalanobis* result into
  `create_pca_outlier_plot`, which reads `detect_outliers_pca` reconstruction keys
  (`cumulative_variance`/`reconstruction_errors`) → `KeyError`/blank figure; the Mahalanobis
  PC-projection view is already drawn by `create_mahalanobis_outlier_plots`
  (`mahalanobis_pc_analysis`).
- **D3** — `VisualizeOutliersStep` delegates figure selection to `_select_outlier_figures` on its
  **own pre-computed** `outlier_results` (no re-detection), preserving the pipeline's configured
  detector params. Its rendered output — figures, filenames, count — is **unchanged**.

## Preconditions & safety

NaN-free + unique-index preconditions (matching `remove_outlier_samples`, so the "figures match the
trimmed table" guarantee is sound and the per-genotype indexing is aligned); detector failures
surfaced *before* delegating (the `create_*` functions silently return `{}` on error input);
unknown/cross-method `detect_kwargs` and unavailable `which` keys rejected fail-fast.

## Testing / verification

- New `tests/test_plot_outlier_analysis.py` + a step-refactor filename regression in
  `tests/test_step_visualize_outliers.py` (realistic detector output; asserts the step's mahal/IF
  figures equal the `create_*` keys and one cross-method per-genotype figure).
- **173 passed** across the affected suites; determinism-matches-removal verified for both methods.
- `mypy` baseline `new: 0`; `ruff` / `black` / public-API-docs audit clean; `openspec validate
  --strict` valid.
- Reproducibility: `plot_outlier_analysis` registered in `EXCLUDED` (returns Figures the sweep
  can't compare; adds no new stochastic step over the already-swept `detect_outliers_*`).

## Docs

New `outlier_visualization` section in `docs/API.md` (+ backfilled the composed
`create_mahalanobis_outlier_plots` / `create_isolation_forest_plots` /
`create_outliers_per_genotype_plot` entries the new function references); `docs/CHANGELOG.md`
`[Unreleased]` entry.

## OpenSpec

`add-outlier-plotting-entry-point` — capabilities **`outlier-visualization`** (new) +
**`visualization-pipeline`** (transparent step-refactor delta). Went through a 5-agent adversarial
`/review-openspec` before implementation; B1/D3 ratified in the updated #173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
