### PR TITLE
Release v0.1.0a5

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.0a5] - 2026-07-13 (Pre-release)
+
 ### Added
+- `UMAPResult` (#180): frozen JSON-serializable dataclass (sibling to `PCAResult`):
+  `embedding`, `n_neighbors`, `min_dist`, `n_components`, `feature_names`, `n_samples`,
+  `standardized`, `random_state`. Excludes the fitted `reducer`/`scaler`. Provides
+  `to_dict()`/`to_json()` (strict `allow_nan=False`).
+  `UMAPResult.from_umap_dict(d, *, random_state=None)` derives `n_components`/`n_samples`
+  from the embedding shape and resolves the seed from the argument or the echoed dict
+  key. `perform_umap_analysis` additionally returns `feature_names` + `random_state`
+  (additive, non-breaking). Completes the result-types epic (#130) across
+  PCA/heritability/clustering/UMAP.
 - Public hierarchical-clustering entry point `hierarchical_cluster_labels` (#179):
   the **labeled** counterpart to `perform_hierarchical_clustering` (which returns only
   the dendrogram). Importable from `sleap_roots_analyze`, it composes the existing

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sleap-roots-analyze"
-version = "0.1.0a4"
+version = "0.1.0a5"
 description = "Analyze, visualize, and interpret root traits output from sleap-roots."
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -2133,7 +2133,7 @@ wheels = [
 
 [[package]]
 name = "sleap-roots-analyze"
-version = "0.1.0a4"
+version = "0.1.0a5"
 source = { editable = "." }
 dependencies = [
     { name = "adjusttext" },


### PR DESCRIPTION
## Release v0.1.0a5

Bumps `0.1.0a4 → 0.1.0a5`. Closes #186.

### What's bundled
- **Hierarchical `ClusterResult`** (#179, PR #182): `hierarchical_cluster_labels` + `HierarchicalResult` + `ClusterResult.from_hierarchical_dict`; widens `ClusterResult.random_state` to `Optional[int]`.
- **`UMAPResult`** (#180, PR #181): serializable dataclass + `from_umap_dict` adapter, completing the result-types epic across PCA/heritability/clustering/UMAP.
- **Zero-variance cleanup filter** (#177, PR #178): `apply_data_cleanup_filters` / `clean_traits_for_analysis` now drop + name constant traits at cleaning time.
- **Clustering `feature_names` fix** (#183, PR #185): `perform_kmeans_clustering` / `perform_gmm_clustering` / `perform_hierarchical_clustering` re-derive `feature_names` after `standardize_data` filtering.

### This PR
- Version bump via `uv version 0.1.0a5` (`pyproject.toml` + `uv.lock`).
- CHANGELOG: closed `[Unreleased]` into `## [0.1.0a5] - 2026-07-13 (Pre-release)`.
- Added the `UMAPResult` CHANGELOG entry that PR #181's description said it added but never actually landed (verified: PR #181's squash commit diff has no `docs/CHANGELOG.md` in it, and `origin/main`'s changelog had no UMAP section prior to this PR).

### Pre-Release Checklist
- [x] Tests pass locally (`uv run pytest -m "not integration" --cov`): 2571 passed, 31 skipped, 3 deselected, 86% coverage
- [x] Formatting (`uv run black --check src/sleap_roots_analyze tests`)
- [x] Linting (`uv run ruff check src/sleap_roots_analyze`)
- [x] Build artifacts verified (`uv build`)
- [x] Wheel installs correctly and reports `0.1.0a5`
- [x] CLI entry point works from the built wheel
- [x] `uvx pip-audit`: no known vulnerabilities
- [x] CHANGELOG updated with no empty/placeholder version section

### Post-Merge Steps
1. Tag + create GitHub release `v0.1.0a5` (`--prerelease`)
2. Verify PyPI upload via `build.yml` (trusted publishing)
3. Test installation from PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)
