### PR TITLE
fix(#183): re-derive clustering feature_names from filtered columns

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already removed earlier by the zero-inflation filter, so only constant-nonzero traits are
   affected.)
 
+### Fixed
+- `perform_kmeans_clustering`, `perform_gmm_clustering`, and
+  `perform_hierarchical_clustering` (`clustering.py`) now re-derive `feature_names` from
+  the columns actually used for fitting, on both `standardize=True` and
+  `standardize=False` (#183). Previously `feature_names` was snapshotted **before**
+  constant/non-numeric columns were filtered out, silently mislabeling
+  `cluster_centers`/`means`/`data_processed` for such inputs — not a length mismatch a
+  caller would notice, a positional mislabeling. `standardize=False` additionally now
+  applies the same numeric + non-zero-variance filter `standardize=True` always used
+  internally; previously it applied no filtering at all, so a non-numeric column reached
+  the estimator directly and failed with a raw sklearn "could not convert string to float"
+  error instead of the clear "No numeric columns with non-zero variance found" message.
+  This is separate from the `#177` cleanup change above: `#177` keeps constant traits from
+  ever reaching these functions through the standard cleanup step; `#183` fixes the
+  functions' own label bookkeeping for any caller that doesn't go through it — e.g. direct
+  callers, or `standardize=False`. `KMeansResult`/`GMMResult` and
+  `detect_outliers_kmeans`/`_gmm`/`_hierarchical` (`outlier_detection.py`) inherit the
+  corrected values automatically, with no adapter code changes needed.
+
 ## [0.1.0a4] - 2026-07-02 (Pre-release)
 
 ### Added

--- a/openspec/changes/fix-clustering-feature-names-mismatch/proposal.md
+++ b/openspec/changes/fix-clustering-feature-names-mismatch/proposal.md
@@ -1,0 +1,145 @@
+## Why
+
+`perform_kmeans_clustering`, `perform_gmm_clustering`, and
+`perform_hierarchical_clustering` (all in `clustering.py`) each snapshot
+`feature_names = df_clean.columns.tolist()` **before** calling
+`standardize_data`, then return that snapshot unchanged even when
+`standardize_data` goes on to drop non-numeric and exact-zero-variance
+columns (`pca.py:624-654`). The result is a silent **positional**
+misalignment between `feature_names` and every feature-indexed array in the
+same return dict (`cluster_centers`, `means`, `data_processed`) — not a
+length mismatch a caller would notice, a mislabeling. All three producers
+discard `standardize_data`'s filtered `df_clean` via `_` (e.g.
+`X_processed, scaler, _ = standardize_data(df_clean)`), so nothing in the
+`standardize=True` branch ever re-derives names from what was actually
+clustered. The `standardize=False` branch is worse: it does no filtering at
+all (`X_processed = df_clean.values`), so a non-numeric column reaches
+`KMeans.fit()` / `GaussianMixture.fit()` / `linkage()` directly and either
+mislabels `feature_names` (constant column) or fails with sklearn's own
+`could not convert string to float` error (non-numeric column) instead of
+the clearer "No numeric columns with non-zero variance found" message the
+`standardize=True` path already gives for the equivalent all-filtered case.
+(Verified empirically: both cases are already wrapped in a method-specific
+`RuntimeError` by these producers' existing broad `except Exception`
+handlers — this is not an uncontrolled crash today, just a confusing
+message and, independently, a `feature_names` mismatch whenever at least
+one valid column survives.)
+
+This is the same bug class already fixed for PCA in #74/#76:
+`perform_pca_analysis` (`pca.py:793-812`) re-derives `feature_names` from the
+post-filter `df_clean` on the `standardize=True` path, and manually re-applies
+the same numeric + zero-variance filter to derive `feature_names` on the
+`standardize=False` path. The clustering producers never got either half of
+that fix.
+
+`KMeansResult` and `GMMResult` both carry `feature_names` as a base
+`ClusterResult` field (`result_types.py:421`), so the mismatch propagates
+through the typed, JSON-serialized public API too. `src/sleap_roots_analyze
+/outlier_detection.py`'s `detect_outliers_kmeans`, `detect_outliers_gmm`,
+and `detect_outliers_hierarchical` each `return {**cluster_result, ...}` /
+`{**hier_result, ...}`, re-exporting the same buggy `feature_names`
+verbatim into their own public return dict — including through the QC
+pipeline's `DetectOutliersStep` (`pipeline/steps/detect_outliers.py`), which
+calls all three directly.
+
+GitHub Issue: #183
+
+**Sequencing note re: #179/PR #182.** Issue #183 also flags that the new
+`hierarchical_cluster_labels` entry point and `HierarchicalResult` dataclass
+(#179, PR #182) will inherit this same bug. As of this proposal, **PR #182 is
+still open** (not merged to `main`) — `HierarchicalResult`,
+`from_hierarchical_dict`, and `hierarchical_cluster_labels` do not exist on
+`main` or on this proposal's branch. This proposal fixes `clustering.py`'s
+three producers directly, which is independent of PR #182 and unblocks
+nothing that depends on it. Whichever of #182/#183 merges second SHALL add a
+short regression test confirming `HierarchicalResult.feature_names` reflects
+the corrected values (no code change is needed there, since the adapter
+passes `feature_names` through verbatim) — tracked as a small follow-up, not
+a blocker for either PR.
+
+## What Changes
+
+- Port the `perform_pca_analysis` pattern (`pca.py:793-812`) to all three
+  clustering producers, fixing **both** branches:
+  - `standardize=True`: use the `df_clean` that `standardize_data` actually
+    returns (currently discarded as `_`) and re-derive
+    `feature_names = df_clean.columns.tolist()` from it, after filtering.
+  - `standardize=False`: apply the same numeric-only + non-zero-variance
+    filter `standardize_data` uses internally (`select_dtypes` +
+    `var(ddof=0) > 0`) before deriving `feature_names` and `X_processed`,
+    instead of passing `df_clean.values` through unfiltered. Raise
+    `ValueError("No numeric columns with non-zero variance found")` when
+    nothing survives, matching `standardize_data`'s own guard — this stays
+    inside the existing `try`/`except Exception as e: raise RuntimeError(...)`
+    block (unchanged), so the effective result is the same `RuntimeError`
+    the `standardize=True` path already raises for the identical condition
+    today, not a new/different exception type for only one branch.
+- No change needed in `ClusterResult.from_kmeans_dict` / `from_gmm_dict`, or
+  the `KMeansResult` / `GMMResult` dataclasses — they pass `feature_names`
+  through verbatim, so they inherit the corrected values automatically once
+  the three producers are fixed. Same applies transitively to
+  `outlier_detection.py`'s `detect_outliers_kmeans` / `detect_outliers_gmm` /
+  `detect_outliers_hierarchical`, which dict-spread the producer output.
+- Add regression coverage in `tests/test_outlier_detection.py` confirming
+  `detect_outliers_kmeans` / `_gmm` / `_hierarchical` surface the corrected
+  `feature_names`, since these three currently have no `feature_names`
+  coverage at all and would otherwise silently carry the bug forward
+  undetected.
+
+## Impact
+
+- Affected specs: `serializable-result-types` — new requirements covering
+  clustering `feature_names` accuracy and the fully-filtered error path, plus
+  a clarifying scenario added to the existing "Non-Breaking Clustering
+  Return Shapes" requirement (dict keys are unchanged; only previously-wrong
+  `feature_names` values are corrected).
+- Affected code:
+  - `src/sleap_roots_analyze/clustering.py` — `perform_kmeans_clustering`
+    (~L104-111), `perform_gmm_clustering` (~L355-362),
+    `perform_hierarchical_clustering` (~L572-579)
+  - `src/sleap_roots_analyze/outlier_detection.py` — no code change expected
+    (`detect_outliers_kmeans`/`_gmm`/`_hierarchical` inherit the fix via
+    dict-spread), but needs new regression tests
+  - `tests/fixtures.py` — reuse `pca_constant_feature_data`
+    (`tests/fixtures.py:1046`); add a new fixture mixing a constant numeric
+    column and a non-numeric (string ID) column in the same frame
+  - `tests/test_clustering.py` — parametrized `feature_names`/array-length
+    and named-value regression tests across the three producers, for both
+    `standardize` values
+  - `tests/test_cluster_result.py` — extend `KMeansResult`/`GMMResult`
+    adapter coverage so `feature_names` is checked against
+    `cluster_centers.shape[1]` / `means.shape[1]` on filtered input
+  - `tests/test_outlier_detection.py` — new coverage for
+    `detect_outliers_kmeans`/`_gmm`/`_hierarchical` per above
+  - `tests/test_step_detect_outliers.py` — guardrail confirming the QC
+    pipeline's `DetectOutliersStep` still sees `feature_names` matching the
+    cleanup step's surviving trait list (protected today by #177's cleanup
+    filter; confirms no regression once this fix lands)
+  - `docs/CHANGELOG.md` `[Unreleased]` — new `### Fixed` entry, explicitly
+    distinguished from the existing #177 `### Changed` entry (see note below)
+- No breaking changes: dict keys, shapes for already-clean input, and typed
+  adapter signatures are all unchanged. Only `feature_names` values for
+  inputs with constant/non-numeric columns (previously wrong) and
+  `standardize=False` + non-numeric-column failures (previously a confusing
+  `RuntimeError: ... could not convert string to float`, now either a
+  successful cluster over the surviving numeric columns or the same clean
+  `RuntimeError: ... No numeric columns with non-zero variance found` the
+  `standardize=True` path already raises) are corrected.
+- Explicitly out of scope: no new `excluded_features`-style key is added to
+  the return dicts (`perform_pca_analysis`, the precedent this ports from,
+  doesn't carry one either — see `pca.py:840-844`); pipeline metadata
+  propagation (#80) and the QC cleanup filter (#177) are untouched, since
+  neither is part of `clustering.py`'s producer-internal contract;
+  `HierarchicalResult`/`hierarchical_cluster_labels` (#179/PR #182, still
+  open) per the sequencing note above.
+- **Documentation note:** `docs/CHANGELOG.md`'s existing `[Unreleased]` #177
+  entry says "PCA / UMAP / clustering results are unchanged (those paths
+  already dropped constants before fitting)." That claim is true of the
+  *fitted array values* (already filtered correctly) but not of the
+  `feature_names` *labels* this proposal fixes — the new CHANGELOG entry
+  must explicitly disambiguate from that line so a reader doesn't mistake
+  #183 as redundant with #177.
+- Related: #74/#76 (same bug, already fixed for `perform_pca_analysis`); #80
+  (separate — pipeline `trait_names` metadata, not producer-dict internals);
+  #177 (QC cleanup shields the pipeline path already; does not fix direct
+  callers); #179/PR #182 (open, not yet merged — see sequencing note above).

--- a/openspec/changes/fix-clustering-feature-names-mismatch/specs/serializable-result-types/spec.md
+++ b/openspec/changes/fix-clustering-feature-names-mismatch/specs/serializable-result-types/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: Accurate Clustering Feature Names After Column Filtering
+
+`perform_kmeans_clustering`, `perform_gmm_clustering`, and
+`perform_hierarchical_clustering` SHALL derive `feature_names` from the
+columns actually present in the data used for clustering, after any
+non-numeric or zero-variance column has been dropped, for both
+`standardize=True` and `standardize=False`. `feature_names` SHALL never
+include a column that was dropped before fitting, and its order SHALL match
+the column order of the corresponding feature-indexed array
+(`cluster_centers` for KMeans, `means` for GMM, `data_processed` for
+hierarchical).
+
+#### Scenario: Constant column excluded from KMeans feature_names
+
+- **WHEN** `perform_kmeans_clustering(df)` is called on a DataFrame
+  containing a constant (zero-variance) column, with `standardize=True`
+- **THEN** `feature_names` SHALL NOT include the constant column
+- **AND** `len(feature_names) == cluster_centers.shape[1]`
+- **AND** `dict(zip(feature_names, cluster_centers[k]))` SHALL map each
+  surviving name to the centroid value for that named trait, for every
+  cluster `k`
+
+#### Scenario: Constant column excluded from GMM feature_names
+
+- **WHEN** `perform_gmm_clustering(df)` is called on a DataFrame containing
+  a constant (zero-variance) column, with `standardize=True`
+- **THEN** `feature_names` SHALL NOT include the constant column
+- **AND** `len(feature_names) == means.shape[1]`
+- **AND** `dict(zip(feature_names, means[k]))` SHALL map each surviving name
+  to the correct mean value for that named trait, for every component `k`
+
+#### Scenario: Constant column excluded from hierarchical feature_names
+
+- **WHEN** `perform_hierarchical_clustering(df)` is called on a DataFrame
+  containing a constant (zero-variance) column, with `standardize=True`
+- **THEN** `feature_names` SHALL NOT include the constant column
+- **AND** `len(feature_names) == data_processed.shape[1]`
+- **AND** `dict(zip(feature_names, data_processed[i]))` SHALL map each
+  surviving name to the correct processed value for that named trait, for
+  every sample `i` — a pure length check does not catch a reordering bug,
+  only a per-sample named-value check does
+
+#### Scenario: standardize=False still filters non-numeric and constant columns
+
+- **WHEN** any of the three producers is called with `standardize=False` on a
+  DataFrame containing a non-numeric column, a constant column, or both
+- **THEN** the producer SHALL exclude those columns from `feature_names` and
+  from the array used for fitting, the same way `standardize_data` filters
+  the `standardize=True` path
+- **AND** the producer SHALL NOT raise an uncontrolled sklearn/scipy error
+  (e.g. a `TypeError` from an object-dtype array reaching `KMeans.fit()` /
+  `GaussianMixture.fit()` / `linkage()`)
+
+#### Scenario: Existing clean-input behavior is unchanged
+
+- **WHEN** any of the three producers is called on a DataFrame with no
+  constant and no non-numeric columns (nothing for the filter to drop)
+- **THEN** `feature_names` SHALL be identical to the previously-observed
+  output for that input — the fix corrects only mislabeled cases, it does
+  not reorder or rename features that were already correct
+
+### Requirement: Clean Error on Fully-Filtered Clustering Input
+
+`perform_kmeans_clustering`, `perform_gmm_clustering`, and
+`perform_hierarchical_clustering` SHALL raise a `RuntimeError` whose message
+contains "No numeric columns with non-zero variance found" when every column
+of the input is non-numeric or zero-variance, for both `standardize=True`
+and `standardize=False`. `RuntimeError` (not a bare `ValueError`) matches
+these three producers' existing convention of wrapping every error raised
+inside their fitting pipeline — including `standardize_data`'s own
+`ValueError` on the `standardize=True` path today — into a
+method-specific `RuntimeError`; the fix keeps `standardize=False` consistent
+with that existing, already-tested behavior rather than introducing a new,
+differently-typed exception for only one branch.
+
+#### Scenario: All columns filtered out raises a clear error
+
+- **WHEN** every column of the input DataFrame is non-numeric or
+  zero-variance, for either value of `standardize`
+- **THEN** the producer SHALL raise `RuntimeError` with a message containing
+  "No numeric columns with non-zero variance found"
+- **AND** it SHALL NOT raise an uncontrolled sklearn/scipy error (e.g. a
+  string-conversion `ValueError` from an object-dtype array) instead
+
+## MODIFIED Requirements
+
+### Requirement: Non-Breaking Clustering Return Shapes
+
+Adding the clustering result types SHALL NOT change the return shapes of
+`perform_kmeans_clustering` / `perform_gmm_clustering`; both SHALL keep
+returning their existing dicts so all current callers continue to work.
+Correcting a previously-mislabeled `feature_names` value for inputs with
+constant or non-numeric columns is a bug fix, not a shape change: the dict's
+keys are unchanged, and values are corrected only for inputs where they were
+previously wrong (see "Accurate Clustering Feature Names After Column
+Filtering").
+
+#### Scenario: Existing clustering returns are preserved and not mutated
+
+- **WHEN** `perform_kmeans_clustering()` or `perform_gmm_clustering()` is called
+- **THEN** it SHALL return its existing dict (including `cluster_labels`,
+  `cluster_centers`/`means`, and the quality-metric keys)
+- **AND** calling the corresponding adapter SHALL leave the dict's keys and
+  values unchanged
+- **AND** the typed view SHALL be opt-in, built only via the adapters
+
+#### Scenario: Typed adapters inherit the corrected feature_names
+
+- **WHEN** `ClusterResult.from_kmeans_dict` or `from_gmm_dict` is built from a
+  producer dict that excluded a constant or non-numeric column
+- **THEN** the resulting `KMeansResult` / `GMMResult` `feature_names` SHALL
+  match the producer dict's corrected `feature_names` exactly, with no
+  separate correction logic in the adapters

--- a/openspec/changes/fix-clustering-feature-names-mismatch/tasks.md
+++ b/openspec/changes/fix-clustering-feature-names-mismatch/tasks.md
@@ -1,0 +1,49 @@
+# Tasks: fix-clustering-feature-names-mismatch
+
+**Suggested commit grouping** (per the `fix-pca-zero-variance-crash` precedent,
+which landed as one test commit + one fix commit, not one commit per task
+group): Tasks 1-4 → one `test(#183):` commit (red); Task 5 → one `fix(#183):`
+commit (green, turns the previous commit's tests passing); Tasks 6-7 → one
+`test(#183):` commit; Task 8 → folded into whichever commit is last, plus a
+final `docs(#183):` commit for the checklist. Don't push mid-red-phase while
+a PR is open — batch commits 1-3 into a single push so CI never sees a
+failing intermediate state.
+
+## Task 1: Fixtures
+- [x] 1.1 Reuse `pca_constant_feature_data` (`tests/fixtures.py:1046`) for the clustering producer tests instead of hand-rolling a new one
+- [x] 1.2 Add a new fixture mixing a constant numeric column and a non-numeric (string plant/genotype ID) column in the same frame — no existing fixture covers the `select_dtypes` half of the bug
+
+## Task 2: Write failing tests — structural invariant (TDD Red Phase)
+- [x] 2.1 Add a parametrized test across `perform_kmeans_clustering` / `perform_gmm_clustering` / `perform_hierarchical_clustering`, each with `standardize=True` and `standardize=False`, asserting `len(feature_names) == <array>.shape[1]` (`cluster_centers`, `means`, `data_processed` respectively) on `pca_constant_feature_data`
+- [x] 2.2 Assert the dropped constant column's name is absent from `feature_names` and the surviving real trait names are present in original relative order
+- [x] 2.3 Run tests, confirm they FAIL on current code (length mismatch)
+
+## Task 3: Write failing tests — silent mislabeling regression (TDD Red Phase)
+- [x] 3.1 For KMeans/GMM, build `dict(zip(result["feature_names"], result[<array_key>][k]))` for a known cluster/component and assert each entry matches a hand-computed expected value for that named trait. For hierarchical, build the same mapping per-sample against `data_processed[i]` (there is no per-cluster centroid array for hierarchical) — a pure count assertion would not reliably catch the mislabeling in any of the three
+- [x] 3.2 Run tests, confirm they FAIL on current code (values map to wrong names)
+
+## Task 4: Write failing tests — non-numeric columns and all-filtered error (TDD Red Phase)
+- [x] 4.1 Add tests using the new mixed constant+non-numeric fixture (Task 1.2): for `standardize=False`, `feature_names` excludes the non-numeric and constant columns and the producer succeeds (does not raise) on the surviving numeric columns. Verified empirically today: `standardize=False` on this fixture currently raises `RuntimeError: ... could not convert string to float: 'G0'` for all three producers — confirm that changes to a successful result post-fix
+- [x] 4.2 Add tests confirming a `RuntimeError` whose message contains "No numeric columns with non-zero variance found" still raises when every column is filtered out, for both `standardize` values, across all three producers — build the all-filtered-out `DataFrame` inline (matching the `test_standardize_empty_after_cleaning` precedent in `test_pca.py`), no new fixture needed. Verified empirically: `standardize=True` already raises exactly this today (via `standardize_data`'s `ValueError` wrapped by the producer's own `except Exception`); `standardize=False` currently raises `RuntimeError: ... could not convert string to float` instead — confirm 4.2 fails today for `standardize=False` only
+- [x] 4.3 Run tests, confirm 4.1 fails on `standardize=False` (currently raises instead of succeeding) and 4.2 fails on `standardize=False` (currently raises the wrong message)
+
+## Task 5: Implement the fix (TDD Green Phase)
+- [x] 5.1 `perform_kmeans_clustering` (~L104-111): on `standardize=True`, capture `df_clean` from `standardize_data`'s return (not `_`) and re-derive `feature_names` from it; on `standardize=False`, apply the numeric-only + non-zero-variance filter before deriving `feature_names`/`X_processed`, raising `ValueError` if nothing survives
+- [x] 5.2 Apply the same fix to `perform_gmm_clustering` (~L355-362)
+- [x] 5.3 Apply the same fix to `perform_hierarchical_clustering` (~L572-579)
+- [x] 5.4 Update the `feature_names` docstring line in all three producers (currently just `feature_names: Feature names (if DataFrame input)`) to note it reflects columns remaining after numeric/non-zero-variance filtering, not necessarily the caller's original columns
+- [x] 5.5 Run all Task 2-4 tests, confirm PASS (green); confirm all existing `test_clustering.py` (55 tests) and `test_cluster_result.py` (16 tests) still pass unchanged (no behavior change for already-clean input)
+
+## Task 6: Typed adapter and outlier-detection regression coverage
+- [x] 6.1 Extend `tests/test_cluster_result.py`'s `TestClusterAdapters` so `KMeansResult`/`GMMResult` `feature_names` is checked against `cluster_centers.shape[1]` / `means.shape[1]` on the constant-feature fixture (post-fix, corrected values)
+- [x] 6.2 `HierarchicalResult` does not exist yet on `main` (PR #182 for #179 is still open) — do NOT add a test for it here. Once #182 merges (whichever order the two PRs land in), add one follow-up test asserting `HierarchicalResult.feature_names` matches `perform_hierarchical_clustering(df)["data_processed"].shape[1]`; no code change should be needed since the adapter passes `feature_names` through
+- [x] 6.3 Add tests in `tests/test_outlier_detection.py` for `detect_outliers_kmeans`/`detect_outliers_gmm`/`detect_outliers_hierarchical` on the constant-feature and mixed fixtures (both `standardize` values): assert `feature_names` in the returned dict excludes filtered columns and matches the corresponding array's column count — these three functions currently have zero `feature_names` coverage and dict-spread the producer output verbatim, so they'd otherwise silently carry the bug forward undetected
+
+## Task 7: Pipeline-path guardrail (no regression)
+- [x] 7.1 In `tests/test_step_detect_outliers.py`, assert that when `DetectOutliersStep` (`pipeline/steps/detect_outliers.py`, which calls `detect_outliers_kmeans`/`_gmm`/`_hierarchical` directly) runs downstream of the #177 cleanup step, its `feature_names` output matches the cleanup step's surviving trait list exactly — confirms the pipeline path stays protected before *and* after this fix (the cleanup step already excludes constants before this code runs, so this guards against a regression, not the bug itself)
+
+## Task 8: Verify no regressions
+- [x] 8.1 All existing `test_clustering.py`, `test_cluster_result.py`, and `test_outlier_detection.py` tests pass unchanged
+- [x] 8.2 Full test suite passes (`uv run pytest`)
+- [x] 8.3 Linting, formatting, and the frozen mypy baseline pass (`uv run ruff check`, `uv run black --check`, `uv run mypy src/sleap_roots_analyze | uv run mypy-baseline filter --baseline-path .mypy-baseline.txt`)
+- [x] 8.4 Update `docs/CHANGELOG.md` `[Unreleased]` with a `### Fixed` entry that explicitly distinguishes this fix from the existing #177 `### Changed` entry — e.g. "This is separate from the #177 cleanup change above: #177 keeps constant traits from ever reaching these functions through the standard cleanup step; #183 fixes the functions' own label bookkeeping for any caller that doesn't go through it (direct callers, or `standardize=False`)."

--- a/src/sleap_roots_analyze/clustering.py
+++ b/src/sleap_roots_analyze/clustering.py
@@ -19,7 +19,7 @@ from sklearn.metrics import (
     calinski_harabasz_score,
 )
 
-from sleap_roots_analyze.pca import standardize_data
+from sleap_roots_analyze.pca import standardize_data, filter_numeric_nonzero_variance
 
 
 def perform_kmeans_clustering(
@@ -115,11 +115,7 @@ def perform_kmeans_clustering(
         else:
             # standardize_data's own filtering must still apply here, or a
             # non-numeric/constant column reaches KMeans.fit() directly.
-            df_numeric = df_clean.select_dtypes(include=[np.number])
-            variances = df_numeric.var(ddof=0)
-            df_numeric = df_numeric[variances[variances > 0].index]
-            if df_numeric.empty:
-                raise ValueError("No numeric columns with non-zero variance found")
+            df_numeric = filter_numeric_nonzero_variance(df_clean)
             feature_names = df_numeric.columns.tolist()
             X_processed = df_numeric.values
 
@@ -380,11 +376,7 @@ def perform_gmm_clustering(
             # standardize_data's own filtering must still apply here, or a
             # non-numeric/constant column reaches GaussianMixture.fit()
             # directly.
-            df_numeric = df_clean.select_dtypes(include=[np.number])
-            variances = df_numeric.var(ddof=0)
-            df_numeric = df_numeric[variances[variances > 0].index]
-            if df_numeric.empty:
-                raise ValueError("No numeric columns with non-zero variance found")
+            df_numeric = filter_numeric_nonzero_variance(df_clean)
             feature_names = df_numeric.columns.tolist()
             X_processed = df_numeric.values
 
@@ -610,11 +602,7 @@ def perform_hierarchical_clustering(
         else:
             # standardize_data's own filtering must still apply here, or a
             # non-numeric/constant column reaches linkage() directly.
-            df_numeric = df_clean.select_dtypes(include=[np.number])
-            variances = df_numeric.var(ddof=0)
-            df_numeric = df_numeric[variances[variances > 0].index]
-            if df_numeric.empty:
-                raise ValueError("No numeric columns with non-zero variance found")
+            df_numeric = filter_numeric_nonzero_variance(df_clean)
             feature_names = df_numeric.columns.tolist()
             X_processed = df_numeric.values
 

--- a/src/sleap_roots_analyze/clustering.py
+++ b/src/sleap_roots_analyze/clustering.py
@@ -56,7 +56,9 @@ def perform_kmeans_clustering(
         - davies_bouldin_score: Quality metric [0, inf), lower is better
         - calinski_harabasz_score: Quality metric [0, inf), higher is better
         - data_indices: Original data indices
-        - feature_names: Feature names (if DataFrame input)
+        - feature_names: Feature names (if DataFrame input); reflects columns
+          remaining after numeric/non-zero-variance filtering, not
+          necessarily the caller's original columns
         - data_processed: Processed data used for clustering (N, n_features)
 
     Raises:
@@ -101,14 +103,25 @@ def perform_kmeans_clustering(
         n_clusters = recommended_max_clusters
 
     original_indices = df_clean.index.tolist()
-    feature_names = df_clean.columns.tolist()
 
     try:
-        # Standardize data if requested
+        # Standardize data if requested. feature_names is derived from the
+        # columns that survive filtering (numeric dtype, non-zero variance),
+        # not the pre-filter df_clean, so it stays aligned with X_processed
+        # (pca.py:793-812 precedent).
         if standardize:
-            X_processed, scaler, _ = standardize_data(df_clean)
+            X_processed, scaler, df_clean = standardize_data(df_clean)
+            feature_names = df_clean.columns.tolist()
         else:
-            X_processed = df_clean.values
+            # standardize_data's own filtering must still apply here, or a
+            # non-numeric/constant column reaches KMeans.fit() directly.
+            df_numeric = df_clean.select_dtypes(include=[np.number])
+            variances = df_numeric.var(ddof=0)
+            df_numeric = df_numeric[variances[variances > 0].index]
+            if df_numeric.empty:
+                raise ValueError("No numeric columns with non-zero variance found")
+            feature_names = df_numeric.columns.tolist()
+            X_processed = df_numeric.values
 
         # Fit K-Means
         kmeans = KMeans(n_clusters=n_clusters, random_state=random_state, n_init=10)
@@ -322,7 +335,9 @@ def perform_gmm_clustering(
         - davies_bouldin_score: Quality metric [0, inf), lower is better
         - calinski_harabasz_score: Quality metric [0, inf), higher is better
         - data_indices: Original data indices
-        - feature_names: Feature names (if DataFrame input)
+        - feature_names: Feature names (if DataFrame input); reflects columns
+          remaining after numeric/non-zero-variance filtering, not
+          necessarily the caller's original columns
         - data_processed: Processed data used for clustering (N, n_features)
 
     Raises:
@@ -352,14 +367,26 @@ def perform_gmm_clustering(
         )
 
     original_indices = df_clean.index.tolist()
-    feature_names = df_clean.columns.tolist()
 
     try:
-        # Standardize data if requested
+        # Standardize data if requested. feature_names is derived from the
+        # columns that survive filtering (numeric dtype, non-zero variance),
+        # not the pre-filter df_clean, so it stays aligned with X_processed
+        # (pca.py:793-812 precedent).
         if standardize:
-            X_processed, scaler, _ = standardize_data(df_clean)
+            X_processed, scaler, df_clean = standardize_data(df_clean)
+            feature_names = df_clean.columns.tolist()
         else:
-            X_processed = df_clean.values
+            # standardize_data's own filtering must still apply here, or a
+            # non-numeric/constant column reaches GaussianMixture.fit()
+            # directly.
+            df_numeric = df_clean.select_dtypes(include=[np.number])
+            variances = df_numeric.var(ddof=0)
+            df_numeric = df_numeric[variances[variances > 0].index]
+            if df_numeric.empty:
+                raise ValueError("No numeric columns with non-zero variance found")
+            feature_names = df_numeric.columns.tolist()
+            X_processed = df_numeric.values
 
         bic_scores = []
         aic_scores = []
@@ -530,7 +557,9 @@ def perform_hierarchical_clustering(
         - cophenetic_correlation: Quality metric [0, 1], higher is better.
           Measures how faithfully the dendrogram preserves pairwise distances.
         - data_indices: Original data indices
-        - feature_names: Feature names (if DataFrame input)
+        - feature_names: Feature names (if DataFrame input); reflects columns
+          remaining after numeric/non-zero-variance filtering, not
+          necessarily the caller's original columns
         - data_processed: Processed data used for clustering (N, n_features)
 
     Raises:
@@ -569,14 +598,25 @@ def perform_hierarchical_clustering(
         raise ValueError("Ward linkage requires euclidean metric")
 
     original_indices = df_clean.index.tolist()
-    feature_names = df_clean.columns.tolist()
 
     try:
-        # Standardize data if requested
+        # Standardize data if requested. feature_names is derived from the
+        # columns that survive filtering (numeric dtype, non-zero variance),
+        # not the pre-filter df_clean, so it stays aligned with X_processed
+        # (pca.py:793-812 precedent).
         if standardize:
-            X_processed, scaler, _ = standardize_data(df_clean)
+            X_processed, scaler, df_clean = standardize_data(df_clean)
+            feature_names = df_clean.columns.tolist()
         else:
-            X_processed = df_clean.values
+            # standardize_data's own filtering must still apply here, or a
+            # non-numeric/constant column reaches linkage() directly.
+            df_numeric = df_clean.select_dtypes(include=[np.number])
+            variances = df_numeric.var(ddof=0)
+            df_numeric = df_numeric[variances[variances > 0].index]
+            if df_numeric.empty:
+                raise ValueError("No numeric columns with non-zero variance found")
+            feature_names = df_numeric.columns.tolist()
+            X_processed = df_numeric.values
 
         # Perform hierarchical clustering
         linkage_matrix = linkage(X_processed, method=method, metric=metric)

--- a/src/sleap_roots_analyze/pca.py
+++ b/src/sleap_roots_analyze/pca.py
@@ -621,6 +621,35 @@ def calculate_pca_reconstruction_error(
     return reconstruction_errors
 
 
+def filter_numeric_nonzero_variance(df: pd.DataFrame) -> pd.DataFrame:
+    """Keep only numeric, non-zero-variance columns.
+
+    Shared by standardize_data (the standardize=True path across PCA/UMAP/
+    clustering) and every standardize=False branch that needs the identical
+    filter without standardizing, so the two paths can never drift apart.
+
+    Args:
+        df: DataFrame to filter
+
+    Returns:
+        DataFrame containing only the surviving columns, in original order
+
+    Raises:
+        ValueError: If no numeric column has non-zero variance
+    """
+    df_numeric = df.select_dtypes(include=[np.number])
+
+    # Drop columns with zero variance
+    # Use ddof=0 for population variance (consistent with sklearn)
+    variances = df_numeric.var(ddof=0)
+    df_numeric = df_numeric[variances[variances > 0].index]
+
+    if df_numeric.empty:
+        raise ValueError("No numeric columns with non-zero variance found")
+
+    return df_numeric
+
+
 def standardize_data(
     df: pd.DataFrame,
 ) -> Tuple[np.ndarray, StandardScaler, pd.DataFrame]:
@@ -634,18 +663,11 @@ def standardize_data(
             - X_scaled: Standardized data array
             - scaler: Fitted StandardScaler
             - df_clean: DataFrame with non-numeric columns removed
+
+    Raises:
+        ValueError: If no numeric column has non-zero variance
     """
-    # Remove non-numeric columns
-    df_clean = df.select_dtypes(include=[np.number])
-
-    # Drop columns with zero variance
-    # Use ddof=0 for population variance (consistent with sklearn)
-    variances = df_clean.var(ddof=0)
-    non_zero_var_cols = variances[variances > 0].index
-    df_clean = df_clean[non_zero_var_cols]
-
-    if df_clean.empty:
-        raise ValueError("No numeric columns with non-zero variance found")
+    df_clean = filter_numeric_nonzero_variance(df)
 
     # Standardize
     scaler = StandardScaler()
@@ -796,17 +818,7 @@ def perform_pca_analysis(
             feature_names = df_clean.columns.tolist()
         else:
             # Manual cleaning without standardization
-            df_numeric = df_clean.select_dtypes(include=[np.number])
-
-            # Drop columns with zero variance
-            # ddof = 0 for population variance
-            variances = df_numeric.var(ddof=0)
-            non_zero_var_cols = variances[variances > 0].index
-            df_numeric = df_numeric[non_zero_var_cols]
-
-            if df_numeric.empty:
-                raise ValueError("No numeric columns with non-zero variance found")
-
+            df_numeric = filter_numeric_nonzero_variance(df_clean)
             feature_names = df_numeric.columns.tolist()
             X_processed = df_numeric.values
             scaler = None

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3464,6 +3464,29 @@ def edge_case_cluster_data():
 
 
 @pytest.fixture
+def cluster_mixed_constant_and_nonnumeric_data():
+    """Create clustering data mixing a constant column and a non-numeric column.
+
+    Covers the half of the feature_names bug that pca_constant_feature_data
+    does not: a non-numeric (string) column silently dropped by
+    select_dtypes inside standardize_data.
+    """
+    np.random.seed(42)
+    n_samples = 90
+
+    df = pd.DataFrame(
+        {
+            "genotype_id": [f"G{i % 3}" for i in range(n_samples)],
+            "constant_trait": np.full(n_samples, 7.0),
+            "variable1": np.random.randn(n_samples),
+            "variable2": np.random.randn(n_samples) * 2,
+        }
+    )
+
+    return df
+
+
+@pytest.fixture
 def linkage_matrix_small():
     """Create a small linkage matrix for hierarchical clustering edge cases."""
     from scipy.cluster.hierarchy import linkage

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3487,6 +3487,51 @@ def cluster_mixed_constant_and_nonnumeric_data():
 
 
 @pytest.fixture
+def cluster_nonnumeric_only_data():
+    """Create clustering data with a non-numeric column but no constant column.
+
+    cluster_mixed_constant_and_nonnumeric_data always pairs the non-numeric
+    column with a constant column; this isolates the select_dtypes half of
+    the filter on its own.
+    """
+    np.random.seed(42)
+    n_samples = 90
+
+    df = pd.DataFrame(
+        {
+            "genotype_id": [f"G{i % 3}" for i in range(n_samples)],
+            "variable1": np.random.randn(n_samples),
+            "variable2": np.random.randn(n_samples) * 2,
+        }
+    )
+
+    return df
+
+
+@pytest.fixture
+def cluster_separated_data_with_constant():
+    """Well-separated 3-cluster 2D data plus one constant column.
+
+    Clusters are separated enough (10 units apart, 0.3 std) that GMM's soft
+    assignments collapse to hard assignments to machine precision, making
+    each cluster's true center exactly recoverable from cluster_labels +
+    data_processed. Needed to test that cluster_centers/means (not just
+    data_processed) are positionally aligned with feature_names -- unlike
+    pca_constant_feature_data, whose variable1/variable2 have no true
+    cluster structure, so GMM's per-component means only approximately
+    match a hard-assignment recomputation there.
+    """
+    np.random.seed(42)
+    cluster1 = np.random.randn(30, 2) * 0.3 + np.array([0, 0])
+    cluster2 = np.random.randn(30, 2) * 0.3 + np.array([10, 10])
+    cluster3 = np.random.randn(30, 2) * 0.3 + np.array([-10, 10])
+    data = np.vstack([cluster1, cluster2, cluster3])
+    df = pd.DataFrame(data, columns=["trait_a", "trait_b"])
+    df["constant_trait"] = 7.0
+    return df
+
+
+@pytest.fixture
 def linkage_matrix_small():
     """Create a small linkage matrix for hierarchical clustering edge cases."""
     from scipy.cluster.hierarchy import linkage

--- a/tests/test_cluster_result.py
+++ b/tests/test_cluster_result.py
@@ -175,6 +175,41 @@ class TestClusterAdapters:
             )
 
 
+class TestClusterAdapterFeatureNamesAfterFiltering:
+    """Regression tests for #183: adapters inherit the corrected feature_names.
+
+    KMeansResult/GMMResult carry feature_names straight through from the
+    producer dict, with no separate correction logic in the adapters
+    themselves — these confirm that inheritance holds once the producers
+    (perform_kmeans_clustering/perform_gmm_clustering) are fixed to derive
+    feature_names from the post-filter columns.
+    """
+
+    def test_kmeans_adapter_feature_names_matches_filtered_centers(
+        self, pca_constant_feature_data
+    ):
+        """feature_names excludes constant columns and matches centers width."""
+        d = perform_kmeans_clustering(
+            pca_constant_feature_data, n_clusters=3, standardize=True
+        )
+        result = ClusterResult.from_kmeans_dict(d, random_state=42)
+
+        assert result.feature_names == ["variable1", "variable2"]
+        assert len(result.feature_names) == len(result.cluster_centers[0])
+
+    def test_gmm_adapter_feature_names_matches_filtered_means(
+        self, pca_constant_feature_data
+    ):
+        """feature_names excludes constant columns and matches means width."""
+        d = perform_gmm_clustering(
+            pca_constant_feature_data, n_components=3, standardize=True
+        )
+        result = ClusterResult.from_gmm_dict(d, random_state=42)
+
+        assert result.feature_names == ["variable1", "variable2"]
+        assert len(result.feature_names) == len(result.cluster_centers[0])
+
+
 class TestClusterDeterminism:
     """Same seed -> identical result via the typed view (#118)."""
 

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -733,7 +733,9 @@ class TestClusteringFeatureNamesAfterFiltering:
 
         A length check alone would not catch feature_names paired with the
         wrong column; this checks the actual per-column content, not just
-        the array's shape.
+        the array's shape. This exercises data_processed specifically (every
+        producer returns it); see TestClusteringCentroidArrayAlignment below
+        for the equivalent check against cluster_centers/means directly.
         """
         result = fn(pca_constant_feature_data, standardize=standardize, **kwargs)
         data_processed = result["data_processed"]
@@ -747,6 +749,60 @@ class TestClusteringFeatureNamesAfterFiltering:
                 expected = series
             np.testing.assert_allclose(
                 data_processed[:, name_to_col[col]], expected.to_numpy(), rtol=1e-6
+            )
+
+
+CENTROID_PRODUCERS = [
+    pytest.param(
+        perform_kmeans_clustering, {"n_clusters": 3}, "cluster_centers", id="kmeans"
+    ),
+    pytest.param(perform_gmm_clustering, {"n_components": 3}, "means", id="gmm"),
+]
+
+
+class TestClusteringCentroidArrayAlignment:
+    """cluster_centers/means themselves must align with feature_names.
+
+    The data_processed check above only proves feature_names is correctly
+    paired with the raw fitted data; it does not exercise cluster_centers
+    (KMeans) or means (GMM) directly. hierarchical has no equivalent
+    per-cluster centroid array distinct from data_processed, so it is not
+    parametrized here. Uses well-separated clusters (not
+    pca_constant_feature_data, which has no true cluster structure) so a
+    cluster's hard-assignment mean recomputed from cluster_labels +
+    data_processed matches cluster_centers/means to machine precision --
+    verified empirically before writing this test.
+    """
+
+    @pytest.mark.parametrize("standardize", [True, False])
+    @pytest.mark.parametrize("fn, kwargs, array_key", CENTROID_PRODUCERS)
+    def test_array_key_matches_hard_assignment_means(
+        self, cluster_separated_data_with_constant, fn, kwargs, array_key, standardize
+    ):
+        """array_key column j is the mean of data_processed[:, j] per cluster."""
+        result = fn(
+            cluster_separated_data_with_constant, standardize=standardize, **kwargs
+        )
+        assert result["feature_names"] == ["trait_a", "trait_b"]
+
+        data_processed = result["data_processed"]
+        labels = np.asarray(result["cluster_labels"])
+        array = np.asarray(result[array_key])
+        n_groups = array.shape[0]
+
+        for col_pos, col_name in enumerate(result["feature_names"]):
+            hard_means = np.array(
+                [data_processed[labels == k, col_pos].mean() for k in range(n_groups)]
+            )
+            np.testing.assert_allclose(
+                array[:, col_pos],
+                hard_means,
+                rtol=1e-6,
+                atol=1e-6,
+                err_msg=(
+                    f"{array_key} column for {col_name!r} does not match its "
+                    "hard-assignment cluster mean"
+                ),
             )
 
 
@@ -776,6 +832,38 @@ class TestClusteringMixedConstantAndNonNumeric:
         )
         assert result["feature_names"] == ["variable1", "variable2"]
         assert result[array_key].shape[1] == 2
+
+    @pytest.mark.parametrize("standardize", [True, False])
+    @pytest.mark.parametrize("fn, kwargs, array_key", FEATURE_NAMES_PRODUCERS)
+    def test_excludes_nonnumeric_without_constant_present(
+        self, cluster_nonnumeric_only_data, fn, kwargs, array_key, standardize
+    ):
+        """Non-numeric exclusion works even with no constant column present."""
+        result = fn(cluster_nonnumeric_only_data, standardize=standardize, **kwargs)
+        assert result["feature_names"] == ["variable1", "variable2"]
+        assert result[array_key].shape[1] == 2
+
+
+class TestClusteringUnchangedOnAlreadyCleanInput:
+    """Pin standardize=False behavior on already-clean input.
+
+    The old code was `X_processed = df_clean.values; feature_names =
+    df_clean.columns.tolist()`. When nothing needs filtering (no
+    non-numeric or constant column, as in simple_cluster_data), the new
+    filter_numeric_nonzero_variance()-based code must reduce to exactly
+    that, byte-for-byte -- not merely "close" or "same shape".
+    """
+
+    @pytest.mark.parametrize("fn, kwargs, array_key", FEATURE_NAMES_PRODUCERS)
+    def test_standardize_false_matches_old_unfiltered_behavior(
+        self, simple_cluster_data, fn, kwargs, array_key
+    ):
+        """data_processed and feature_names exactly match the old unfiltered pass-through."""
+        result = fn(simple_cluster_data, standardize=False, **kwargs)
+        assert result["feature_names"] == list(simple_cluster_data.columns)
+        np.testing.assert_array_equal(
+            result["data_processed"], simple_cluster_data.values
+        )
 
 
 class TestClusteringAllColumnsFilteredOut:

--- a/tests/test_clustering.py
+++ b/tests/test_clustering.py
@@ -9,6 +9,7 @@ import pytest
 from sleap_roots_analyze.clustering import (
     perform_kmeans_clustering,
     perform_gmm_clustering,
+    perform_hierarchical_clustering,
     calculate_cluster_quality_metrics,
 )
 
@@ -679,3 +680,125 @@ class TestClusteringWithNaN:
 
         # Should have fewer samples than input
         assert len(result["data_indices"]) < len(cluster_result_with_nan)
+
+
+# ============================================================================
+# Regression tests for #183: feature_names silently mislabeled after
+# standardize_data drops non-numeric/zero-variance columns.
+# ============================================================================
+
+FEATURE_NAMES_PRODUCERS = [
+    pytest.param(
+        perform_kmeans_clustering, {"n_clusters": 3}, "cluster_centers", id="kmeans"
+    ),
+    pytest.param(perform_gmm_clustering, {"n_components": 3}, "means", id="gmm"),
+    pytest.param(
+        perform_hierarchical_clustering, {}, "data_processed", id="hierarchical"
+    ),
+]
+
+
+class TestClusteringFeatureNamesAfterFiltering:
+    """feature_names must reflect the columns actually used for fitting.
+
+    perform_kmeans_clustering/perform_gmm_clustering/perform_hierarchical_clustering
+    all filter out non-numeric and zero-variance columns before fitting, but
+    previously kept returning a pre-filter feature_names snapshot.
+    """
+
+    @pytest.mark.parametrize("standardize", [True, False])
+    @pytest.mark.parametrize("fn, kwargs, array_key", FEATURE_NAMES_PRODUCERS)
+    def test_length_matches_array(
+        self, pca_constant_feature_data, fn, kwargs, array_key, standardize
+    ):
+        """feature_names length must equal the array's actual column count."""
+        result = fn(pca_constant_feature_data, standardize=standardize, **kwargs)
+        assert len(result["feature_names"]) == result[array_key].shape[1]
+
+    @pytest.mark.parametrize("standardize", [True, False])
+    @pytest.mark.parametrize("fn, kwargs, array_key", FEATURE_NAMES_PRODUCERS)
+    def test_constant_columns_excluded_in_original_order(
+        self, pca_constant_feature_data, fn, kwargs, array_key, standardize
+    ):
+        """Constant columns are dropped; surviving names keep original order."""
+        result = fn(pca_constant_feature_data, standardize=standardize, **kwargs)
+        assert result["feature_names"] == ["variable1", "variable2"]
+
+    @pytest.mark.parametrize("standardize", [True, False])
+    @pytest.mark.parametrize("fn, kwargs, array_key", FEATURE_NAMES_PRODUCERS)
+    def test_named_value_matches_processed_data(
+        self, pca_constant_feature_data, fn, kwargs, array_key, standardize
+    ):
+        """Named value in data_processed matches a hand-computed expectation.
+
+        A length check alone would not catch feature_names paired with the
+        wrong column; this checks the actual per-column content, not just
+        the array's shape.
+        """
+        result = fn(pca_constant_feature_data, standardize=standardize, **kwargs)
+        data_processed = result["data_processed"]
+        name_to_col = {name: i for i, name in enumerate(result["feature_names"])}
+
+        for col in ("variable1", "variable2"):
+            series = pca_constant_feature_data[col]
+            if standardize:
+                expected = (series - series.mean()) / series.std(ddof=0)
+            else:
+                expected = series
+            np.testing.assert_allclose(
+                data_processed[:, name_to_col[col]], expected.to_numpy(), rtol=1e-6
+            )
+
+
+class TestClusteringMixedConstantAndNonNumeric:
+    """standardize=False must apply the same filter standardize=True does.
+
+    Today standardize=False passes df_clean.values through unfiltered, so a
+    non-numeric column reaches KMeans/GaussianMixture/linkage directly and
+    fails with a raw sklearn "could not convert string to float" error.
+    """
+
+    @pytest.mark.parametrize("standardize", [True, False])
+    @pytest.mark.parametrize("fn, kwargs, array_key", FEATURE_NAMES_PRODUCERS)
+    def test_excludes_nonnumeric_and_constant_columns(
+        self,
+        cluster_mixed_constant_and_nonnumeric_data,
+        fn,
+        kwargs,
+        array_key,
+        standardize,
+    ):
+        """Non-numeric and constant columns are excluded, not just tolerated."""
+        result = fn(
+            cluster_mixed_constant_and_nonnumeric_data,
+            standardize=standardize,
+            **kwargs,
+        )
+        assert result["feature_names"] == ["variable1", "variable2"]
+        assert result[array_key].shape[1] == 2
+
+
+class TestClusteringAllColumnsFilteredOut:
+    """Every column non-numeric or zero-variance must raise a clear error.
+
+    Not an uncontrolled sklearn/scipy failure, for either standardize value.
+    """
+
+    @pytest.mark.parametrize("standardize", [True, False])
+    @pytest.mark.parametrize("fn, kwargs, array_key", FEATURE_NAMES_PRODUCERS)
+    def test_raises_runtime_error_with_clear_message(
+        self, fn, kwargs, array_key, standardize
+    ):
+        """A fully-filtered input raises RuntimeError with a clear message."""
+        n = 20
+        df = pd.DataFrame(
+            {
+                "genotype_id": [f"G{i % 3}" for i in range(n)],
+                "constant_trait": np.full(n, 7.0),
+                "constant_trait2": np.zeros(n),
+            }
+        )
+        with pytest.raises(
+            RuntimeError, match="No numeric columns with non-zero variance found"
+        ):
+            fn(df, standardize=standardize, **kwargs)

--- a/tests/test_outlier_detection.py
+++ b/tests/test_outlier_detection.py
@@ -11,6 +11,9 @@ from sleap_roots_analyze.outlier_detection import (
     detect_outliers_mahalanobis,
     detect_outliers_pca,
     detect_outliers_isolation_forest,
+    detect_outliers_kmeans,
+    detect_outliers_gmm,
+    detect_outliers_hierarchical,
     calculate_outlier_threshold,
     identify_outliers_from_distances,
     remove_outliers_from_data,
@@ -2991,3 +2994,85 @@ class TestCombineOutlierMethods:
             assert (
                 actual_total == 2
             ), f"Total methods mismatch: expected 2, got {actual_total}"
+
+
+# ============================================================================
+# Regression tests for #183: detect_outliers_kmeans/_gmm/_hierarchical each
+# dict-spread the clustering producer's output verbatim (e.g.
+# `return {**cluster_result, ...}`), so they inherit the same feature_names
+# mismatch with no coverage of their own today.
+# ============================================================================
+
+DETECT_OUTLIERS_PRODUCERS = [
+    pytest.param(
+        detect_outliers_kmeans, {"n_clusters": 3}, "cluster_centers", id="kmeans"
+    ),
+    pytest.param(detect_outliers_gmm, {"n_components": 3}, "means", id="gmm"),
+    pytest.param(
+        detect_outliers_hierarchical,
+        {"n_clusters": 3},
+        "data_processed",
+        id="hierarchical",
+    ),
+]
+
+
+class TestDetectOutliersFeatureNamesAfterFiltering:
+    """feature_names must reflect the columns actually used for fitting."""
+
+    @pytest.mark.parametrize("standardize", [True, False])
+    @pytest.mark.parametrize("fn, kwargs, array_key", DETECT_OUTLIERS_PRODUCERS)
+    def test_feature_names_matches_filtered_array(
+        self, pca_constant_feature_data, fn, kwargs, array_key, standardize
+    ):
+        """feature_names excludes constants and matches the array's width."""
+        result = fn(pca_constant_feature_data, standardize=standardize, **kwargs)
+        assert "error" not in result
+        assert result["feature_names"] == ["variable1", "variable2"]
+        array = np.asarray(result[array_key])
+        assert len(result["feature_names"]) == array.shape[1]
+
+    @pytest.mark.parametrize("standardize", [True, False])
+    @pytest.mark.parametrize("fn, kwargs, array_key", DETECT_OUTLIERS_PRODUCERS)
+    def test_excludes_nonnumeric_and_constant_columns(
+        self,
+        cluster_mixed_constant_and_nonnumeric_data,
+        fn,
+        kwargs,
+        array_key,
+        standardize,
+    ):
+        """Non-numeric and constant columns are excluded, not just tolerated."""
+        result = fn(
+            cluster_mixed_constant_and_nonnumeric_data,
+            standardize=standardize,
+            **kwargs,
+        )
+        assert "error" not in result
+        assert result["feature_names"] == ["variable1", "variable2"]
+
+
+class TestDetectOutliersAllColumnsFilteredOut:
+    """Every column non-numeric or zero-variance reports a clear error.
+
+    Instead of an uncontrolled sklearn/scipy failure or a silent crash.
+    These functions catch internally and report via an "error" key rather
+    than raising.
+    """
+
+    @pytest.mark.parametrize("standardize", [True, False])
+    @pytest.mark.parametrize("fn, kwargs, array_key", DETECT_OUTLIERS_PRODUCERS)
+    def test_reports_clear_error(self, fn, kwargs, array_key, standardize):
+        """A fully-filtered input reports a clear error, not a raw crash."""
+        n = 20
+        df = pd.DataFrame(
+            {
+                "genotype_id": [f"G{i % 3}" for i in range(n)],
+                "constant_trait": np.full(n, 7.0),
+                "constant_trait2": np.zeros(n),
+            }
+        )
+        result = fn(df, standardize=standardize, **kwargs)
+        assert "No numeric columns with non-zero variance found" in result.get(
+            "error", ""
+        )

--- a/tests/test_step_detect_outliers.py
+++ b/tests/test_step_detect_outliers.py
@@ -227,3 +227,72 @@ class TestDetectOutliersStepEdgeCases:
 
         assert result.metadata["outlier_counts"] == {}
         assert result.metadata["methods_run"] == []
+
+
+class TestDetectOutliersStepFeatureNamesGuardrail:
+    """Regression guardrail for #183.
+
+    DetectOutliersStep builds numeric_df from the raw DataFrame via
+    get_numeric_traits_only(), which excludes barcode/genotype/replicate but
+    not a stray constant trait — so the clustering-based outlier detectors'
+    own internal filtering (fixed in #183) is what keeps a constant column
+    out of feature_names here, not anything DetectOutliersStep does itself.
+    This confirms that protection holds at the pipeline-integration layer.
+    """
+
+    def test_clustering_methods_exclude_constant_trait_from_feature_names(
+        self, tmp_path
+    ):
+        """A stray constant trait in the raw frame never reaches feature_names."""
+        np.random.seed(42)
+        n_samples = 30
+        data = pd.DataFrame(
+            {
+                "Barcode": [f"plant{i}" for i in range(n_samples)],
+                "geno": (["A"] * 10 + ["B"] * 10 + ["C"] * 10),
+                "rep": [1, 2, 3] * 10,
+                "trait1": np.random.randn(n_samples) * 10 + 50,
+                "trait2": np.random.randn(n_samples) * 5 + 25,
+                "trait3": np.random.randn(n_samples) * 3 + 15,
+                # Present in the raw frame but already excluded from
+                # valid_trait_names upstream (simulating #177's cleanup) --
+                # DetectOutliersStep does not itself re-filter to
+                # valid_trait_names before building numeric_df.
+                "constant_trait": np.full(n_samples, 7.0),
+            }
+        )
+        trait_cols = ["trait1", "trait2", "trait3"]
+
+        config = QCPipelineConfig(
+            pipeline_name="test_qc",
+            columns=ColumnConfig(barcode="Barcode", genotype="geno", replicate="rep"),
+            data=DataConfig(csv_path="dummy.csv"),
+            outlier_detection=OutlierDetectionConfig(
+                traditional_methods=[],
+                clustering_methods=["kmeans", "gmm", "hierarchical"],
+            ),
+        )
+        prev_result = StepResult(
+            data=data,
+            metadata={
+                "valid_trait_names": trait_cols,
+                "trait_names": trait_cols,
+                "samples": len(data),
+                "column_mapping": {
+                    "barcode": "Barcode",
+                    "genotype": "geno",
+                    "replicate": "rep",
+                },
+            },
+            files_generated=[],
+        )
+
+        step = DetectOutliersStep()
+        result = step.execute(
+            data=data, config=config, run_dir=tmp_path, prev_result=prev_result
+        )
+
+        for method in ("kmeans", "gmm", "hierarchical"):
+            method_result = result.metadata["outlier_results"][method]
+            assert method_result.get("error") is None
+            assert method_result["feature_names"] == trait_cols


### PR DESCRIPTION
## Summary
- `perform_kmeans_clustering`, `perform_gmm_clustering`, and `perform_hierarchical_clustering` snapshotted `feature_names` **before** `standardize_data` dropped non-numeric/zero-variance columns, silently mislabeling `cluster_centers`/`means`/`data_processed` for such inputs — not a length mismatch, a positional mislabeling. Ports the pattern already correct in `perform_pca_analysis` (`pca.py:793-812`) to both `standardize` branches; `standardize=False` now applies the same numeric + non-zero-variance filter `standardize=True` always used internally, instead of no filtering at all.
- `KMeansResult`/`GMMResult` and `detect_outliers_kmeans`/`_gmm`/`_hierarchical` (which dict-spread the producer output and had zero `feature_names` coverage) inherit the corrected values automatically — no adapter code changes needed, but added regression tests since nothing previously covered them.
- No breaking changes: dict keys, shapes for already-clean input, and typed adapter signatures are unchanged. Full OpenSpec proposal at `openspec/changes/fix-clustering-feature-names-mismatch/`.

Closes #183.

**Note on #179/PR #182:** the new `HierarchicalResult`/`hierarchical_cluster_labels` (PR #182) also inherit this bug once merged, but PR #182 is still open — this PR only touches `clustering.py`'s three producers, which are independent of it. Whichever PR merges second should add a small follow-up test confirming `HierarchicalResult.feature_names` reflects the corrected values (no code change expected).

## Test plan
- [x] New parametrized tests across all three producers × both `standardize` values: `feature_names` length matches the array, constant/non-numeric columns excluded in original order, named-value regression against `data_processed` (catches mislabeling a length check alone would miss), fully-filtered-input error path
- [x] `KMeansResult`/`GMMResult` adapter regression coverage
- [x] `detect_outliers_kmeans`/`_gmm`/`_hierarchical` regression coverage (previously zero `feature_names` coverage)
- [x] Pipeline-path guardrail in `DetectOutliersStep`
- [x] Full suite: 2486 passed, 31 skipped, 0 failed
- [x] `ruff check`, `black --check`, and the frozen `mypy` baseline (0 new errors) all clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)