### PR TITLE
Release v0.1.0a4

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0a4] - 2026-07-02 (Pre-release)
+
 ### Added
 - Public outlier-plotting entry point `plot_outlier_analysis` (#173): the
   **plotting** sibling of `remove_outlier_samples`. Importable from

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sleap-roots-analyze"
-version = "0.1.0a3"
+version = "0.1.0a4"
 description = "Analyze, visualize, and interpret root traits output from sleap-roots."
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -2133,7 +2133,7 @@ wheels = [
 
 [[package]]
 name = "sleap-roots-analyze"
-version = "0.1.0a3"
+version = "0.1.0a4"
 source = { editable = "." }
 dependencies = [
     { name = "adjusttext" },


### PR DESCRIPTION
## Release v0.1.0a4

Cuts `0.1.0a4` from current `main`. Implements #174. Bundles the outlier-removal + outlier-plotting entry points and the canonical cleanup-defaults fix — all a4 items are already merged on `main` (#172, #171, #175), so this is the issue's **recommended** bundle (plots included, not deferred to a5).

### Diff vs `main` (minimal)
- `pyproject.toml` + `uv.lock`: `0.1.0a3` → `0.1.0a4` (`__init__` is dynamic via `importlib.metadata`).
- `docs/CHANGELOG.md`: new `## [0.1.0a4] - 2026-07-02 (Pre-release)` section (moved from `[Unreleased]`, which is now empty).

### What's in this cut (already on `main`)
- **`remove_outlier_samples`** — public outlier-removal entry point (#165, PR #172).
- **`plot_outlier_analysis`** + `select_outlier_figures` + additive `remove_outlier_samples(return_detector_result=...)` — public outlier-plotting entry point (#173, PR #175).
- **Canonical cleanup-defaults fix** — `apply_data_cleanup_filters` bare defaults aligned to `CleanupConfig()` (#167, PR #171).
- (chore: OpenSpec archive — PR #170.)

### Pre-release validation (local)
- [x] `uv build` → wheel + sdist built as `0.1.0a4`
- [x] Isolated wheel smoke test: `__version__ == 0.1.0a4`; `remove_outlier_samples` / `plot_outlier_analysis` / `select_outlier_figures` import; CLI `--help` works
- [x] `tests/test_public_api.py`: 62 passed (release-safe changelog test green)
- [ ] Full matrix test suite — verified by this PR's CI

### Post-merge
1. Create GitHub release `v0.1.0a4` (`--prerelease`) → triggers `build.yml` trusted-publish to PyPI.
2. Verify `0.1.0a4` on PyPI; clean-env install + import check.

### Unblocks
- bloom-mcp pin bump to `sleap-roots-analyze>=0.1.0a4` + re-lock (mirror #327) → the `remove_outliers` tool (bloom#378) with optional `include_plots`, and dropping the `qc_clean` `_QC_DEFAULTS` temp override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
