### PR TITLE
feat(#109): BLUP-adjusted genotype means (Tier 1 cross-platform prediction)

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -591,6 +591,41 @@ Build a comparison table of variance components and heritability across traits.
 
 ---
 
+#### `extract_blup_table`
+
+```python
+extract_blup_table(
+    heritability_results: Dict
+) -> pd.DataFrame
+```
+
+Build a genotype x trait BLUP-adjusted-means table from a
+`calculate_heritability_estimates` result (issue #109).
+
+**Parameters:**
+- `heritability_results`: The dict returned by `calculate_heritability_estimates`
+  (the `remove_low_h2=False` form, or the first element of the
+  `remove_low_h2=True` tuple)
+
+**Returns:**
+- DataFrame indexed by genotype (the union of every succeeded trait's `blup`
+  keys), one column per trait (excluding `__calculation_metadata__`), in the
+  input's trait order. `adjusted_mean = intercept + blup[genotype]` for each
+  succeeded trait/genotype cell. A trait whose model failed, used the
+  ANOVA-based or no-variance path, or was skipped gets an entire `NaN`
+  column — not omitted, not zero-filled. A genotype missing from one
+  succeeded trait's `blup` dict but present in another's gets a cell-level
+  `NaN` for that genotype/trait pair only. Never raises: a run-level
+  short-circuit dict (`{"error": "..."}`) returns an empty `pd.DataFrame()`.
+
+**Example:**
+```python
+heritability_results = calculate_heritability_estimates(df, trait_cols)
+blup_table = extract_blup_table(heritability_results)
+```
+
+---
+
 ## `pca` Module
 
 Principal Component Analysis for dimensionality reduction of root trait data.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `extract_blup_table(heritability_results)` (#109): builds a genotype x trait
+  BLUP-adjusted-means `pd.DataFrame` from a `calculate_heritability_estimates` result —
+  `adjusted_mean = intercept + blup[genotype]` for each trait whose mixed model
+  succeeded, with a genuine `NaN` column (not dropped, not zero-filled) for any
+  trait that failed. Importable from `sleap_roots_analyze`. Tier 1 of the
+  cross-platform genotype-prediction program: BLUP-adjusted means are the predictor
+  substrate later tiers use to test whether one phenotyping platform's genotype
+  effects predict another's.
+- Serializable `BLUPResult` dataclass and `BLUPResult.from_blup_table(df, *,
+  intercepts=None)` adapter (#109): holds the genotype x trait adjusted-means matrix
+  for traits whose model succeeded, plus the names of traits that failed
+  (`failed_traits`) — a column needs to be entirely finite to count as succeeded, so
+  even a single cell-level gap reclassifies a trait the same as an outright model
+  failure. Provides `to_dict()` / `to_json()` (strict `allow_nan=False`).
+- `StatisticsConfig.generate_blup_table` (default `True`): controls whether the QC/Viz
+  pipeline's `StatisticalAnalysisStep` writes `08_blup_adjusted_means.csv` alongside
+  `08_heritability_results.csv`. Only takes effect when `calculate_heritability` is
+  also `True` — free once the model is fit.
+
+### Changed
+- `calculate_heritability_estimates` additively returns `blup` (`dict[str, float]`) and
+  `intercept` (`float`) keys per trait when its mixed model succeeds (#109) — both
+  existing return shapes (plain dict, or the `remove_low_h2=True` 4-tuple) are
+  unchanged. A trait solved via the ANOVA-based or no-variance path carries no such
+  keys, since no fitted mixed-model result exists for those paths.
+
 ## [0.1.0a5] - 2026-07-13 (Pre-release)
 
 ### Added

--- a/docs/QC_PIPELINE_GUIDE.md
+++ b/docs/QC_PIPELINE_GUIDE.md
@@ -143,6 +143,8 @@ The QC pipeline executes 10 steps in sequence:
 ### Analysis Files
 - `08_anova_results.csv` - ANOVA F-statistics and p-values
 - `08_heritability_results.csv` - Heritability estimates (H²) per trait
+- `08_blup_adjusted_means.csv` - BLUP-adjusted genotype means per trait (when
+  `generate_blup_table` and `calculate_heritability` are both enabled)
 - `08_trait_statistics.json` - Descriptive statistics for all traits
 - `10_pipeline_summary.json` - Complete pipeline execution summary
 

--- a/docs/result-types.md
+++ b/docs/result-types.md
@@ -71,6 +71,7 @@ exported as the constants `ALGORITHM_KMEANS` / `ALGORITHM_GMM` / `ALGORITHM_HIER
 | `KMeansResult` / `GMMResult` (subclasses of `ClusterResult`) | `perform_kmeans_clustering` / `perform_gmm_clustering` dict | `ClusterResult.from_kmeans_dict(d, *, random_state)` / `from_gmm_dict(...)` |
 | `HierarchicalResult` (subclass of `ClusterResult`) | `hierarchical_cluster_labels` dict | `ClusterResult.from_hierarchical_dict(d)` (no `random_state` — hierarchical is deterministic) |
 | `UMAPResult` | `perform_umap_analysis` dict | `UMAPResult.from_umap_dict(d, *, random_state=None)` |
+| `BLUPResult` | `extract_blup_table` DataFrame | `BLUPResult.from_blup_table(df, *, intercepts=None)` |
 
 All are exported from the top-level `sleap_roots_analyze` namespace and `__all__`.
 

--- a/openspec/changes/add-blup-extraction/design.md
+++ b/openspec/changes/add-blup-extraction/design.md
@@ -1,0 +1,275 @@
+## Context
+
+`calculate_heritability_estimates` (`statistics.py:195-448`) fits
+`smf.mixedlm("value ~ 1", model_data, groups=genotype)` per trait with REML and
+extracts only `result.cov_re` (σ²_G) and `result.scale` (σ²_E) to compute H².
+`result.random_effects` — a dict mapping genotype → estimated random effect
+(the BLUP) — is a lazy property on the same fitted `result` object and is
+never touched. This is the entry point for Tier 1 of the wheat EDPIE
+cross-platform genotype prediction program (see `c:\vaults\sleap-roots\
+wheat-edpie-paper\cross-platform-prediction\{roadmap,theory}.md`, external to
+this repo): BLUP-adjusted genotype means are the predictor substrate for later
+tiers (ridge/PLS + leave-one-genotype-out CV across platforms), which are out
+of scope here.
+
+The serializable-result-types epic (#130) already established the pattern this
+change follows: `PCAResult`, `HeritabilityResult`, `ClusterResult`/
+`KMeansResult`/`GMMResult`, and `UMAPResult` are frozen dataclasses built from
+a legacy dict via a `from_*_dict()` adapter, holding only JSON-native fields
+with a `to_json(allow_nan=False)` finite-floats contract. `HeritabilityResult`
+in particular already separates succeeded traits (`per_trait`) from failed
+ones (`failed_traits`, names only) — the direct precedent for how `BLUPResult`
+handles a trait whose mixed model failed.
+
+The roadmap flagged one design question as blocking for this tier: return
+BLUPs inside the existing heritability dict, or as a new `BLUPResult`
+dataclass? This was resolved via `superpowers:brainstorming` this session (see
+resolutions below), after reading `result_types.py` to confirm the existing
+pattern.
+
+## Goals / Non-Goals
+
+- **Goals:** extract `result.random_effects` (accessed exactly once per
+  successful trait fit) and `result.fe_params["Intercept"]`; a genotype ×
+  trait adjusted-means table (`extract_blup_table()`) with a genuine `NaN`
+  column for failed traits; a `BLUPResult` dataclass satisfying the
+  finite-floats contract; a `08_blup_adjusted_means.csv` pipeline output behind a
+  default-`True` config flag; no breaking changes to
+  `calculate_heritability_estimates`'s two existing return shapes.
+- **Non-Goals:** changing the H² formula or variance-component extraction;
+  Tier 2's fixed-effects formula change (`R_j` handling); any LOGO-CV,
+  ridge/PLS, or prediction machinery (Tier 3+); a new pipeline step (BLUP
+  output is folded into the existing `StatisticalAnalysisStep`, not a separate
+  step); reconciling `08_blup_adjusted_means.csv`'s trait set with
+  `FilterHeritabilityStep`'s later low-H² trait removal — `StatisticalAnalysisStep`
+  always calls `calculate_heritability_estimates(..., remove_low_h2=False)`
+  (heritability-based filtering is Step 9, not Step 8), so the BLUP CSV
+  intentionally includes columns for traits a later step may drop from the
+  final high-heritability trait set. Reconciling the two is a Tier 2+ concern.
+
+## Decisions
+
+### Decision 1: `blup`/`intercept` are additive keys, not a new opt-in parameter
+
+**What:** When a trait's mixed model succeeds, its per-trait result dict gains
+`blup: dict[str, float]` and `intercept: float`, unconditionally — no new
+parameter on `calculate_heritability_estimates`.
+
+**Why:** The extraction is free (the model is already fit; accessing
+`result.random_effects` and `result.fe_params` costs nothing beyond what's
+already computed). An opt-in parameter would need to be threaded through the
+one caller (`StatisticalAnalysisStep`) for no benefit, and would let a caller
+silently miss BLUPs by forgetting to pass it. Both existing return shapes
+(dict / 4-tuple) are dicts-of-dicts already, so adding keys to an inner dict
+cannot change the outer shape — genuinely non-breaking.
+
+**Implementation detail that matters for correctness:** the per-trait success
+dict literal at `statistics.py:414-428` is shared by *two* independent success
+paths — the mixed-model branch (`if use_mixed_model:`, has a fitted `result`)
+and the ANOVA-based branch (`else:`, `force_method="anova_based"`, computes
+variance components directly from groupby arithmetic and never calls
+`smf.mixedlm` — no `result` object exists). A third success path, the
+no-variance short-circuit (`subset[trait].nunique() == 1`), builds its own
+dict and `continue`s before reaching that shared literal at all, so it's
+unaffected either way. `blup`/`intercept` MUST be computed as local variables
+inside the mixed-model branch only (defaulting to unset/`None` otherwise) and
+added to the shared dict conditionally — an unconditional
+`result.random_effects` reference at the shared literal would raise
+`UnboundLocalError` whenever a trait takes the ANOVA-based path, since
+`force_method="anova_based"` is a real, user-selectable code path
+(`calculate_heritability_estimates(..., force_method="anova_based")`), not a
+hypothetical.
+
+**Alternatives considered:**
+- **New `extract_blups: bool = False` parameter.** Rejected: more
+  conservative, but adds signature complexity for a change that costs nothing
+  to always perform, and risks the pipeline step forgetting to opt in.
+- **Separate function that refits the same mixedlm models.** Rejected:
+  wastes a full model refit per trait; theory.md is explicit that "the model
+  only needs to be fit once per trait."
+
+### Decision 2: `BLUPResult` dataclass, not BLUPs folded into the heritability dict
+
+**What:** A new frozen `BLUPResult` in `result_types.py`, built via
+`BLUPResult.from_blup_table(df, intercepts=...)` from the `extract_blup_table()`
+DataFrame — not a modification to `HeritabilityResult`'s shape.
+
+**Why:** This was the roadmap's explicitly flagged blocking question,
+recommended answer `BLUPResult`, confirmed by reading `result_types.py`
+first: `HeritabilityResult` is per-trait-shaped (one `TraitHeritability` row
+per trait); BLUPs are genotype × trait-shaped (one row per genotype, columns
+of traits) — a fundamentally different axis of aggregation that doesn't fit
+`HeritabilityResult`'s per-trait row schema. A separate type keeps each
+dataclass's shape aligned with what it actually represents, matching how
+`PCAResult` (component-indexed) and `ClusterResult` (sample-indexed) are
+already separate types for different aggregation axes.
+
+**Alternatives considered:**
+- **Add a `blup_table` field to `HeritabilityResult`.** Rejected: forces a
+  genotype × trait matrix onto a dataclass whose every other field is
+  per-trait-indexed; `from_heritability_dict()` would need a second input
+  shape (the DataFrame) that today's `HeritabilityResult` adapter doesn't
+  take.
+
+### Decision 3: Failed traits — NaN in the CSV, excluded (not NaN) in the dataclass
+
+**What:** `extract_blup_table()` returns a `pd.DataFrame` with a genuine `NaN`
+column for any failed trait (the CSV oracle: "not silently dropped, not
+zero"). `BLUPResult.from_blup_table()` then splits that DataFrame: finite
+columns become `trait_names`/`adjusted_means`; all-`NaN` columns become
+entries in `failed_traits` (names only, no values) and are excluded from the
+numeric matrix.
+
+**Why:** `BLUPResult.to_json()` enforces `allow_nan=False`, matching every
+sibling result type's finite-floats contract. Storing `NaN` inside
+`adjusted_means` would either violate that contract (raise on every normal run
+with any failed trait) or require weakening it (deviating from the shared
+contract other result types enforce, letting a `NaN` leak across the JSON
+boundary a strict consumer like bloom-mcp rejects). Excluding failed columns
+and naming them separately mirrors `HeritabilityResult.per_trait`/
+`failed_traits` exactly — the same split, one level up (genotype × trait
+matrix instead of per-trait scalar).
+
+**Alternatives considered:**
+- **`to_json(allow_nan=True)` override on `BLUPResult` only.** Rejected:
+  breaks the shared contract other result types enforce for no reason other
+  than convenience; the CSV already satisfies the "must show NaN" oracle, so
+  the dataclass doesn't need to duplicate it.
+- **Zero-filled matrix with a boolean success mask.** Rejected: the roadmap
+  oracle explicitly says "not zero" — a placeholder zero risks a consumer
+  reading it as a real adjusted mean if the mask is forgotten.
+
+**Two edge cases the "all-NaN column" framing doesn't cover on its own:**
+- **Cell-level gaps.** `calculate_heritability_estimates` computes each
+  trait's genotype set independently (`subset = df[[trait, genotype_col]].dropna()`
+  per trait), so two *both-succeeded* traits can legitimately cover different
+  genotype sets. A genotype missing from one succeeded trait's `blup` dict but
+  present in another's produces a single `NaN` cell in an otherwise-finite
+  column — not a whole failed column. `BLUPResult.from_blup_table()` treats
+  this the same as a fully-failed trait (excluded from `trait_names`, name in
+  `failed_traits`): a column needs to be *entirely* finite to enter the
+  always-finite matrix, so a partially-finite column is not eligible either.
+  This is simpler than a per-cell exception and preserves the "matrix is
+  rectangular and complete" property `PCAResult`/`ClusterResult` also rely on.
+- **Zero succeeded traits.** `pd.Series([], dtype=float).notna().all()`
+  evaluates to `True` in pandas (vacuous truth) — so a naive
+  `df[col].notna().all()` partition would misclassify an all-failed-traits
+  input (zero genotype universe, zero-row columns) as "all succeeded." The
+  adapter's partition logic must explicitly special-case a zero-row column as
+  failed, not rely on `.notna().all()` alone.
+
+### Decision 4: Module placement — `statistics.py` / `result_types.py` split
+
+**What:** `extract_blup_table()` lives in `statistics.py`; `BLUPResult` lives
+in `result_types.py`. No new `blup.py` module.
+
+**Why:** Matches the existing one-way dependency rule stated in
+`result_types.py`'s module docstring ("this module imports nothing from the
+analytical modules") and the precedent of every other analytical
+function/result-type pair (`perform_pca_analysis`/`PCAResult`,
+`calculate_heritability_estimates`/`HeritabilityResult`,
+`perform_umap_analysis`/`UMAPResult`).
+
+**Alternatives considered:**
+- **New `blup.py` module** for both. Rejected for Tier 1: no evidence yet that
+  BLUP logic needs a dedicated file; if Tier 2/3 substantially grow the BLUP
+  surface, this can be revisited then without churn now.
+
+### Decision 5: Config flag on `StatisticsConfig`, default `True`
+
+**What:** `StatisticsConfig.generate_blup_table: bool = True`, gated on
+`calculate_heritability` also being `True`.
+
+**Why:** `StatisticsConfig` already owns `calculate_heritability` (the flag
+this one is a free byproduct of); grouping them keeps the gating relationship
+in one dataclass. Default `True` per the roadmap ("free once the model is
+fit") and matches how a brand-new pipeline run should get the new CSV without
+any config change — purely additive from a user's point of view.
+
+**Alternatives considered:**
+- **New field on `HeritabilityConfig`** (alongside `generate_diagnostics`).
+  Rejected: `HeritabilityConfig.enabled` gates *filtering*, a downstream step
+  (`FilterHeritabilityStep`) — BLUP extraction happens in
+  `StatisticalAnalysisStep`, before filtering, and depends only on
+  `calculate_heritability`, not on whether filtering is enabled. Coupling it to
+  `HeritabilityConfig` would make BLUP output depend on a step it doesn't
+  actually run before.
+- **Warn (not raise) when `generate_blup_table=True` and
+  `calculate_heritability=False`**, mirroring the `umap.enabled`-on-an-
+  unwired-path precedent (`pipeline/config/utils.py` warns that setting
+  "will be ignored"). Tried first, then rejected on closer inspection during
+  round-2 review: the analogy doesn't hold up. `umap.enabled` defaults
+  `False`, so its warning only fires on a rare, deliberate opt-in into a
+  feature that would otherwise look silently broken. `generate_blup_table`
+  defaults `True`, so the equivalent warning would fire whenever a user does
+  the ordinary, legitimate thing of disabling heritability — confirmed
+  concretely: four existing tests in `tests/test_step_statistical_analysis.py`
+  already construct exactly this configuration
+  (`calculate_heritability=False`, `generate_blup_table` left at its default)
+  and would start emitting the warning on every run once implemented.
+  Warning from both `validate_viz_config()` (config-load time) and the step's
+  runtime path (needed for the QC pipeline, which has no config-validation
+  entry point) also meant a Viz-pipeline user would see the same warning fire
+  twice per run. Unlike `umap.enabled` (an explicit opt-in into a stub),
+  "BLUPs need the same model fit heritability does" is a self-evident
+  consequence already stated in the config field's own docstring — closer to
+  the *already-accepted* silent no-op precedent
+  (`calculate_heritability=True` + `heritability.enabled=False`) than to the
+  UMAP stub case.
+
+**Decision (revised after round-2 review): silent no-op, documented in the
+config field's docstring, no warning.** `generate_blup_table=True` while
+`calculate_heritability=False` simply produces no BLUP output — no exception,
+no warning — consistent with the project's other "one flag makes another
+irrelevant" precedent.
+
+## Risks / Trade-offs
+
+- **`StatisticalAnalysisStep` runs in both the QC and Viz pipelines, but only
+  `VizPipelineConfig` composes `StatisticsConfig`.** `QCPipelineConfig` has no
+  `statistics` field; the step already resolves this for
+  `calculate_heritability` via `getattr(config, "statistics", None)`
+  (defaulting to `True` when absent). `generate_blup_table` must use the same
+  guard, or reading `config.statistics.generate_blup_table` directly raises
+  `AttributeError` on every QC-pipeline run — this is not a hypothetical edge
+  case, it is the primary pipeline's default code path.
+- **Two boolean flags gating one output** (`calculate_heritability` and
+  `generate_blup_table`) could confuse a user who sets `generate_blup_table=
+  True` while `calculate_heritability=False` and gets no CSV. A warning was
+  tried first (see Decision 5) but reversed after round-2 review found it
+  would fire on every run of an ordinary, legitimate configuration
+  (heritability disabled), not just a rare deliberate misconfiguration —
+  concretely demonstrated by four existing tests that already hit this
+  combination, and it would additionally double-fire for the Viz pipeline
+  (once in `validate_viz_config()`, once at runtime). Mitigated instead by
+  clear docstring documentation on `StatisticsConfig.generate_blup_table`
+  stating the dependency explicitly, consistent with the project's other
+  accepted silent-no-op precedent (`calculate_heritability=True` +
+  `heritability.enabled=False`).
+- **`BLUPResult.intercepts` duplicates information also derivable from
+  `adjusted_means` and a genotype's raw BLUP** — kept as an explicit field
+  (not reconstructed) because the raw per-genotype BLUP values themselves are
+  *not* stored on `BLUPResult` (only the already-summed adjusted means are),
+  so `intercepts` is the only way to recover `blup[g] = adjusted_means[g] -
+  intercepts[trait]` if a future consumer needs the decomposition.
+- **`extract_blup_table()` takes the `heritability_results` dict, not raw
+  data** — consistent with the accepted precedent from
+  `add-heritability-diagnostics` (Decision 1 in that design: "Diagnostic
+  Functions Accept Pre-Calculated Results... avoids redundant computation").
+
+## Migration Plan
+
+Purely additive — no existing caller changes required:
+- `calculate_heritability_estimates` callers reading `result[trait]["heritability"]`
+  etc. are unaffected by the new `blup`/`intercept` keys.
+- `StatisticalAnalysisStep` gains one new output file, on by default; a config
+  that doesn't set `generate_blup_table` gets it for free.
+- `BLUPResult` and `extract_blup_table` are new, opt-in surface.
+
+No rollback concerns beyond reverting the additive commits — no existing
+behavior is modified.
+
+## Open Questions
+
+None blocking Tier 1. Tier 2's `R_j` (fixed vs. random effect) question is
+answered tentatively in `proposal.md` for continuity but is out of scope here.

--- a/openspec/changes/add-blup-extraction/proposal.md
+++ b/openspec/changes/add-blup-extraction/proposal.md
@@ -1,0 +1,155 @@
+## Why
+
+The QC pipeline fits a linear mixed model (`statsmodels MixedLM` with REML) in
+`calculate_heritability_estimates` (`src/sleap_roots_analyze/statistics.py:195-448`)
+to estimate broad-sense heritability (H²), but discards the fitted model's random
+effects. These random effects are BLUPs (Best Linear Unbiased Predictions) —
+shrinkage-adjusted genotype estimates that are more reliable than raw genotype
+means, especially for unbalanced designs (the wheat EDPIE field platform has
+n=2-3 reps per genotype). `result.random_effects` is a lazy property that is
+never accessed today even though the model is already fit.
+
+This is Tier 1 (`add-blup-extraction`, tracking issue
+[talmolab/sleap-roots-analyze#109](https://github.com/talmolab/sleap-roots-analyze/issues/109))
+of a larger cross-platform genotype prediction program: BLUP-adjusted genotype
+means are the predictor substrate that later tiers (ridge/PLS regression with
+leave-one-genotype-out cross-validation, not in scope here) will use to test
+whether one phenotyping platform's genotype effects predict another's. See the
+program roadmap and statistical grounding at
+`c:\vaults\sleap-roots\wheat-edpie-paper\cross-platform-prediction\{roadmap,theory}.md`
+(external to this repo; referenced here for provenance only).
+
+## What Changes
+
+- **Extract BLUPs during the existing model fit.** In
+  `calculate_heritability_estimates`, when a trait's mixed model succeeds
+  (`model_type == "mixed_model"`), add two keys to that trait's per-trait
+  result dict: `blup` (a `dict[genotype, float]` from `result.random_effects`,
+  accessed exactly once) and `intercept`
+  (`float(result.fe_params["Intercept"])`). Purely additive — both existing
+  return shapes (plain dict when `remove_low_h2=False`; 4-tuple when
+  `remove_low_h2=True`) are unchanged, no new parameter, no signature change.
+  The function has two other success paths that reach the same shared
+  per-trait dict literal without ever fitting a mixed model — the ANOVA-based
+  path (`force_method="anova_based"`) and the no-variance short-circuit — and
+  those traits correctly get no `blup`/`intercept` keys, since there is no
+  `result.random_effects` to extract for them.
+- **Add `extract_blup_table()`** — a new function in `statistics.py` that
+  builds a genotype × trait adjusted-means `pd.DataFrame` from a
+  `heritability_results` dict: `adjusted_mean[g, trait] = intercept + blup[g]`
+  for succeeded traits; a genuine `NaN` column (not dropped, not zero-filled)
+  for any trait whose model failed, used the ANOVA-based/no-variance path, or
+  was skipped. Handles the run-level short-circuit form (`{"error": ...}`,
+  no per-trait entries) and the zero-succeeded-traits case without raising.
+- **Add `BLUPResult`** — a new frozen `@dataclass` in `result_types.py`,
+  following the `PCAResult`/`HeritabilityResult`/`UMAPResult` pattern exactly
+  (`to_dict()`/`to_json(allow_nan=False)` finite-float contract). Fields:
+  `genotype_names`, `trait_names` (succeeded traits only), `adjusted_means`
+  (always-finite `list[list[float]]`), `failed_traits` (names only, mirrors
+  `HeritabilityResult.failed_traits`), `intercepts`. Built via the classmethod
+  `BLUPResult.from_blup_table(df, intercepts=...)`, which drops `NaN` columns
+  into `failed_traits` so the dataclass's numeric matrix is always finite even
+  though the source CSV/DataFrame carries real `NaN`s. A column needs to be
+  *entirely* finite to count as succeeded — even a single cell-level gap (a
+  genotype covered by one succeeded trait's model but not another's, since
+  each trait's genotype set is computed independently) reclassifies that
+  whole trait into `failed_traits`, identically to a trait whose model failed
+  outright.
+- **Add config flag** `StatisticsConfig.generate_blup_table: bool = True`
+  (`pipeline/config/components.py`), gated on `calculate_heritability` also
+  being `True`. Setting `generate_blup_table=True` while
+  `calculate_heritability=False` does not raise and does not warn — it simply
+  produces no BLUP output, since there is no model fit to extract from. (A
+  warning mirroring the `umap.enabled` precedent was considered and rejected
+  after round-2 review — see `design.md` Decision 5: that precedent defaults
+  `False` and gates a rare, deliberate opt-in, whereas `generate_blup_table`
+  defaults `True` and the inert combination arises from the ordinary act of
+  disabling heritability.)
+- **Pipeline output**: `StatisticalAnalysisStep`
+  (`pipeline/steps/statistical_analysis.py`) writes `08_blup_adjusted_means.csv`
+  to `run_dir/data/` alongside `08_heritability_results.csv` when both config
+  flags are enabled. `StatisticalAnalysisStep` runs in **both** the QC
+  pipeline (`qc_pipeline.py`) and the Viz pipeline (`viz_pipeline.py`), but
+  only `VizPipelineConfig` composes `StatisticsConfig` — `QCPipelineConfig` has
+  no `statistics` field at all. The step already resolves this for
+  `calculate_heritability` via `getattr(config, "statistics", None)`
+  (defaulting to `True` when absent, at `statistical_analysis.py:154-159`);
+  `generate_blup_table` must be resolved with the same guard, so a QC-pipeline
+  run always gets the default for both flags and cannot configure
+  `generate_blup_table` any other way. The CSV write itself belongs in the
+  step's *second* `if calculate_heritability:` block (the one that already
+  writes `08_heritability_results.csv`, after `data_dir`/`files` exist), not
+  the earlier block that only computes `heritability_results`.
+- **Public exports**: `extract_blup_table` and `BLUPResult` are exported from
+  the package root and `__all__`, per the existing statistics-api /
+  serializable-result-types conventions.
+
+No breaking changes — every change is additive (new dict keys, a new
+function, a new dataclass, a new config field defaulting to the
+already-enabled behavior, a new output file). Existing callers of
+`calculate_heritability_estimates`, `StatisticalAnalysisStep`, and
+`StatisticsConfig` continue to work unchanged.
+
+## Design decisions (resolved via brainstorming this session — full rationale and alternatives considered in `design.md`)
+
+- `BLUPResult` dataclass, not BLUPs folded into the existing heritability
+  dict — the roadmap's flagged blocking question for Tier 1, resolved by
+  reading `result_types.py` first.
+- `blup`/`intercept` are added unconditionally (no new opt-in parameter) —
+  the extraction is free and purely additive, but only for traits whose fit
+  is `model_type == "mixed_model"`.
+- Failed-trait handling splits by artifact: the CSV keeps a genuine `NaN`
+  column; `BLUPResult` excludes failed columns and lists their names in
+  `failed_traits`.
+- Module placement matches the existing analytical/result-type split:
+  `extract_blup_table()` in `statistics.py`, `BLUPResult` in
+  `result_types.py`.
+- Config flag on `StatisticsConfig` (not a new `BLUPConfig`, not on
+  `HeritabilityConfig`), default `True`, silent no-op (documented in its
+  docstring) when it's inert — a warning was tried and reversed, see
+  `design.md` Decision 5.
+- **Tier 2 continuity note (non-blocking for Tier 1)**: the roadmap's open
+  question about `R_j` (field block/replicate) will be answered in Tier 2
+  (`add-heritability-fixed-effects`, #114) as a **fixed effect** via a new
+  `fixed_effects` parameter (`value ~ <fixed_effects> + (1|genotype)`), not a
+  second random effect — no re-architecture of Tier 1's BLUP extraction is
+  needed.
+
+## Impact
+
+### Affected specs
+
+- `statistics-api` (MODIFIED) — `extract_blup_table` added to the public
+  surface (9 functions total); `calculate_heritability_estimates`'s additive
+  `blup`/`intercept` keys documented as non-breaking.
+- `serializable-result-types` (ADDED + MODIFIED) — `BLUPResult` type, adapter,
+  and public export (ADDED); `calculate_heritability_estimates`'s additive
+  `blup`/`intercept` keys folded into the existing "Non-Breaking Heritability
+  Return Shape" requirement (MODIFIED).
+- `config-management` (ADDED) — `StatisticsConfig.generate_blup_table` gating
+  behavior.
+
+### Affected code
+
+- `src/sleap_roots_analyze/statistics.py` — extract BLUPs in
+  `calculate_heritability_estimates`; add `extract_blup_table()`
+- `src/sleap_roots_analyze/result_types.py` — add `BLUPResult`
+- `src/sleap_roots_analyze/pipeline/config/components.py` — add
+  `StatisticsConfig.generate_blup_table`
+- `src/sleap_roots_analyze/pipeline/steps/statistical_analysis.py` — write
+  `08_blup_adjusted_means.csv`
+- `src/sleap_roots_analyze/__init__.py` — root exports + `__all__`
+- `docs/API.md`, `docs/result-types.md`, `docs/CHANGELOG.md`,
+  `docs/QC_PIPELINE_GUIDE.md` (Analysis Files output list)
+- `tests/test_statistics.py`, `tests/test_blup_result.py` (new, mirrors
+  `tests/test_heritability_result.py`), `tests/fixtures.py` (new unbalanced-reps
+  fixture), `tests/test_step_statistical_analysis.py`, `tests/test_public_api.py`
+
+### Explicitly out of scope
+
+- Tier 2 (`add-heritability-fixed-effects`, #114): fixed-effects param, R_j
+  handling.
+- Tier 3+ (LOGO-CV, prediction pipeline, permutation nulls, figures): separate
+  future changes.
+- Any change to `calculate_heritability_estimates`'s H² formula or existing
+  variance-component behavior.

--- a/openspec/changes/add-blup-extraction/specs/config-management/spec.md
+++ b/openspec/changes/add-blup-extraction/specs/config-management/spec.md
@@ -1,0 +1,95 @@
+## ADDED Requirements
+
+### Requirement: BLUP Table Output Config Gating
+
+`StatisticsConfig` SHALL expose `generate_blup_table: bool = True`, controlling
+whether `StatisticalAnalysisStep` writes `08_blup_adjusted_means.csv`. This flag
+SHALL only take effect when `calculate_heritability` is also `True` — BLUP
+extraction reuses the same mixed-model fit as heritability, so it cannot run
+independently of it. Setting `generate_blup_table=True` while
+`calculate_heritability=False` SHALL NOT raise (unlike the contradictory
+`heritability.enabled`/`calculate_heritability` combination, which raises) and
+SHALL NOT warn — it SHALL simply produce no BLUP output, since there is no
+model fit to extract from. This mirrors the project's other accepted
+"one flag makes another irrelevant" precedent (`calculate_heritability=True`
++ `heritability.enabled=False`), rather than the `umap.enabled`-on-an-unwired-
+path warning precedent: unlike that case (a rare, deliberate opt-in into a
+feature that would otherwise look silently broken), `generate_blup_table`
+defaults `True`, so a warning would fire on the ordinary, common act of
+disabling heritability. The dependency SHALL instead be documented in the
+field's own docstring.
+
+`StatisticalAnalysisStep` runs in both the QC pipeline (`qc_pipeline.py`) and
+the Viz pipeline (`viz_pipeline.py`). Only `VizPipelineConfig` composes
+`StatisticsConfig`; `QCPipelineConfig` has no `statistics` field. The step
+already resolves this via `getattr(config, "statistics", None)`, treating a
+QC-pipeline config (which has no `statistics` field to set) as
+`calculate_heritability=True` by default — `generate_blup_table` SHALL be
+resolved the same way, so a QC-pipeline run always gets the default (`True`)
+for both flags and cannot configure `generate_blup_table` any other way.
+
+#### Scenario: Both flags enabled — CSV is written
+
+- **WHEN** a pipeline runs `StatisticalAnalysisStep` with
+  `statistics.calculate_heritability=True` and
+  `statistics.generate_blup_table=True` (the defaults)
+- **THEN** `08_blup_adjusted_means.csv` SHALL be written to the run's `data/`
+  directory
+- **AND** its row count SHALL equal the number of distinct genotypes in the
+  input data
+- **AND** its column count SHALL equal the number of trait columns passed to
+  the step, including any trait whose heritability estimation failed (those
+  columns are `NaN`, per `extract_blup_table()`'s contract) — not just the
+  traits that succeeded
+
+#### Scenario: generate_blup_table disabled — no CSV
+
+- **WHEN** a pipeline runs `StatisticalAnalysisStep` with
+  `statistics.calculate_heritability=True` and
+  `statistics.generate_blup_table=False`
+- **THEN** `08_blup_adjusted_means.csv` SHALL NOT be written
+- **AND** `08_heritability_results.csv` SHALL still be written unchanged
+
+#### Scenario: calculate_heritability disabled — no CSV, no warning, no exception
+
+- **WHEN** a pipeline runs `StatisticalAnalysisStep` with
+  `statistics.calculate_heritability=False` and
+  `statistics.generate_blup_table=True` (the default)
+- **THEN** `08_blup_adjusted_means.csv` SHALL NOT be written
+- **AND** no exception SHALL be raised
+- **AND** no warning SHALL be issued — this is an ordinary, legitimate
+  configuration (heritability disabled entirely), not a misconfiguration to
+  flag
+
+#### Scenario: calculate_heritability disabled and generate_blup_table also disabled — no CSV
+
+- **WHEN** a pipeline runs `StatisticalAnalysisStep` with
+  `statistics.calculate_heritability=False` and
+  `statistics.generate_blup_table=False`
+- **THEN** `08_blup_adjusted_means.csv` SHALL NOT be written
+- **AND** no exception or warning SHALL be raised
+
+#### Scenario: Default config produces BLUP output
+
+- **WHEN** a `StatisticsConfig` is constructed with default values
+  (`calculate_heritability=True`, `generate_blup_table=True`)
+- **THEN** `StatisticalAnalysisStep` SHALL write `08_blup_adjusted_means.csv`
+- **AND** existing configs that do not set `generate_blup_table` explicitly
+  SHALL get this default (backward-compatible, additive behavior — an
+  existing pipeline run gains one new output file with no other change)
+
+#### Scenario: QC-pipeline config has no way to configure generate_blup_table
+
+- **WHEN** `StatisticalAnalysisStep.execute()` runs with a `QCPipelineConfig`
+  (which has no `statistics` field)
+- **THEN** `generate_blup_table` SHALL resolve to `True` (the same default
+  fallback already used for `calculate_heritability` when `config.statistics`
+  is absent)
+- **AND** the implementation MUST resolve this via a
+  `getattr(config, "statistics", None)` guard rather than a direct
+  `config.statistics.generate_blup_table` attribute access — the latter would
+  raise `AttributeError` on `.statistics` itself, before `.generate_blup_table`
+  is ever reached, since `QCPipelineConfig` has no `statistics` attribute at
+  all
+- **AND** `StatisticalAnalysisStep.execute()` SHALL NOT raise `AttributeError`
+  when run with such a config

--- a/openspec/changes/add-blup-extraction/specs/serializable-result-types/spec.md
+++ b/openspec/changes/add-blup-extraction/specs/serializable-result-types/spec.md
@@ -1,0 +1,217 @@
+## MODIFIED Requirements
+
+### Requirement: Non-Breaking Heritability Return Shape
+
+Neither adding `HeritabilityResult` nor extracting BLUPs SHALL change the
+return shape of `calculate_heritability_estimates()`; the function SHALL keep
+returning its existing dict / tuple (a plain `dict` when
+`remove_low_h2=False`, or a 4-tuple `(heritability_results, df_filtered,
+removed_traits, removal_details)` when `remove_low_h2=True`) so all current
+callers continue to work unchanged. BLUP extraction MAY add `blup`
+(`dict[str, float]`) and `intercept` (`float`) keys to a trait's own
+per-trait dict, but only when that trait's mixed model fit succeeds
+(`model_type == "mixed_model"`); a trait solved via the ANOVA-based path
+(`model_type == "anova_based"`), the no-variance short-circuit (`model_type ==
+"no_variance"`), or any error path SHALL NOT carry `blup`/`intercept` keys,
+since no fitted mixed-model `result` object exists for those paths.
+`result.random_effects` SHALL be accessed exactly once per successful trait
+fit.
+
+#### Scenario: Existing heritability return is preserved and not mutated
+
+- **WHEN** `calculate_heritability_estimates()` is called with
+  `remove_low_h2=False`
+- **THEN** it SHALL return the existing trait-keyed dict (including the
+  `__calculation_metadata__` entry)
+- **AND** calling `HeritabilityResult.from_heritability_dict(d, threshold)` SHALL
+  leave `d`'s keys and values unchanged
+- **AND** the `HeritabilityResult` view SHALL be opt-in, built only via
+  `HeritabilityResult.from_heritability_dict()`
+
+#### Scenario: Existing dict return is preserved and only additively extended with BLUPs
+
+- **WHEN** `calculate_heritability_estimates(df, trait_cols, ...)` is called
+  with `remove_low_h2=False` (the default) and a trait's mixed model succeeds
+- **THEN** the returned `dict`'s per-trait entry SHALL still contain the
+  existing keys (`heritability`, `var_genetic`, `var_residual`, `mean_n_reps`,
+  `n_genotypes`, `n_observations`, `model_type`, `reps_per_geno_stats`)
+- **AND** it SHALL additionally contain `blup` (a `dict[str, float]` keyed by
+  genotype label) and `intercept` (a `float`)
+- **AND** the top-level return type SHALL remain a plain `dict`
+
+#### Scenario: remove_low_h2=True keeps its 4-tuple shape with BLUP keys
+
+- **WHEN** `calculate_heritability_estimates(df, trait_cols, ..., remove_low_h2=True)`
+  is called
+- **THEN** the return value SHALL still be a 4-tuple
+  `(heritability_results, df_filtered, removed_traits, removal_details)`
+- **AND** `heritability_results`'s per-trait entries SHALL carry the same
+  additive `blup`/`intercept` keys as the `remove_low_h2=False` case, even for
+  traits later dropped from `df_filtered`/`removed_traits` (heritability-based
+  trait removal filters the DataFrame; it does not strip keys from
+  `heritability_results`)
+
+#### Scenario: A trait whose mixed model fit fails carries no blup/intercept keys
+
+- **WHEN** a trait's mixed model fit raises (caught internally, recorded as
+  `{"error": ..., "model_type": "mixed_model_failed"}`)
+- **THEN** that trait's per-trait dict SHALL NOT contain a `blup` or
+  `intercept` key
+
+#### Scenario: A trait solved via the ANOVA-based or no-variance path carries no blup/intercept keys
+
+- **WHEN** a trait succeeds via `force_method="anova_based"` (`model_type ==
+  "anova_based"`) or via the no-variance short-circuit (`model_type ==
+  "no_variance"`, all values identical)
+- **THEN** that trait's per-trait dict SHALL NOT contain a `blup` or
+  `intercept` key
+- **AND** no exception SHALL be raised while producing that trait's result,
+  even though no fitted mixed-model `result` object exists for it
+
+## ADDED Requirements
+
+### Requirement: Serializable BLUP Result Type
+
+The package SHALL provide a frozen stdlib `@dataclass` `BLUPResult` in
+`result_types.py` that captures only the JSON-serializable science of an
+`extract_blup_table()` run: the genotype × trait adjusted-means matrix for
+traits whose mixed model succeeded, plus the names of traits that failed.
+Every scalar field SHALL be a native Python type (`int`, `float`, `str`) —
+not a numpy or pandas scalar — and every array field a (nested) list thereof,
+so that `json.dumps(dataclasses.asdict(result))` succeeds without a custom
+serializer. `BLUPResult` SHALL provide `to_dict()` and `to_json()` (the
+`allow_nan=False` finite-floats contract, matching `PCAResult`/
+`HeritabilityResult`/`UMAPResult`).
+
+`BLUPResult`'s fields are: `genotype_names: list[str]`, `trait_names: list[str]`
+(only traits whose model succeeded — failed traits are excluded from this list
+and from `adjusted_means`), `adjusted_means: list[list[float]]` (shape
+`(n_genotypes, n_traits)`, aligned to `genotype_names` × `trait_names`, always
+finite), `failed_traits: list[str]` (names only, no values — mirrors
+`HeritabilityResult.failed_traits`), and `intercepts: dict[str, float]` (one
+entry per succeeded trait in `trait_names`).
+
+#### Scenario: BLUPResult round-trips through JSON as native types
+
+- **WHEN** a `BLUPResult` is built from an `extract_blup_table()` DataFrame via
+  `BLUPResult.from_blup_table()` and passed to
+  `json.dumps(dataclasses.asdict(result))`
+- **THEN** the call SHALL succeed without raising
+- **AND** parsing the string back with `json.loads` SHALL yield every element of
+  `genotype_names` and `trait_names` and `failed_traits` as a Python `str`,
+  every element of `adjusted_means` as a Python `float`, and every value in
+  `intercepts` as a Python `float`
+- **AND** the round-tripped `adjusted_means` values SHALL equal the input
+  values within floating-point tolerance
+
+#### Scenario: Fields are native types before serialization
+
+- **WHEN** the `BLUPResult` dataclass fields are inspected directly, before any
+  JSON serialization
+- **THEN** every element of `genotype_names`, `trait_names`, and
+  `failed_traits` SHALL be a native `str`, every element of `adjusted_means` a
+  native `float`, and every value of `intercepts` a native `float` — not a
+  numpy or pandas scalar (a JSON round-trip would silently cast a leaked
+  `np.float64` to `float`, so this check MUST be pre-serialization)
+
+#### Scenario: A failed trait never appears as NaN in the dataclass
+
+- **GIVEN** an `extract_blup_table()` DataFrame with a genuine `NaN` column for
+  a failed trait
+- **WHEN** `BLUPResult.from_blup_table()` builds the result
+- **THEN** that trait's name SHALL appear in `failed_traits`
+- **AND** that trait SHALL NOT appear in `trait_names`
+- **AND** `adjusted_means` SHALL contain no `NaN`/`Infinity` value contributed
+  by that trait
+- **AND** `to_json()` SHALL succeed without raising (the finite-floats
+  contract is satisfied even though the source table has a NaN column)
+
+#### Scenario: A cell-level NaN (partial genotype coverage) also excludes that trait as failed
+
+- **GIVEN** an `extract_blup_table()` DataFrame where a trait's column has
+  finite values for most genotypes but `NaN` for one genotype absent from that
+  trait's `blup` dict (see the cell-level-NaN scenario under "BLUP
+  Adjusted-Means Table Extraction")
+- **WHEN** `BLUPResult.from_blup_table()` builds the result
+- **THEN** that trait SHALL be classified as failed (its name in
+  `failed_traits`, excluded from `trait_names` and `adjusted_means`) — a
+  partially-finite column is not eligible to appear in the always-finite
+  matrix
+
+#### Scenario: Zero succeeded traits produce an empty (not misclassified) result
+
+- **GIVEN** an `extract_blup_table()` DataFrame with zero rows (no genotype
+  universe, because every trait failed) and one column per input trait
+- **WHEN** `BLUPResult.from_blup_table()` builds the result
+- **THEN** every column SHALL be classified as failed (`failed_traits`
+  contains all trait names, `trait_names` and `adjusted_means` are empty) —
+  a zero-row column SHALL NOT be treated as vacuously finite
+- **AND** `genotype_names` SHALL be an empty list
+- **AND** `to_json()` SHALL succeed without raising
+
+#### Scenario: to_json rejects a non-finite adjusted mean
+
+- **WHEN** `to_json()` is called on a `BLUPResult` constructed directly (not via
+  the adapter) with a non-finite value (`NaN` or `Infinity`) in
+  `adjusted_means`
+- **THEN** a `ValueError` SHALL be raised (under the default `allow_nan=False`)
+  rather than emitting the non-standard `NaN`/`Infinity` tokens a strict JSON
+  consumer rejects
+
+### Requirement: BLUPResult Adapter From The BLUP Table
+
+The package SHALL provide `BLUPResult.from_blup_table(df)` that maps an
+`extract_blup_table()` DataFrame (rows = genotypes, columns = traits, `NaN`
+columns for failed traits) into a `BLUPResult`. A column SHALL be classified
+as succeeded only if it has at least one row AND every value in it is finite;
+a column with zero rows, or with any `NaN`/`Infinity` value (including a
+single cell-level gap in an otherwise-finite column), SHALL be classified as
+failed. The adapter SHALL NOT mutate `df`.
+
+#### Scenario: Adapter splits succeeded and failed trait columns
+
+- **GIVEN** an `extract_blup_table()` DataFrame with some fully-finite trait
+  columns and at least one all-`NaN` trait column
+- **WHEN** `BLUPResult.from_blup_table(df)` is called
+- **THEN** `trait_names` SHALL equal the finite columns, in their original
+  column order
+- **AND** `failed_traits` SHALL equal the all-`NaN` columns, in their original
+  column order
+- **AND** `adjusted_means` SHALL be a nested `list[list[float]]` of shape
+  `(len(genotype_names), len(trait_names))` built only from the finite columns
+
+#### Scenario: genotype_names preserves row order
+
+- **WHEN** `BLUPResult.from_blup_table(df)` is called
+- **THEN** `genotype_names` SHALL equal `[str(g) for g in df.index]`, in the
+  DataFrame's row order
+
+#### Scenario: intercepts covers exactly the succeeded traits
+
+- **GIVEN** a DataFrame produced from `heritability_results` where each
+  succeeded trait's `intercept` is known
+- **WHEN** `BLUPResult.from_blup_table(df, intercepts=...)` is called with that
+  intercept mapping
+- **THEN** `result.intercepts` SHALL contain exactly one entry per name in
+  `trait_names`, with matching float values
+- **AND** `result.intercepts` SHALL NOT contain an entry for any name in
+  `failed_traits`
+
+#### Scenario: Adapter does not mutate the input DataFrame
+
+- **WHEN** `BLUPResult.from_blup_table(df)` is called
+- **THEN** `df`'s values, columns, and index SHALL be unchanged after the call
+
+### Requirement: BLUPResult Public Export
+
+The package SHALL export `BLUPResult` from the top-level `sleap_roots_analyze`
+namespace and list it in `__all__`.
+
+#### Scenario: BLUPResult importable from package root
+
+- **WHEN** a consumer runs `from sleap_roots_analyze import BLUPResult`
+- **THEN** the import SHALL succeed
+- **AND** `"BLUPResult"` SHALL appear in `sleap_roots_analyze.__all__` with no
+  duplicate entries
+- **AND** `BLUPResult` SHALL be importable from `sleap_roots_analyze.result_types`
+  and listed in `result_types.__all__`

--- a/openspec/changes/add-blup-extraction/specs/statistics-api/spec.md
+++ b/openspec/changes/add-blup-extraction/specs/statistics-api/spec.md
@@ -1,0 +1,206 @@
+## MODIFIED Requirements
+
+### Requirement: Public Statistics API Surface
+
+The package SHALL export all heritability, ANOVA, trait-variance, and BLUP
+functions defined in `statistics.py` from the top-level `sleap_roots_analyze`
+namespace so downstream code can import them without reaching into internal
+modules.
+
+#### Scenario: All nine statistics functions are importable from the package root
+
+- **WHEN** a consumer runs `from sleap_roots_analyze import (calculate_trait_statistics, perform_anova_by_genotype, calculate_heritability_estimates, identify_high_heritability_traits, analyze_heritability_thresholds, analyze_trait_variance, diagnose_heritability_issues, compare_trait_heritabilities, extract_blup_table)`
+- **THEN** the import SHALL succeed
+- **AND** each imported object SHALL be identity-equal (`is`) to the function
+  defined in `sleap_roots_analyze.statistics`
+
+#### Scenario: Each function is listed in `__all__` and bound by star import
+
+- **WHEN** `sleap_roots_analyze.__all__` is inspected
+- **THEN** it SHALL contain the name of each of the nine statistics functions
+- **AND** SHALL contain no duplicate entries
+- **AND** `from sleap_roots_analyze import *` SHALL bind each of those names
+
+### Requirement: Resolvable Statistics Type Hints
+
+Each public statistics function SHALL have type hints that resolve at runtime, so
+downstream tool-schema generators that call `typing.get_type_hints()` do not fail.
+
+#### Scenario: get_type_hints succeeds on every public function
+
+- **WHEN** `typing.get_type_hints(fn)` is called on each of the nine functions
+- **THEN** it SHALL return without raising `NameError`
+- **AND** every parameter and the return value SHALL carry a type annotation
+
+### Requirement: Documented Statistics Functions
+
+Each public statistics function SHALL have a complete Google-style docstring, and
+the module SHALL describe its scope, so consumers and tooling can understand the
+contract.
+
+#### Scenario: Every public function has Args and Returns sections
+
+- **WHEN** any of the nine public statistics functions is inspected
+- **THEN** its docstring SHALL include populated Args and Returns sections in
+  Google style (and a Raises section where the function raises)
+- **AND** functions returning structured dictionaries SHALL enumerate the returned
+  keys in the Returns section
+
+#### Scenario: Module docstring distinguishes statistics from cross-experiment analysis
+
+- **WHEN** the `statistics.py` module docstring is read
+- **THEN** it SHALL describe the module's scope (single-experiment heritability,
+  ANOVA, and trait-variance analysis)
+- **AND** it SHALL name `cross_experiment_analysis` to clarify how that scope differs
+
+### Requirement: Statistics API Reference Documentation
+
+The project documentation SHALL keep its hand-maintained API reference and
+changelog in sync with the newly-public statistics functions.
+
+#### Scenario: API reference lists all nine statistics functions
+
+- **WHEN** `docs/API.md` is viewed
+- **THEN** the `## statistics Module` section SHALL include a reference entry for
+  each of the nine statistics functions, including `extract_blup_table`
+- **AND** each entry's documented signature and defaults SHALL match the code
+
+#### Scenario: Changelog records the newly-public API
+
+- **WHEN** `docs/CHANGELOG.md` `[Unreleased]` section is viewed
+- **THEN** it SHALL include an `### Added` entry noting `extract_blup_table` is
+  now importable from `sleap_roots_analyze`
+
+## ADDED Requirements
+
+### Requirement: BLUP Adjusted-Means Table Extraction
+
+The package SHALL provide `extract_blup_table(heritability_results)` in
+`statistics.py` that builds a genotype × trait adjusted-means table from the
+dict returned by `calculate_heritability_estimates()`. For each trait whose
+per-trait entry carries a `blup` dict and an `intercept` float (i.e. the mixed
+model succeeded), the adjusted mean for genotype `g` SHALL be
+`intercept + blup[g]`. For a trait with no `blup`/`intercept` (the model
+failed, errored, used the ANOVA-based or no-variance path, or was skipped),
+the entire column SHALL be `NaN` — not omitted from the table and not
+zero-filled. A genotype absent from one succeeded trait's `blup` dict but
+present in another's (a real possibility, since
+`calculate_heritability_estimates` computes each trait's genotype set
+independently via a per-trait `dropna()`) SHALL produce a cell-level `NaN` for
+that genotype/trait combination, not a row drop or a column-level failure. The
+function SHALL NOT mutate its input, and SHALL NOT raise when
+`heritability_results` is a run-level short-circuit (`{"error": "..."}`, no
+per-trait entries) or when every trait failed (zero succeeded traits).
+
+#### Scenario: Successful traits populate adjusted means
+
+- **GIVEN** a `heritability_results` dict where trait `"trait_a"` has
+  `heritability_results["trait_a"]["blup"] == {"G01": 0.5, "G02": -0.5}` and
+  `heritability_results["trait_a"]["intercept"] == 10.0`
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the returned `pd.DataFrame` SHALL have a row per genotype (`"G01"`,
+  `"G02"`) and a `"trait_a"` column
+- **AND** `df.loc["G01", "trait_a"] == pytest.approx(10.5)` and
+  `df.loc["G02", "trait_a"] == pytest.approx(9.5)`
+
+#### Scenario: Failed-model trait produces a NaN column, not a dropped or zero column
+
+- **GIVEN** a `heritability_results` dict where trait `"trait_failed"` has no
+  `blup` key (e.g. `{"error": "Mixed model failed: ..."}`) while at least one
+  other trait succeeded
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the returned `pd.DataFrame` SHALL still contain a `"trait_failed"`
+  column
+- **AND** every value in that column SHALL be `NaN` (`pd.isna(...).all()`)
+- **AND** no value in that column SHALL be `0.0`
+
+#### Scenario: A trait solved via the ANOVA-based or no-variance path has no BLUP column, without raising
+
+- **GIVEN** a `heritability_results` dict where trait `"trait_anova"` succeeded
+  with `model_type == "anova_based"` (no fitted mixed model exists for this
+  trait, since `force_method="anova_based"` never calls `smf.mixedlm`) or
+  `model_type == "no_variance"` (the trait short-circuited before any model
+  fit), and therefore carries no `blup`/`intercept` keys
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the call SHALL NOT raise
+- **AND** the `"trait_anova"` column SHALL be entirely `NaN`, identically to a
+  failed trait's column
+
+#### Scenario: Row and column shape matches genotypes and traits
+
+- **GIVEN** a `heritability_results` dict where the union of every succeeded
+  trait's `blup.keys()` contains `N` distinct genotypes, and `T` total traits
+  are present (including failed, ANOVA-based, no-variance, and skipped ones)
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the returned `pd.DataFrame` SHALL have exactly `N` rows (indexed by
+  that genotype union, not any single trait's own genotype set) and `T`
+  columns (one per trait, in `trait_cols` order, excluding the
+  `__calculation_metadata__` key)
+
+#### Scenario: A genotype missing from one succeeded trait's blup dict gets a cell-level NaN
+
+- **GIVEN** two traits that both succeed (`model_type == "mixed_model"`), where
+  trait `"trait_a"`'s `blup` dict covers genotypes `{"G01", "G02"}` and trait
+  `"trait_b"`'s `blup` dict covers `{"G01", "G02", "G03"}` (e.g. `"trait_a"`
+  dropped `"G03"`'s only observation as NaN before the model was fit)
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the returned `pd.DataFrame` SHALL have a `"G03"` row
+- **AND** `df.loc["G03", "trait_a"]` SHALL be `NaN` while `df.loc["G03",
+  "trait_b"]` SHALL be a finite adjusted mean — a cell-level gap, distinct from
+  the whole-column `NaN` of a failed trait
+
+#### Scenario: A run-level short-circuit dict produces an empty table without raising
+
+- **GIVEN** `heritability_results == {"error": "Missing required columns: ['geno']"}`
+  (the run-level short-circuit form `calculate_heritability_estimates` returns
+  when required columns are absent, carrying no per-trait entries)
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the call SHALL NOT raise
+- **AND** the returned `pd.DataFrame` SHALL be empty (zero rows, zero columns)
+
+#### Scenario: Zero succeeded traits produce an all-NaN table, not a misclassified one
+
+- **GIVEN** a `heritability_results` dict where every trait failed (no trait
+  carries a `blup` key), so the genotype universe collected from succeeded
+  traits is empty
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the returned `pd.DataFrame` SHALL have zero rows (no genotype
+  universe to index by) and one column per input trait
+- **AND** every column SHALL be treated as failed, not as vacuously "all
+  finite" by virtue of having zero rows
+
+#### Scenario: Input dict is not mutated
+
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** `heritability_results`'s keys and values SHALL be unchanged after the
+  call
+
+### Requirement: BLUP Shrinkage and Balanced-Design Properties
+
+The BLUP-adjusted means produced by `extract_blup_table()` SHALL exhibit the
+mixed-model shrinkage property described in `theory.md`: under a balanced
+design (equal replication per genotype), the adjusted mean SHALL approximate
+the raw genotype mean; under an unbalanced design, genotypes with fewer
+replicates SHALL be shrunk toward the grand mean more than genotypes with more
+replicates.
+
+#### Scenario: Balanced design — adjusted mean approximates the raw genotype mean
+
+- **GIVEN** a balanced dataset (equal replicates per genotype) with a known,
+  non-trivial genetic variance component
+- **WHEN** `calculate_heritability_estimates()` is run and its result passed to
+  `extract_blup_table()`
+- **THEN** for every genotype and trait, the adjusted mean SHALL be within a
+  documented, noise-scaled tolerance of that genotype's raw trait mean
+  (`df.groupby(genotype_col)[trait].mean()`)
+
+#### Scenario: Unbalanced design — low-replicate genotypes shrink further than high-replicate genotypes
+
+- **GIVEN** an unbalanced dataset where some genotypes have substantially fewer
+  replicates than others, with a known genetic variance component
+- **WHEN** `calculate_heritability_estimates()` is run and its result passed to
+  `extract_blup_table()`
+- **THEN** for a low-replicate genotype, `|adjusted_mean - grand_mean|` SHALL be
+  smaller than `|raw_mean - grand_mean|` (shrinkage toward the grand mean)
+- **AND** this shrinkage gap SHALL be larger for low-replicate genotypes than
+  for high-replicate genotypes (shrinkage scales inversely with replication)

--- a/openspec/changes/add-blup-extraction/tasks.md
+++ b/openspec/changes/add-blup-extraction/tasks.md
@@ -1,0 +1,380 @@
+> Test fixtures: reuse `heritability_data_known_h2` (`tests/fixtures.py:182`, balanced —
+> 20 genotypes × 5 reps) for the balanced-BLUP≈raw-mean oracle. Add one new fixture,
+> `heritability_data_unbalanced_reps`, for the shrinkage oracle (task 1.1). Section 1/2
+> tests import `from sleap_roots_analyze.statistics import calculate_heritability_estimates,
+> extract_blup_table` and `from sleap_roots_analyze.result_types import BLUPResult`
+> directly (the package-root export doesn't land until §5).
+
+## 1. Fixtures + `calculate_heritability_estimates` BLUP extraction (test-first)
+
+- [x] 1.1 Add `heritability_data_unbalanced_reps` fixture to `tests/fixtures.py`
+      (mirror `heritability_data_known_h2`'s structure and column names —
+      `geno`/`rep`/`Barcode`, seed 42): a single trait `trait_unbalanced` with a
+      known genetic variance σ²_G=4.0 and residual variance σ²_E=1.0
+      (genotype effect `np.random.normal(0, 2.0)`, per-rep noise
+      `np.random.normal(0, 1.0)`, base value 50). 20 genotypes total: 10
+      "low-rep" genotypes (`G01`-`G10`) with **n=2** reps each, 10 "high-rep"
+      genotypes (`G11`-`G20`) with **n=20** reps each. Return `(df, meta)` where
+      `meta = {"low_rep_genotypes": [...10 ids...], "high_rep_genotypes":
+      [...10 ids...], "trait": "trait_unbalanced"}` — the test computes raw
+      means and the grand mean itself from `df` rather than the fixture
+      pre-computing them, so there's one source of truth.
+- [x] 1.2 Write failing test `test_blup_extracted_for_successful_trait`
+      (`tests/test_statistics.py`, new `TestBLUPExtraction` class): call
+      `calculate_heritability_estimates` on `heritability_data_known_h2`; assert
+      each successful (`model_type == "mixed_model"`) trait's per-trait dict
+      contains `blup` (a `dict` keyed by every genotype label present in the
+      input) and `intercept` (a `float`); assert `type(intercept) is float` and
+      every `blup` value `is float` (guard against a leaked
+      `np.float64`/pandas scalar).
+- [x] 1.3 Write failing test `test_existing_return_shape_unchanged`: with
+      `remove_low_h2=False` (default), the return value is still a plain `dict`
+      containing the pre-existing per-trait keys (`heritability`, `var_genetic`,
+      `var_residual`, `mean_n_reps`, `n_genotypes`, `n_observations`,
+      `model_type`, `reps_per_geno_stats`) unchanged, with `blup`/`intercept`
+      added alongside; with `remove_low_h2=True`, the return value is still the
+      4-tuple `(heritability_results, df_filtered, removed_traits,
+      removal_details)` and `heritability_results`'s per-trait dicts carry the
+      same additive keys — including for a trait present in `removed_traits`
+      (heritability-based removal filters `df_filtered`/`removed_traits`, it
+      does not strip keys from `heritability_results`).
+- [x] 1.4a Write failing test `test_single_genotype_trait_has_no_blup_keys`:
+      a trait with fewer than 2 genotypes (`len(reps_per_geno) < 2`, the
+      existing `"Insufficient genotypes..."` error path) has no `blup`/
+      `intercept` key.
+- [x] 1.4b Write failing test `test_mixed_model_fit_failure_has_no_blup_keys`:
+      mock `statsmodels.formula.api.mixedlm` (or construct data that reliably
+      fails to converge) so the mixed-model `try` block raises; assert that
+      trait's dict has `model_type == "mixed_model_failed"` and no `blup`/
+      `intercept` key. (Distinct code path from 1.4a — do not conflate the two
+      under one test.)
+- [x] 1.4c Write failing test
+      `test_anova_based_and_no_variance_traits_have_no_blup_keys_no_crash`:
+      call `calculate_heritability_estimates(..., force_method="anova_based")`
+      on `heritability_data_known_h2` and separately on a fixture with
+      `nunique() == 1` (reuse or adapt `heritability_zero_data`-style constant
+      values); assert neither call raises, and both traits' dicts have
+      `model_type` in `{"anova_based", "no_variance"}` with no `blup`/
+      `intercept` key. This guards the real bug risk that the shared per-trait
+      dict literal (`statistics.py:414-428`) is reached by the ANOVA-based
+      branch too, which never fits a mixedlm model and has no `result` object.
+- [x] 1.5 Write failing test `test_adjusted_mean_matches_independent_raw_mean`
+      (an independent oracle, not tautological — do NOT compare
+      `intercept + blup[g]` against itself): for a known-H2 balanced trait,
+      compute `intercept + blup[g]` from `calculate_heritability_estimates`'s
+      own returned dict and assert it is within a documented tolerance of
+      `df.groupby("geno")[trait].mean()` computed directly from the input
+      DataFrame — i.e. the same comparison 2.5 will later run against
+      `extract_blup_table`'s output, but exercised here directly against the
+      dict's `blup`/`intercept` fields so this section's tests don't depend on
+      §2 existing yet.
+- [x] 1.6 Implement the extraction in `calculate_heritability_estimates`
+      (`statistics.py:338-372`, the `if use_mixed_model:` branch only): inside
+      the inner `try` block, immediately after
+      `result = model.fit(reml=True)`, compute
+      `blup = {str(g): float(v.iloc[0]) for g, v in result.random_effects.items()}`
+      and `intercept = float(result.fe_params["Intercept"])` as local
+      variables (access `result.random_effects` exactly once). Initialize
+      `blup = None` and `intercept = None` before the `if use_mixed_model:`/
+      `else:` branch (so the ANOVA-based branch leaves them `None`), and in the
+      shared dict literal (~line 414), add the keys conditionally: build the
+      dict without `blup`/`intercept` first, then
+      `if blup is not None: heritability_results[trait]["blup"] = blup;
+      heritability_results[trait]["intercept"] = intercept`. This ensures the
+      ANOVA-based branch (no `result` object) cannot reference an unbound
+      variable. Make 1.2–1.5 green (1.4a/1.4b/1.4c should already be green from
+      existing behavior — confirm, don't newly break them). Update the
+      function's `Returns:` docstring to document the new `blup`/`intercept`
+      keys and the mixed-model-only condition.
+- [x] 1.7 Write a failing backward-compatibility regression test in
+      `tests/test_heritability_result.py` (the existing
+      `TestHeritabilityResultNonBreaking` class): build a hand-crafted
+      per-trait dict containing the pre-existing keys **plus** the new
+      `blup`/`intercept` keys, pass it through
+      `HeritabilityResult.from_heritability_dict`, and assert the resulting
+      `TraitHeritability` fields are unaffected by the extra keys — confirms
+      the "purely additive" claim from this same commit rather than assuming
+      it from the adapter's use of `.get()`. No implementation change needed
+      (`from_heritability_dict` already reads via `.get(...)` on a fixed key
+      set); this should already be green once 1.6 lands — if it isn't,
+      that's a real regression to fix before moving on.
+
+## 2. `extract_blup_table()` (test-first)
+
+- [x] 2.1 Write failing test `test_extract_blup_table_success_values`
+      (`tests/test_statistics.py`): build a minimal `heritability_results` dict
+      by hand (2 traits succeeded with known `blup`/`intercept`, one trait
+      failed — no `blup` key), call `extract_blup_table(heritability_results)`,
+      assert the returned `pd.DataFrame` has `adjusted_mean = intercept +
+      blup[g]` for every genotype/succeeded-trait cell (`pytest.approx`).
+- [x] 2.2 Write failing test `test_extract_blup_table_failed_trait_is_nan_column`:
+      the failed trait's column is present, every value is `NaN`
+      (`df["trait_failed"].isna().all()`), and no value is `0.0`.
+- [x] 2.3 Write failing test `test_extract_blup_table_shape`: rows = union of
+      genotypes across traits, columns = `trait_cols` order (excluding
+      `__calculation_metadata__`); row/column counts match a hand-built fixture.
+- [x] 2.4 Write failing test `test_extract_blup_table_does_not_mutate_input`: deep-
+      copy `heritability_results` before the call, assert equality after (mirror
+      the `_assert_dict_unchanged` pattern from `tests/test_umap_result.py` /
+      `tests/test_cluster_result.py`).
+- [x] 2.4a Write failing test `test_extract_blup_table_run_level_error_dict`:
+      call `extract_blup_table({"error": "Missing required columns: ['geno']"})`
+      (the run-level short-circuit form with no per-trait entries); assert no
+      exception is raised and the returned `pd.DataFrame` is empty (0 rows, 0
+      columns).
+- [x] 2.4b Write failing test `test_extract_blup_table_all_traits_failed`: build
+      a `heritability_results` dict where every trait has no `blup` key (e.g.
+      all `{"error": ...}` or `model_type in {"anova_based", "no_variance",
+      "mixed_model_failed"}`); assert no exception is raised, the returned
+      `pd.DataFrame` has zero rows and one column per input trait, and every
+      column is entirely `NaN` (this is the empty-genotype-universe case —
+      there is no `blup` dict anywhere to source a genotype index from).
+- [x] 2.4c Write failing test `test_extract_blup_table_cell_level_nan_for_partial_genotype_coverage`:
+      build a `heritability_results` dict with two succeeded traits whose
+      `blup` dicts cover different, overlapping-but-not-identical genotype
+      sets (e.g. `"trait_a"`'s `blup` has `{"G01", "G02"}`, `"trait_b"`'s has
+      `{"G01", "G02", "G03"}`); assert the returned DataFrame has a `"G03"`
+      row, `df.loc["G03", "trait_a"]` is `NaN`, and `df.loc["G03", "trait_b"]`
+      is a finite value — a cell-level gap, distinct from 2.2's whole-column
+      failure.
+- [x] 2.5 Write failing integration test `test_blup_table_balanced_matches_raw_mean`
+      using `heritability_data_known_h2`: run `calculate_heritability_estimates`
+      then `extract_blup_table`; for each genotype/trait, assert the
+      BLUP-adjusted mean is within tolerance of that genotype's raw trait mean
+      (`df.groupby("geno")[trait].mean()`) — the balanced-design oracle. Use a
+      **per-trait** tolerance, not one shared constant: empirically (verified
+      against this exact fixture, seed 42) `max|adjusted_mean - raw_mean|` is
+      ≈0.13 for `trait_high_h2`, ≈0.31 for `trait_moderate_h2`, and ≈0.37 for
+      `trait_low_h2` — so use `atol=0.3` for `trait_high_h2` and `atol=0.5`
+      for the other two, not a single flat `atol=0.5` shared across all three
+      traits with no margin check. (A noise-scaled formula such as
+      `2 * sqrt(var_residual / mean_n_reps)` was considered as a general
+      alternative to hardcoded per-trait constants, but rejected: on this
+      fixture it evaluates to ≈0.89 for every trait — looser than the
+      empirical maxima above by 2-7x and insensitive to `var_genetic`, so it
+      would mask exactly the kind of shrinkage-formula regression this test
+      exists to catch. Use the concrete per-trait values.)
+- [x] 2.6 Write failing integration test
+      `test_blup_table_unbalanced_shrinks_low_rep_genotypes` using
+      `heritability_data_unbalanced_reps` (task 1.1): the "grand mean" is the
+      model's own `intercept` (not the naive `df[trait].mean()` — those
+      differ slightly under an unbalanced design), and the comparison is the
+      per-genotype **shrinkage ratio** `|adjusted_mean - intercept| /
+      |raw_mean - intercept|`, not raw gap magnitude — both genotype groups
+      draw their true effect from the same distribution, so a high-rep
+      genotype can legitimately land a larger raw/adjusted gap than any
+      low-rep genotype by chance; the ratio isolates the shrinkage factor
+      itself (theory.md: `lambda = var_genetic / (var_genetic +
+      var_residual / n_reps)`), which is smaller for n=2 than n=20
+      regardless of which genotype drew the larger true effect. Assert (a)
+      every genotype's adjusted gap is smaller than its raw gap, and (b) the
+      mean shrinkage ratio for low-rep genotypes is smaller than for
+      high-rep genotypes — the unbalanced-design oracle.
+- [x] 2.7 Implement `extract_blup_table(heritability_results: dict) -> pd.DataFrame`
+      in `statistics.py` (near `calculate_heritability_estimates`):
+      - If `heritability_results` is the run-level short-circuit form (has an
+        `"error"` key with a string value and no per-trait entries), return an
+        empty `pd.DataFrame()` immediately.
+      - Otherwise, collect the genotype universe as the union of every
+        succeeded trait's `blup.keys()` (an empty union — zero succeeded
+        traits — yields zero rows).
+      - Build one column per trait (excluding `__calculation_metadata__`):
+        `intercept + blup[g]` where the trait succeeded **and** `g` is a key
+        in that trait's `blup` dict; `np.nan` otherwise (covers failed
+        traits, ANOVA-based/no-variance traits, and genotypes absent from a
+        succeeded trait's own `blup` dict).
+      - Return a DataFrame indexed by genotype (the collected union, possibly
+        empty), columns in trait-cols order.
+      Full Google-style docstring (Args/Returns), documenting the run-level
+      short-circuit, all-failed, and cell-level-NaN behaviors. Make 2.1–2.4c
+      and 2.5–2.6 green.
+
+## 3. `BLUPResult` + adapter (test-first)
+
+- [x] 3.1 Create `tests/test_blup_result.py` (mirror `tests/test_heritability_result.py`
+      / `tests/test_umap_result.py`). Write failing test
+      `test_json_roundtrip_native_types`: build a `BLUPResult` via
+      `BLUPResult.from_blup_table(df, intercepts=...)` from a hand-built
+      `extract_blup_table()`-shaped DataFrame with one all-NaN (failed) column;
+      `json.dumps(dataclasses.asdict(result))` succeeds; parsed values are native
+      `str`/`float`.
+- [x] 3.2 Write failing test `test_fields_are_native_types_pre_serialization`
+      (assert on dataclass fields directly, pre-JSON, mirroring the sibling
+      comment that JSON round-trips hide an `np.float64` leak): every
+      `genotype_names`/`trait_names`/`failed_traits` element `is str`; every
+      `adjusted_means` element `is float`; every `intercepts` value `is float`.
+- [x] 3.3 Write failing test `test_failed_trait_excluded_from_matrix_not_nan`:
+      the failed (all-NaN) column's name is in `failed_traits`, NOT in
+      `trait_names`; no element of `adjusted_means` is `NaN`/`Infinity`;
+      `to_json()` succeeds without raising.
+- [x] 3.3a Write failing test `test_cell_level_nan_column_classified_as_failed`:
+      from a DataFrame built like 2.4c's (one trait with a single `NaN` cell,
+      otherwise finite), assert that trait's name is in `failed_traits`, not
+      `trait_names` — a partially-finite column is not eligible for the
+      always-finite matrix.
+- [x] 3.3b Write failing test `test_zero_succeeded_traits_not_misclassified`:
+      from a zero-row DataFrame (all columns entirely `NaN`, per 2.4b's
+      shape), assert `genotype_names == []`, `trait_names == []`,
+      `failed_traits` contains every input column name, and `to_json()`
+      succeeds. This specifically guards against a naive `df[col].notna().all()`
+      partition, which is vacuously `True` on a zero-row column in pandas.
+- [x] 3.4 Write failing test `test_to_json_rejects_non_finite_adjusted_mean`
+      (mirror `test_to_json_rejects_non_finite_h2`): construct a `BLUPResult`
+      directly (bypassing the adapter) with a `NaN`/`Infinity` in
+      `adjusted_means`; `to_json()` raises `ValueError`; `to_dict()` does not.
+- [x] 3.5 Write failing adapter tests: `genotype_names == [str(g) for g in
+      df.index]` (row order preserved); `trait_names`/`failed_traits` partition
+      `df.columns` by column-finiteness, in original column order;
+      `adjusted_means` shape is `(len(genotype_names), len(trait_names))`;
+      `intercepts` has exactly one entry per `trait_names` name and none for
+      `failed_traits` names; the input `df` is unchanged after the call
+      (`_assert_dict_unchanged`-style deep-copy compare, adapted for a DataFrame).
+- [x] 3.6 Add `BLUPResult(frozen=True)` to `result_types.py` with fields
+      `genotype_names: list[str]`, `trait_names: list[str]`,
+      `adjusted_means: list[list[float]]`, `failed_traits: list[str] =
+      field(default_factory=list)`, `intercepts: dict[str, float] =
+      field(default_factory=dict)`; `to_dict()`/`to_json()` (the
+      `allow_nan=False` finite-floats contract, copied from `HeritabilityResult`).
+      Google-style docstring with a complete `Attributes:` block (the
+      `check_public_api_docs` audit requires every field name to appear) and the
+      shallow-`frozen=True` read-only caveat. Append `"BLUPResult"` to
+      `result_types.__all__`.
+- [x] 3.7 Add `BLUPResult.from_blup_table(df, *, intercepts=None)` classmethod.
+      Partition `df.columns`: a column is **succeeded** only if it has at
+      least one row AND `df[col].notna().all()` — explicitly treat a
+      zero-row DataFrame's columns as **failed**, not succeeded (do not rely
+      on `.notna().all()` alone, since it is vacuously `True` on an empty
+      column: `pd.Series([], dtype=float).notna().all() is True`). Build
+      `adjusted_means` from `df[trait_names].to_numpy().tolist()`;
+      `intercepts` defaults to `{}` if not supplied, else filtered to
+      `trait_names` only. Non-mutating. Make 3.1–3.5 (incl. 3.3a/3.3b) green.
+
+## 4. Config + pipeline output (test-first)
+
+- [x] 4.1 Write failing test `test_generate_blup_table_default_true`
+      (`tests/test_step_statistical_analysis.py` — no dedicated config-defaults
+      test file exists in this repo; a small standalone assertion here is the
+      right home): `StatisticsConfig().generate_blup_table is True`.
+- [x] 4.2 Add `generate_blup_table: bool = True` to `StatisticsConfig`
+      (`pipeline/config/components.py:524`), with a docstring `Attributes:` entry
+      explaining the `calculate_heritability` gating (mirror the
+      `HeritabilityConfig.generate_diagnostics` docstring style), and noting
+      that setting it `True` while `calculate_heritability=False` is inert —
+      no exception, no warning, just no BLUP output, since there's no model
+      fit to extract from. Make 4.1 green.
+- [x] 4.3 Write failing test `test_blup_csv_written_when_both_enabled`
+      (`tests/test_step_statistical_analysis.py`, mirror
+      `test_heritability_file_generated`): run `StatisticalAnalysisStep.execute()`
+      with default `VizPipelineConfig`-style config (`calculate_heritability=True`,
+      `generate_blup_table=True`); assert `data/08_blup_adjusted_means.csv` exists
+      under `tmp_path`, and its row count equals `sample_data["Genotype"].nunique()`.
+- [x] 4.4 Write failing test `test_blup_csv_absent_when_generate_blup_table_false`:
+      same step, `generate_blup_table=False`; assert the CSV is absent while
+      `08_heritability_results.csv` is still present.
+- [x] 4.5 Write failing test `test_blup_csv_absent_when_heritability_disabled`:
+      `calculate_heritability=False`, `generate_blup_table=True` (the
+      default); assert the CSV is absent and no exception is raised. This is
+      an ordinary, legitimate configuration (heritability turned off
+      entirely) — assert no warning is raised either (e.g. via
+      `warnings.catch_warnings(record=True)` and an empty list), since a
+      warning here would be noise on a common config, not a useful signal
+      (see design.md Decision 5 for why this reverses an earlier warn-based
+      draft).
+- [x] 4.5a Write failing test `test_blup_table_works_with_qc_config_no_statistics`
+      (mirror the existing `test_heritability_works_with_qc_config_no_statistics`
+      at `tests/test_step_statistical_analysis.py:469`): run
+      `StatisticalAnalysisStep.execute()` with a bare `QCPipelineConfig` (no
+      `statistics=` field set at all); assert no `AttributeError` is raised and
+      `08_blup_adjusted_means.csv` is written (both flags resolve to their
+      defaults via the same `getattr(config, "statistics", None)` fallback
+      `calculate_heritability` already uses). This is the regression guard for
+      the QC-pipeline crash risk found in review.
+- [x] 4.6 Implement the write path in `StatisticalAnalysisStep.execute()`
+      (`pipeline/steps/statistical_analysis.py`):
+      - Resolve `generate_blup_table` with the same `getattr(config,
+        "statistics", None)` guard already used for `calculate_heritability`
+        (`statistical_analysis.py:154-159`), defaulting to `True` when
+        `config.statistics` is absent (the QC-pipeline case).
+      - If `calculate_heritability` is `True` and `generate_blup_table` is
+        `True`: call `extract_blup_table(heritability_results)` and
+        `self.save_dataframe(blup_df, "08_blup_adjusted_means.csv", data_dir)`,
+        appending to `files`. Add this in the **second** `if
+        calculate_heritability:` block (~line 303-308, the one that writes
+        `08_heritability_results.csv`) — not the earlier block (~line 161)
+        that only computes `heritability_results`, since `data_dir`/`files`
+        don't exist yet at that point.
+      - If `calculate_heritability` is `False`, do nothing further regardless
+        of `generate_blup_table` — no exception, no warning. (An earlier
+        draft added a warning here mirroring the `umap.enabled` precedent;
+        reversed after round-2 review found it would fire on the ordinary,
+        common configuration of disabling heritability — see design.md
+        Decision 5.) Do **not** touch `validate_viz_config()` for this
+        change.
+      Make 4.3–4.5a green.
+
+## 5. Public exports + docs
+
+- [x] 5.1 Write failing test extending the statistics-api export test in
+      `tests/test_public_api.py` (confirmed existing eight-function import/
+      `__all__` check, `STATISTICS_FUNCTIONS` list): the import list grows to
+      nine functions including `extract_blup_table`; `__all__` contains it with
+      no duplicates; `typing.get_type_hints` and the docstring-completeness
+      check (`TestDocsInSync`) both cover it like the other eight.
+- [x] 5.2 Write failing test `test_blupresult_importable_from_root` in
+      `tests/test_blup_result.py` (class `TestBLUPResultExport`, mirroring
+      `TestHeritabilityResultExport`/`TestUMAPResultExport`): `from
+      sleap_roots_analyze import BLUPResult` succeeds; `"BLUPResult"` in
+      `sleap_roots_analyze.__all__` with no duplicates; importable from
+      `sleap_roots_analyze.result_types` and listed in `result_types.__all__`.
+- [x] 5.3 Add `extract_blup_table` to the statistics import/`__all__` block in
+      `__init__.py` (alongside the existing eight); add `BLUPResult` to the
+      `result_types` import block and `__all__` (the "Serializable result types
+      (#130)" group). Make 5.1–5.2 green. (This is the commit where the public-
+      API docstring audit fires — 3.6's complete `Attributes:` block and the
+      `extract_blup_table` docstring must already be in place.)
+- [x] 5.4 Update the `result_types.py` module docstring enumeration (the
+      "`PCAResult` … `HeritabilityResult` (#128), `ClusterResult` (#129), and
+      `UMAPResult` (#180) follow" sentence) to include `BLUPResult (#109)` —
+      citing its issue number, matching every other entry's per-type citation.
+- [x] 5.5 Update `docs/result-types.md`: add the BLUP row to the types table
+      (Built from `extract_blup_table` DataFrame; adapter
+      `BLUPResult.from_blup_table(df, *, intercepts=None)`).
+- [x] 5.6 Update `docs/API.md` `## statistics Module` section: add an entry for
+      `extract_blup_table` matching its final signature/defaults.
+- [x] 5.6a Update `docs/QC_PIPELINE_GUIDE.md`'s "Analysis Files" list (~line
+      146, alongside the existing `08_heritability_results.csv` entry): add
+      `` `08_blup_adjusted_means.csv` - BLUP-adjusted genotype means per trait
+      (when `generate_blup_table` and `calculate_heritability` are both
+      enabled) ``.
+- [x] 5.7 Add a `docs/CHANGELOG.md` `[Unreleased]` entry, split like the
+      `UMAPResult` entry it mirrors (which separates a `### Changed` bullet
+      for additive keys on an *existing* function from `### Added` for
+      brand-new symbols — do not lump both under `### Added`):
+      - `### Added`: `extract_blup_table`, `BLUPResult`,
+        `BLUPResult.from_blup_table`, `StatisticsConfig.generate_blup_table`,
+        and the new `08_blup_adjusted_means.csv` pipeline output.
+      - `### Changed`: `calculate_heritability_estimates` additively returns
+        `blup`/`intercept` keys per trait when its mixed model succeeds.
+      Add a one-line rationale (mirroring the `UMAPResult` entry's style):
+      these are Tier 1 of the cross-platform genotype-prediction program
+      (#109). Do **not** bump `pyproject.toml` or add a dated version
+      heading — per the established convention (the `UMAPResult` entry is
+      still sitting in `[Unreleased]` with no version cut since), this
+      bundles into a future release PR, not this one.
+
+## 6. Validation
+
+- [x] 6.1 `openspec validate add-blup-extraction --strict` — resolve every
+      reported issue before requesting review.
+- [x] 6.2 `/lint` (black + ruff) on all changed files.
+- [x] 6.3 Full `uv run pytest --cov --cov-branch` — confirm no regressions in
+      existing `test_statistics.py`, `test_step_statistical_analysis.py`
+      (including the pre-existing `test_heritability_works_with_qc_config_no_statistics`
+      and `test_heritability_calculated_when_enabled`, both of which now
+      exercise the new BLUP code paths for the first time),
+      `test_result_serialization.py` (should still skip
+      `calculate_heritability_estimates` — its return type is still a dict),
+      and confirm the new `tests/test_blup_result.py` and extended
+      `tests/test_public_api.py` suites pass.
+- [x] 6.4 `/review-openspec` — adversarial proposal review (≥1 round) before
+      requesting user approval, per the roadmap's per-tier loop.

--- a/src/sleap_roots_analyze/__init__.py
+++ b/src/sleap_roots_analyze/__init__.py
@@ -18,6 +18,7 @@ from sleap_roots_analyze.statistics import (
     analyze_trait_variance,
     diagnose_heritability_issues,
     compare_trait_heritabilities,
+    extract_blup_table,
 )
 from sleap_roots_analyze.data_cleanup import (
     load_trait_data,
@@ -55,6 +56,7 @@ from sleap_roots_analyze.result_types import (
     GMMResult,
     HierarchicalResult,
     UMAPResult,
+    BLUPResult,
 )
 
 from sleap_roots_analyze.umap import (
@@ -253,6 +255,7 @@ __all__ = [
     "GMMResult",
     "HierarchicalResult",
     "UMAPResult",
+    "BLUPResult",
     # UMAP functions
     "perform_umap_analysis",
     # Clustering functions
@@ -355,6 +358,7 @@ __all__ = [
     "analyze_trait_variance",
     "diagnose_heritability_issues",
     "compare_trait_heritabilities",
+    "extract_blup_table",
     # PC-correlation & trait-enrichment workflows
     "cross_platform_pc_correlations",
     "trait_correlation_enrichment",

--- a/src/sleap_roots_analyze/pipeline/config/components.py
+++ b/src/sleap_roots_analyze/pipeline/config/components.py
@@ -536,11 +536,20 @@ class StatisticsConfig:
         calculate_anova: Whether to calculate ANOVA.
         calculate_heritability: Whether to calculate heritability.
         alpha: Significance level for tests.
+        generate_blup_table: Whether to write a `08_blup_adjusted_means.csv`
+            (genotype x trait BLUP-adjusted means) alongside the heritability
+            results. BLUPs are extracted from the same mixed-model fit
+            heritability uses, so this flag only takes effect when
+            `calculate_heritability` is also True. Setting it True while
+            `calculate_heritability` is False is inert — no exception, no
+            warning, just no BLUP output, since there is no model fit to
+            extract from.
     """
 
     calculate_anova: bool = True
     calculate_heritability: bool = True
     alpha: float = 0.05
+    generate_blup_table: bool = True
 
 
 @dataclass

--- a/src/sleap_roots_analyze/pipeline/steps/statistical_analysis.py
+++ b/src/sleap_roots_analyze/pipeline/steps/statistical_analysis.py
@@ -15,6 +15,7 @@ from sleap_roots_analyze.pipeline.core import BaseStep, StepResult
 from sleap_roots_analyze.statistics import (
     calculate_heritability_estimates,
     calculate_trait_statistics,
+    extract_blup_table,
     perform_anova_by_genotype,
 )
 
@@ -154,6 +155,15 @@ class StatisticalAnalysisStep(BaseStep):
         statistics_config = getattr(config, "statistics", None)
         calculate_heritability = (
             statistics_config.calculate_heritability
+            if statistics_config is not None
+            else True
+        )
+        # generate_blup_table only takes effect when calculate_heritability is
+        # also True (BLUPs come from the same model fit). Resolved with the
+        # same getattr fallback as calculate_heritability so a QCPipelineConfig
+        # (no `statistics` field) still defaults to True (issue #109).
+        generate_blup_table = (
+            statistics_config.generate_blup_table
             if statistics_config is not None
             else True
         )
@@ -306,6 +316,11 @@ class StatisticalAnalysisStep(BaseStep):
                     heritability_df, "08_heritability_results.csv", data_dir
                 )
             )
+            if generate_blup_table:
+                blup_df = extract_blup_table(heritability_results)
+                files.append(
+                    self.save_dataframe(blup_df, "08_blup_adjusted_means.csv", data_dir)
+                )
 
         files.append(
             self.save_json(summary, "08_statistical_analysis_summary.json", data_dir)

--- a/src/sleap_roots_analyze/pipeline/steps/statistical_analysis.py
+++ b/src/sleap_roots_analyze/pipeline/steps/statistical_analysis.py
@@ -318,6 +318,10 @@ class StatisticalAnalysisStep(BaseStep):
             )
             if generate_blup_table:
                 blup_df = extract_blup_table(heritability_results)
+                # extract_blup_table indexes by genotype; save_dataframe writes with
+                # index=False, so the genotype labels must become a real column first
+                # or they are silently dropped from the CSV.
+                blup_df = blup_df.reset_index(names=genotype_col)
                 files.append(
                     self.save_dataframe(blup_df, "08_blup_adjusted_means.csv", data_dir)
                 )

--- a/src/sleap_roots_analyze/pipeline/steps/statistical_analysis.py
+++ b/src/sleap_roots_analyze/pipeline/steps/statistical_analysis.py
@@ -317,6 +317,11 @@ class StatisticalAnalysisStep(BaseStep):
                 )
             )
             if generate_blup_table:
+                # calculate_heritability_estimates is called above with the
+                # literal remove_low_h2=False, so its return is always the
+                # plain-dict form, never the 4-tuple; the isinstance check
+                # narrows the function's Union return type for mypy.
+                assert isinstance(heritability_results, dict)
                 blup_df = extract_blup_table(heritability_results)
                 # extract_blup_table indexes by genotype; save_dataframe writes with
                 # index=False, so the genotype labels must become a real column first

--- a/src/sleap_roots_analyze/result_types.py
+++ b/src/sleap_roots_analyze/result_types.py
@@ -18,9 +18,10 @@ serialization rather than silently producing invalid JSON. Callers crossing the
 boundary should use ``to_json`` (or pass ``allow_nan=False`` themselves).
 
 The first type is :class:`PCAResult` (issue #127, the detailed exemplar);
-``HeritabilityResult`` (#128), ``ClusterResult`` (#129), and ``UMAPResult``
-(#180) follow the same convention here. This module imports nothing from the
-analytical modules (``pca.py`` etc.) so dependencies stay one-way.
+``HeritabilityResult`` (#128), ``ClusterResult`` (#129), ``UMAPResult``
+(#180), and ``BLUPResult`` (#109) follow the same convention here. This
+module imports nothing from the analytical modules (``pca.py`` etc.) so
+dependencies stay one-way.
 """
 
 from __future__ import annotations
@@ -31,6 +32,7 @@ from dataclasses import dataclass, field
 from typing import Any, Optional
 
 import numpy as np
+import pandas as pd
 
 __all__ = [
     "FeatureContribution",
@@ -42,6 +44,7 @@ __all__ = [
     "GMMResult",
     "HierarchicalResult",
     "UMAPResult",
+    "BLUPResult",
     "ALGORITHM_KMEANS",
     "ALGORITHM_GMM",
     "ALGORITHM_HIERARCHICAL",
@@ -788,4 +791,125 @@ class UMAPResult:
             n_samples=int(embedding.shape[0]),
             standardized=d.get("scaler") is not None,
             random_state=None if seed is None else int(seed),
+        )
+
+
+@dataclass(frozen=True)
+class BLUPResult:
+    """JSON-serializable view of a BLUP-adjusted-means run (science only).
+
+    Built from an ``extract_blup_table()`` DataFrame via
+    :meth:`from_blup_table`. Holds the genotype x trait adjusted-means matrix
+    for traits whose mixed model succeeded, plus the names of traits that
+    failed (mirroring :class:`HeritabilityResult`'s ``per_trait``/
+    ``failed_traits`` split, one level up: genotype x trait matrix instead of
+    a per-trait scalar).
+
+    A trait column must be *entirely* finite to be included in
+    ``adjusted_means``/``trait_names`` — a genuine ``NaN`` column (the
+    model failed, used the ANOVA-based/no-variance path, or was skipped) and
+    a column with even a single cell-level ``NaN`` (a genotype covered by one
+    succeeded trait's model but not another's) are both classified as
+    failed, listed in ``failed_traits`` by name only. This keeps
+    ``adjusted_means`` always finite, satisfying :meth:`to_json`'s
+    ``allow_nan=False`` contract even though the source
+    ``extract_blup_table()`` DataFrame carries real ``NaN``s.
+
+    ``frozen=True`` is shallow: the dataclass fields cannot be rebound, but the
+    nested ``list``/``dict`` fields are still mutable in place. Treat the
+    result as read-only. Float fields must be finite to satisfy the JSON
+    boundary — use :meth:`to_json` to enforce it.
+
+    Attributes:
+        genotype_names: Genotype labels, in the source DataFrame's row order.
+        trait_names: Names of traits whose model succeeded (excludes failed
+            traits), in the source DataFrame's column order.
+        adjusted_means: ``(n_genotypes, n_traits)`` nested list of BLUP-adjusted
+            means (``intercept + blup[genotype]``), aligned to
+            ``genotype_names`` x ``trait_names``. Always finite.
+        failed_traits: Names of traits excluded from ``trait_names`` — no
+            model fit, or at least one cell-level gap. Names only, no values.
+        intercepts: Fixed-effect intercept per succeeded trait in
+            ``trait_names``; empty if not supplied to the adapter.
+    """
+
+    genotype_names: list[str]
+    trait_names: list[str]
+    adjusted_means: list[list[float]]
+    failed_traits: list[str] = field(default_factory=list)
+    intercepts: dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain ``dict`` view via :func:`dataclasses.asdict`."""
+        return dataclasses.asdict(self)
+
+    def to_json(self, **kwargs: Any) -> str:
+        """Serialize to a strict-JSON string, enforcing the finite-floats contract.
+
+        Defaults to ``allow_nan=False`` so a non-finite value (``NaN``/
+        ``Infinity`` from a degenerate run) raises a ``ValueError`` here rather
+        than emitting the non-standard tokens a strict JSON consumer (e.g.
+        bloom-mcp) rejects. Extra keyword arguments are forwarded to
+        :func:`json.dumps`.
+
+        Raises:
+            ValueError: If any float field is non-finite (under the default
+                ``allow_nan=False``).
+        """
+        kwargs.setdefault("allow_nan", False)
+        return json.dumps(self.to_dict(), **kwargs)
+
+    @classmethod
+    def from_blup_table(
+        cls, df: "pd.DataFrame", *, intercepts: Optional[dict[str, float]] = None
+    ) -> "BLUPResult":
+        """Build a :class:`BLUPResult` from an ``extract_blup_table()`` DataFrame.
+
+        Partitions ``df.columns`` into succeeded (entirely finite, non-empty)
+        and failed (any non-finite value, or zero rows) columns. A zero-row
+        column is explicitly treated as failed — ``pd.Series([],
+        dtype=float).notna().all()`` is vacuously ``True`` in pandas, so
+        relying on ``.notna().all()`` alone would misclassify an
+        all-traits-failed input (zero genotype universe) as all-succeeded.
+        Does not mutate ``df``.
+
+        Args:
+            df: The DataFrame returned by ``extract_blup_table()`` — rows are
+                genotypes, columns are traits, failed traits are ``NaN``
+                columns.
+            intercepts: Fixed-effect intercept per trait, keyed by trait name
+                (typically each succeeded trait's ``heritability_results[trait]
+                ["intercept"]``). Entries for traits not in the resulting
+                ``trait_names`` are dropped; defaults to ``{}`` if omitted.
+
+        Returns:
+            A frozen :class:`BLUPResult` holding only JSON-serializable
+            science.
+        """
+        genotype_names = [str(g) for g in df.index]
+
+        trait_names: list[str] = []
+        failed_traits: list[str] = []
+        for column in df.columns:
+            is_succeeded = len(df) > 0 and bool(df[column].notna().all())
+            if is_succeeded:
+                trait_names.append(str(column))
+            else:
+                failed_traits.append(str(column))
+
+        adjusted_means = (
+            df[trait_names].to_numpy(dtype=float).tolist() if trait_names else []
+        )
+        resolved_intercepts = {
+            str(trait): float(intercepts[trait])
+            for trait in trait_names
+            if intercepts is not None and trait in intercepts
+        }
+
+        return cls(
+            genotype_names=genotype_names,
+            trait_names=trait_names,
+            adjusted_means=adjusted_means,
+            failed_traits=failed_traits,
+            intercepts=resolved_intercepts,
         )

--- a/src/sleap_roots_analyze/result_types.py
+++ b/src/sleap_roots_analyze/result_types.py
@@ -861,7 +861,7 @@ class BLUPResult:
 
     @classmethod
     def from_blup_table(
-        cls, df: "pd.DataFrame", *, intercepts: Optional[dict[str, float]] = None
+        cls, df: pd.DataFrame, *, intercepts: Optional[dict[str, float]] = None
     ) -> "BLUPResult":
         """Build a :class:`BLUPResult` from an ``extract_blup_table()`` DataFrame.
 
@@ -897,9 +897,12 @@ class BLUPResult:
             else:
                 failed_traits.append(str(column))
 
-        adjusted_means = (
-            df[trait_names].to_numpy(dtype=float).tolist() if trait_names else []
-        )
+        # df[trait_names] naturally yields one (possibly empty) row per genotype
+        # even when trait_names is empty, keeping adjusted_means aligned to
+        # genotype_names — do not special-case `if trait_names else []`, which
+        # would collapse a non-empty genotype universe to `[]` instead of
+        # `[[], [], ...]` when every trait failed via cell-level gaps.
+        adjusted_means = df[trait_names].to_numpy(dtype=float).tolist()
         resolved_intercepts = {
             str(trait): float(intercepts[trait])
             for trait in trait_names

--- a/src/sleap_roots_analyze/statistics.py
+++ b/src/sleap_roots_analyze/statistics.py
@@ -479,6 +479,67 @@ def calculate_heritability_estimates(
     return heritability_results
 
 
+def extract_blup_table(heritability_results: Dict) -> pd.DataFrame:
+    """Build a genotype x trait BLUP-adjusted-means table (issue #109).
+
+    Consumes the dict returned by ``calculate_heritability_estimates`` (the
+    ``remove_low_h2=False`` form, or the first element of the
+    ``remove_low_h2=True`` tuple) and builds a table of
+    ``adjusted_mean = intercept + blup[genotype]`` for every trait whose mixed
+    model succeeded.
+
+    A trait with no ``blup``/``intercept`` keys (the model failed, used the
+    ANOVA-based or no-variance path, or was skipped) gets an entire ``NaN``
+    column — not omitted from the table and not zero-filled. A genotype
+    missing from one succeeded trait's ``blup`` dict but present in another's
+    (traits compute their own genotype set independently, via a per-trait
+    ``dropna()``) gets a cell-level ``NaN`` for that genotype/trait pair only.
+
+    Does not mutate its input. Never raises: a run-level short-circuit dict
+    (``{"error": "..."}``, no per-trait entries) produces an empty
+    ``pd.DataFrame()``; a dict where every trait failed produces a zero-row
+    table with one all-``NaN`` column per input trait.
+
+    Args:
+        heritability_results: The dict returned by
+            ``calculate_heritability_estimates``.
+
+    Returns:
+        pd.DataFrame: Rows indexed by genotype (the union of every succeeded
+        trait's ``blup`` keys), one column per trait (excluding
+        ``__calculation_metadata__``), in the input's trait order.
+    """
+    run_level_error = heritability_results.get("error")
+    if isinstance(run_level_error, str):
+        return pd.DataFrame()
+
+    trait_entries = {
+        trait: entry
+        for trait, entry in heritability_results.items()
+        if trait != "__calculation_metadata__"
+    }
+
+    genotype_universe: set = set()
+    for entry in trait_entries.values():
+        blup = entry.get("blup") if isinstance(entry, dict) else None
+        if blup is not None:
+            genotype_universe.update(blup.keys())
+
+    genotypes = sorted(genotype_universe)
+    columns = {}
+    for trait, entry in trait_entries.items():
+        blup = entry.get("blup") if isinstance(entry, dict) else None
+        intercept = entry.get("intercept") if isinstance(entry, dict) else None
+        if blup is None or intercept is None:
+            columns[trait] = [np.nan] * len(genotypes)
+        else:
+            columns[trait] = [
+                intercept + blup[g] if g in blup else np.nan for g in genotypes
+            ]
+
+    return pd.DataFrame(columns, index=genotypes)
+
+
 def identify_high_heritability_traits(
     heritability_results: Dict, threshold: float = 0.5
 ) -> List[str]:

--- a/src/sleap_roots_analyze/statistics.py
+++ b/src/sleap_roots_analyze/statistics.py
@@ -246,6 +246,16 @@ def calculate_heritability_estimates(
             - n_genotypes: Number of genotypes
             - n_observations: Total number of observations
             - model_type: Type of model used (mixed_model or anova_based)
+            - blup: BLUP (Best Linear Unbiased Prediction) per genotype, a
+              dict[str, float] from the fitted mixed model's
+              ``result.random_effects``. Present only when
+              ``model_type == "mixed_model"`` — the ANOVA-based and
+              no-variance paths never fit a mixedlm model, so they carry no
+              ``blup``/``intercept`` keys.
+            - intercept: The fixed-effect intercept
+              (``result.fe_params["Intercept"]``) from the same fit. The
+              genotype-adjusted mean is ``intercept + blup[genotype]``.
+              Present under the same condition as ``blup``.
 
         If remove_low_h2=True:
             Tuple of:
@@ -335,6 +345,14 @@ def calculate_heritability_estimates(
                 }
                 continue
 
+            # blup/intercept are BLUPs (Best Linear Unbiased Predictions) extracted
+            # from the mixed model fit below (issue #109). Only the mixed-model
+            # branch has a fitted `result` to extract them from; the ANOVA-based
+            # branch (below) computes variance components via groupby arithmetic
+            # and never fits a model, so these stay None for that path.
+            blup = None
+            intercept = None
+
             if use_mixed_model:
                 # Use mixed model approach (matches R lme4)
                 # Create a clean dataframe for the model
@@ -362,6 +380,14 @@ def calculate_heritability_estimates(
                     )
 
                     model_type = "mixed_model"
+
+                    # Extract BLUPs (issue #109): result.random_effects is a lazy
+                    # property, accessed exactly once here.
+                    blup = {
+                        str(geno): float(effect.iloc[0])
+                        for geno, effect in result.random_effects.items()
+                    }
+                    intercept = float(result.fe_params["Intercept"])
 
                 except Exception as e:
                     # If mixed model fails for this trait, record the error but keep going
@@ -426,6 +452,11 @@ def calculate_heritability_estimates(
                     "std": float(reps_per_geno.std()) if len(reps_per_geno) > 1 else 0,
                 },
             }
+            # Additive BLUP keys (issue #109) — only present when the mixed
+            # model actually fit (blup is None for the ANOVA-based path).
+            if blup is not None:
+                heritability_results[trait]["blup"] = blup
+                heritability_results[trait]["intercept"] = intercept
 
         except Exception as e:
             heritability_results[trait] = {

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -293,6 +293,64 @@ def heritability_zero_data():
     return pd.DataFrame(data)
 
 
+@pytest.fixture
+def heritability_data_unbalanced_reps():
+    """Generate unbalanced-replication data for the BLUP shrinkage oracle.
+
+    Known genetic variance sigma^2_G=4.0, residual variance sigma^2_E=1.0.
+    10 "low-rep" genotypes (G01-G10) have n=2 reps each; 10 "high-rep"
+    genotypes (G11-G20) have n=20 reps each. Low-rep genotypes' raw means
+    are noisier and should shrink further toward the grand mean than
+    high-rep genotypes' raw means once BLUPs are computed.
+
+    Returns:
+        tuple: (pd.DataFrame, dict) where the dict is
+            {"low_rep_genotypes": [...], "high_rep_genotypes": [...],
+            "trait": "trait_unbalanced"}. Raw means and the grand mean are
+            deliberately not pre-computed here; tests derive them directly
+            from the returned DataFrame so there is one source of truth.
+    """
+    np.random.seed(42)
+
+    low_rep_genotypes = [f"G{g:02d}" for g in range(1, 11)]
+    high_rep_genotypes = [f"G{g:02d}" for g in range(11, 21)]
+
+    data = []
+    barcode = 0
+    for geno in low_rep_genotypes:
+        genotype_effect = np.random.normal(0, 2.0)
+        for r in range(2):
+            data.append(
+                {
+                    "geno": geno,
+                    "rep": r + 1,
+                    "Barcode": f"BC{barcode:04d}",
+                    "trait_unbalanced": 50 + genotype_effect + np.random.normal(0, 1.0),
+                }
+            )
+            barcode += 1
+    for geno in high_rep_genotypes:
+        genotype_effect = np.random.normal(0, 2.0)
+        for r in range(20):
+            data.append(
+                {
+                    "geno": geno,
+                    "rep": r + 1,
+                    "Barcode": f"BC{barcode:04d}",
+                    "trait_unbalanced": 50 + genotype_effect + np.random.normal(0, 1.0),
+                }
+            )
+            barcode += 1
+
+    df = pd.DataFrame(data)
+    meta = {
+        "low_rep_genotypes": low_rep_genotypes,
+        "high_rep_genotypes": high_rep_genotypes,
+        "trait": "trait_unbalanced",
+    }
+    return df, meta
+
+
 # ============================================================================
 # HERITABILITY DIAGNOSTIC FIXTURES - Data for testing diagnostic functions
 # ============================================================================

--- a/tests/test_blup_result.py
+++ b/tests/test_blup_result.py
@@ -165,3 +165,21 @@ class TestBLUPResultAdapter:
         BLUPResult.from_blup_table(df, intercepts={"trait_a": 10.0, "trait_b": 20.0})
 
         pd.testing.assert_frame_equal(df, before)
+
+
+class TestBLUPResultExport:
+    """Public API surface."""
+
+    def test_blupresult_importable_from_root(self):
+        """BLUPResult is importable from the package root and in __all__."""
+        import sleap_roots_analyze as sra
+
+        assert sra.BLUPResult is BLUPResult
+        assert "BLUPResult" in sra.__all__
+        assert len(sra.__all__) == len(set(sra.__all__))
+
+    def test_listed_in_result_types_all(self):
+        """BLUPResult is listed in result_types.__all__."""
+        from sleap_roots_analyze import result_types
+
+        assert "BLUPResult" in result_types.__all__

--- a/tests/test_blup_result.py
+++ b/tests/test_blup_result.py
@@ -1,0 +1,167 @@
+"""Tests for the serializable ``BLUPResult`` dataclass and adapter (#109).
+
+Covers the serializable-result-types contract for BLUP-adjusted genotype
+means: native-type JSON round-trips (the reproducibility CI gate), adapter
+partition logic (succeeded vs. failed trait columns, including the
+cell-level-NaN and zero-succeeded-traits edge cases), the finite-floats
+contract, and the non-mutating guarantee. Sibling to
+``tests/test_heritability_result.py`` (#128) and ``tests/test_umap_result.py``
+(#180).
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sleap_roots_analyze.result_types import BLUPResult
+
+
+def _blup_df():
+    """A hand-built ``extract_blup_table()``-shaped DataFrame.
+
+    Two succeeded traits (``trait_a``, ``trait_b``), one failed trait
+    (``trait_failed``, entirely NaN), two genotypes.
+    """
+    return pd.DataFrame(
+        {
+            "trait_a": [10.5, 9.5],
+            "trait_b": [21.0, 22.0],
+            "trait_failed": [np.nan, np.nan],
+        },
+        index=["G01", "G02"],
+    )
+
+
+class TestBLUPResultJSON:
+    """BLUPResult clean view serializes to native Python types."""
+
+    def test_fields_are_native_types_pre_serialization(self):
+        """Fields are native types on the dataclass, not laundered by JSON.
+
+        ``np.float64`` is a subclass of ``float``, so a JSON round-trip
+        silently casts a leak to native float before any assertion — assert
+        on the fields directly.
+        """
+        result = BLUPResult.from_blup_table(
+            _blup_df(), intercepts={"trait_a": 10.0, "trait_b": 20.0}
+        )
+
+        assert all(type(v) is str for v in result.genotype_names)
+        assert all(type(v) is str for v in result.trait_names)
+        assert all(type(v) is str for v in result.failed_traits)
+        assert all(type(v) is float for row in result.adjusted_means for v in row)
+        assert all(type(v) is float for v in result.intercepts.values())
+
+    def test_json_roundtrip_native_types(self):
+        """BLUPResult round-trips to native types with values preserved."""
+        result = BLUPResult.from_blup_table(
+            _blup_df(), intercepts={"trait_a": 10.0, "trait_b": 20.0}
+        )
+        parsed = json.loads(json.dumps(dataclasses.asdict(result)))
+
+        assert all(type(v) is str for v in parsed["genotype_names"])
+        assert all(type(v) is str for v in parsed["trait_names"])
+        assert all(type(v) is str for v in parsed["failed_traits"])
+        assert all(type(v) is float for row in parsed["adjusted_means"] for v in row)
+        np.testing.assert_allclose(
+            np.asarray(parsed["adjusted_means"]),
+            np.asarray(dataclasses.asdict(result)["adjusted_means"]),
+        )
+
+    def test_failed_trait_excluded_from_matrix_not_nan(self):
+        """A failed (all-NaN) column is excluded from the matrix, not NaN within it."""
+        result = BLUPResult.from_blup_table(_blup_df())
+
+        assert "trait_failed" in result.failed_traits
+        assert "trait_failed" not in result.trait_names
+        assert all(np.isfinite(v) for row in result.adjusted_means for v in row)
+        result.to_json()  # succeeds despite the source table having a NaN column
+
+    def test_cell_level_nan_column_classified_as_failed(self):
+        """A single cell-level NaN in an otherwise-finite column also fails it."""
+        df = pd.DataFrame(
+            {
+                "trait_a": [10.5, 9.5, np.nan],
+                "trait_b": [21.0, 22.0, 11.0],
+            },
+            index=["G01", "G02", "G03"],
+        )
+
+        result = BLUPResult.from_blup_table(df)
+
+        assert "trait_a" in result.failed_traits
+        assert "trait_a" not in result.trait_names
+        assert result.trait_names == ["trait_b"]
+
+    def test_zero_succeeded_traits_not_misclassified(self):
+        """A zero-row DataFrame's columns are all failed, not vacuously finite.
+
+        ``pd.Series([], dtype=float).notna().all()`` is ``True`` in pandas —
+        the adapter must special-case a zero-row column as failed rather than
+        relying on ``.notna().all()`` alone.
+        """
+        df = pd.DataFrame({"trait_a": [], "trait_b": []}).astype(float)
+
+        result = BLUPResult.from_blup_table(df)
+
+        assert result.genotype_names == []
+        assert result.trait_names == []
+        assert set(result.failed_traits) == {"trait_a", "trait_b"}
+        result.to_json()  # succeeds
+
+    def test_to_json_rejects_non_finite_adjusted_mean(self):
+        """A non-finite adjusted_means value raises at to_json, not to_dict."""
+        result = BLUPResult(
+            genotype_names=["G01"],
+            trait_names=["trait_a"],
+            adjusted_means=[[float("nan")]],
+        )
+
+        with pytest.raises(ValueError):
+            result.to_json()
+        result.to_dict()  # does not raise
+
+
+class TestBLUPResultAdapter:
+    """from_blup_table maps the extract_blup_table() DataFrame faithfully."""
+
+    def test_adapter_splits_succeeded_and_failed_columns(self):
+        """Finite columns become trait_names; all-NaN columns become failed_traits."""
+        result = BLUPResult.from_blup_table(_blup_df())
+
+        assert result.trait_names == ["trait_a", "trait_b"]
+        assert result.failed_traits == ["trait_failed"]
+        assert len(result.adjusted_means) == 2
+        assert all(len(row) == 2 for row in result.adjusted_means)
+
+    def test_genotype_names_preserves_row_order(self):
+        """genotype_names equals the DataFrame's row order."""
+        result = BLUPResult.from_blup_table(_blup_df())
+        assert result.genotype_names == ["G01", "G02"]
+
+    def test_intercepts_covers_exactly_succeeded_traits(self):
+        """Intercepts has one entry per trait_names name, none for failed_traits."""
+        result = BLUPResult.from_blup_table(
+            _blup_df(),
+            intercepts={"trait_a": 10.0, "trait_b": 20.0, "trait_failed": 0.0},
+        )
+        assert result.intercepts == {"trait_a": 10.0, "trait_b": 20.0}
+
+    def test_intercepts_defaults_to_empty_when_not_supplied(self):
+        """Intercepts defaults to {} when the caller omits it."""
+        result = BLUPResult.from_blup_table(_blup_df())
+        assert result.intercepts == {}
+
+    def test_adapter_does_not_mutate_input_dataframe(self):
+        """from_blup_table does not mutate the input DataFrame."""
+        df = _blup_df()
+        before = df.copy(deep=True)
+
+        BLUPResult.from_blup_table(df, intercepts={"trait_a": 10.0, "trait_b": 20.0})
+
+        pd.testing.assert_frame_equal(df, before)

--- a/tests/test_blup_result.py
+++ b/tests/test_blup_result.py
@@ -114,6 +114,31 @@ class TestBLUPResultJSON:
         assert set(result.failed_traits) == {"trait_a", "trait_b"}
         result.to_json()  # succeeds
 
+    def test_all_traits_cell_level_failed_keeps_adjusted_means_aligned(self):
+        """adjusted_means stays aligned to genotype_names when every trait fails.
+
+        Distinct from ``test_zero_succeeded_traits_not_misclassified``: here the
+        genotype universe is non-empty (3 genotypes) but every column fails via a
+        cell-level NaN (not a zero-row DataFrame), so ``trait_names`` is empty
+        while ``genotype_names`` is not — ``adjusted_means`` must still be one
+        (empty) row per genotype, not collapse to ``[]``.
+        """
+        df = pd.DataFrame(
+            {
+                "trait_a": [10.5, 9.5, np.nan],
+                "trait_b": [np.nan, 22.0, 11.0],
+            },
+            index=["G01", "G02", "G03"],
+        )
+
+        result = BLUPResult.from_blup_table(df)
+
+        assert result.genotype_names == ["G01", "G02", "G03"]
+        assert result.trait_names == []
+        assert set(result.failed_traits) == {"trait_a", "trait_b"}
+        assert result.adjusted_means == [[], [], []]
+        result.to_json()  # succeeds — no non-finite values to reject
+
     def test_to_json_rejects_non_finite_adjusted_mean(self):
         """A non-finite adjusted_means value raises at to_json, not to_dict."""
         result = BLUPResult(

--- a/tests/test_heritability_result.py
+++ b/tests/test_heritability_result.py
@@ -258,3 +258,40 @@ class TestHeritabilityResultNonBreaking:
         before = copy.deepcopy(d)
         HeritabilityResult.from_heritability_dict(d, threshold=0.3)
         assert d == before
+
+    def test_extra_blup_intercept_keys_do_not_affect_traitheritability(self):
+        """Additive blup/intercept keys (#109) don't change TraitHeritability.
+
+        calculate_heritability_estimates now adds blup/intercept keys to a
+        successful trait's dict; from_heritability_dict must keep ignoring
+        unknown keys via .get(), not break or silently absorb them.
+        """
+        d = {
+            "__calculation_metadata__": {
+                "method_used_for_all_traits": "mixed_model",
+                "method_consistency": True,
+            },
+            "trait_a": {
+                "heritability": 0.75,
+                "var_genetic": 3.0,
+                "var_residual": 1.0,
+                "n_genotypes": 20,
+                "n_observations": 100,
+                "model_type": "mixed_model",
+                "blup": {"G01": 0.5, "G02": -0.5},
+                "intercept": 10.0,
+            },
+        }
+
+        result = HeritabilityResult.from_heritability_dict(d, threshold=0.3)
+
+        assert len(result.per_trait) == 1
+        trait = result.per_trait[0]
+        assert isinstance(trait, TraitHeritability)
+        assert trait.trait == "trait_a"
+        assert trait.h2 == pytest.approx(0.75)
+        assert trait.var_genetic == pytest.approx(3.0)
+        assert trait.var_residual == pytest.approx(1.0)
+        assert trait.n_genotypes == 20
+        assert trait.n_observations == 100
+        assert trait.model_type == "mixed_model"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,7 +1,7 @@
 """Tests for the public statistics API surface exposed by ``sleap_roots_analyze``.
 
 These tests guard the contract from the ``statistics-api`` OpenSpec change:
-the eight ``statistics.py`` functions must be importable from the package root,
+the nine ``statistics.py`` functions must be importable from the package root,
 listed in ``__all__``, have resolvable type hints, carry Google-style docstrings,
 and stay in sync with the hand-maintained docs.
 """
@@ -14,7 +14,7 @@ import pytest
 import sleap_roots_analyze as sra
 import sleap_roots_analyze.statistics as stats_module
 
-# The eight functions this change exposes.
+# The nine functions this change exposes.
 STATISTICS_FUNCTIONS = [
     "calculate_trait_statistics",
     "perform_anova_by_genotype",
@@ -24,6 +24,7 @@ STATISTICS_FUNCTIONS = [
     "analyze_trait_variance",
     "diagnose_heritability_issues",
     "compare_trait_heritabilities",
+    "extract_blup_table",
 ]
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -114,7 +115,7 @@ class TestDocsInSync:
 
     @pytest.mark.parametrize("name", STATISTICS_FUNCTIONS)
     def test_api_md_lists_function(self, name):
-        """docs/API.md documents each of the eight functions."""
+        """docs/API.md documents each of the nine functions."""
         api_md = (REPO_ROOT / "docs" / "API.md").read_text(encoding="utf-8")
         assert name in api_md, f"{name} not documented in docs/API.md"
 

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -15,6 +15,7 @@ from sleap_roots_analyze.statistics import (
     analyze_trait_variance,
     diagnose_heritability_issues,
     compare_trait_heritabilities,
+    extract_blup_table,
 )
 
 
@@ -510,6 +511,218 @@ class TestBLUPExtraction:
         for geno, raw_mean in raw_means.items():
             adjusted_mean = intercept + blup[geno]
             assert adjusted_mean == pytest.approx(raw_mean, abs=0.3)
+
+
+class TestExtractBlupTable:
+    """Tests for extract_blup_table() (#109)."""
+
+    def test_extract_blup_table_success_values(self):
+        """adjusted_mean = intercept + blup[g] for every succeeded trait/genotype."""
+        heritability_results = {
+            "__calculation_metadata__": {
+                "method_used_for_all_traits": "mixed_model",
+                "method_consistency": True,
+            },
+            "trait_a": {
+                "blup": {"G01": 0.5, "G02": -0.5},
+                "intercept": 10.0,
+                "model_type": "mixed_model",
+            },
+            "trait_b": {
+                "blup": {"G01": 1.0, "G02": 2.0},
+                "intercept": 20.0,
+                "model_type": "mixed_model",
+            },
+            "trait_failed": {
+                "error": "Mixed model failed: boom",
+                "model_type": "mixed_model_failed",
+            },
+        }
+
+        df = extract_blup_table(heritability_results)
+
+        assert df.loc["G01", "trait_a"] == pytest.approx(10.5)
+        assert df.loc["G02", "trait_a"] == pytest.approx(9.5)
+        assert df.loc["G01", "trait_b"] == pytest.approx(21.0)
+        assert df.loc["G02", "trait_b"] == pytest.approx(22.0)
+
+    def test_extract_blup_table_failed_trait_is_nan_column(self):
+        """A failed trait's whole column is NaN — not dropped, not zero."""
+        heritability_results = {
+            "trait_a": {
+                "blup": {"G01": 0.5, "G02": -0.5},
+                "intercept": 10.0,
+                "model_type": "mixed_model",
+            },
+            "trait_failed": {
+                "error": "Mixed model failed: boom",
+                "model_type": "mixed_model_failed",
+            },
+        }
+
+        df = extract_blup_table(heritability_results)
+
+        assert "trait_failed" in df.columns
+        assert df["trait_failed"].isna().all()
+        assert not (df["trait_failed"] == 0.0).any()
+
+    def test_extract_blup_table_shape(self):
+        """Rows = genotype union, columns = traits (excluding metadata key)."""
+        heritability_results = {
+            "__calculation_metadata__": {"method_used_for_all_traits": "mixed_model"},
+            "trait_a": {
+                "blup": {"G01": 0.5, "G02": -0.5},
+                "intercept": 10.0,
+                "model_type": "mixed_model",
+            },
+            "trait_b": {
+                "blup": {"G01": 1.0, "G02": 2.0},
+                "intercept": 20.0,
+                "model_type": "mixed_model",
+            },
+            "trait_failed": {
+                "error": "Mixed model failed: boom",
+                "model_type": "mixed_model_failed",
+            },
+        }
+
+        df = extract_blup_table(heritability_results)
+
+        assert set(df.index) == {"G01", "G02"}
+        assert list(df.columns) == ["trait_a", "trait_b", "trait_failed"]
+
+    def test_extract_blup_table_does_not_mutate_input(self):
+        """extract_blup_table() must not mutate its input dict."""
+        import copy
+
+        heritability_results = {
+            "trait_a": {
+                "blup": {"G01": 0.5, "G02": -0.5},
+                "intercept": 10.0,
+                "model_type": "mixed_model",
+            },
+        }
+        before = copy.deepcopy(heritability_results)
+
+        extract_blup_table(heritability_results)
+
+        assert heritability_results == before
+
+    def test_extract_blup_table_run_level_error_dict(self):
+        """A run-level short-circuit dict produces an empty table, no crash."""
+        df = extract_blup_table({"error": "Missing required columns: ['geno']"})
+
+        assert df.empty
+        assert len(df.columns) == 0
+
+    def test_extract_blup_table_all_traits_failed(self):
+        """Zero succeeded traits: zero rows, one all-NaN column per input trait."""
+        heritability_results = {
+            "trait_a": {
+                "error": "Mixed model failed: boom",
+                "model_type": "mixed_model_failed",
+            },
+            "trait_b": {
+                "model_type": "anova_based",
+                "heritability": 0.5,
+            },
+        }
+
+        df = extract_blup_table(heritability_results)
+
+        assert len(df) == 0
+        assert list(df.columns) == ["trait_a", "trait_b"]
+        assert df["trait_a"].isna().all()
+        assert df["trait_b"].isna().all()
+
+    def test_extract_blup_table_cell_level_nan_for_partial_genotype_coverage(self):
+        """A genotype missing from one succeeded trait's blup gets a cell-level NaN."""
+        heritability_results = {
+            "trait_a": {
+                "blup": {"G01": 0.0, "G02": 0.0},
+                "intercept": 10.0,
+                "model_type": "mixed_model",
+            },
+            "trait_b": {
+                "blup": {"G01": 0.0, "G02": 0.0, "G03": 1.0},
+                "intercept": 10.0,
+                "model_type": "mixed_model",
+            },
+        }
+
+        df = extract_blup_table(heritability_results)
+
+        assert "G03" in df.index
+        assert pd.isna(df.loc["G03", "trait_a"])
+        assert df.loc["G03", "trait_b"] == pytest.approx(11.0)
+
+    def test_blup_table_balanced_matches_raw_mean(self, heritability_data_known_h2):
+        """Balanced design: BLUP-adjusted mean approximates the raw genotype mean."""
+        df, _ = heritability_data_known_h2
+        trait_cols = ["trait_high_h2", "trait_moderate_h2", "trait_low_h2"]
+        tolerances = {
+            "trait_high_h2": 0.3,
+            "trait_moderate_h2": 0.5,
+            "trait_low_h2": 0.5,
+        }
+
+        heritability_results = calculate_heritability_estimates(
+            df, trait_cols, genotype_col="geno", replicate_col="rep"
+        )
+        blup_table = extract_blup_table(heritability_results)
+
+        for trait in trait_cols:
+            raw_means = df.groupby("geno")[trait].mean()
+            for geno, raw_mean in raw_means.items():
+                assert blup_table.loc[geno, trait] == pytest.approx(
+                    raw_mean, abs=tolerances[trait]
+                )
+
+    def test_blup_table_unbalanced_shrinks_low_rep_genotypes(
+        self, heritability_data_unbalanced_reps
+    ):
+        """Unbalanced design: low-rep genotypes shrink more than high-rep ones.
+
+        The "grand mean" shrinkage pulls toward is the mixed model's own
+        fixed-effect intercept, not the naive row-average `df[trait].mean()`
+        — those can differ slightly under an unbalanced design, so the
+        reference point for both the raw and adjusted gaps must be the same
+        (the intercept) for an apples-to-apples shrinkage comparison.
+
+        The shrinkage *ratio* (adjusted gap / raw gap), not the raw gap
+        magnitude, is the right oracle: both genotype groups draw their true
+        effect from the same distribution, so a high-rep genotype can
+        legitimately land a larger true effect (and thus a larger raw/adjusted
+        gap) than any low-rep genotype by chance. The ratio isolates the
+        shrinkage factor (theory.md: lambda = var_genetic / (var_genetic +
+        var_residual / n_reps)), which theory guarantees is smaller for n=2
+        than n=20 regardless of which genotype drew the larger true effect.
+        """
+        df, meta = heritability_data_unbalanced_reps
+        trait = meta["trait"]
+
+        heritability_results = calculate_heritability_estimates(
+            df, [trait], genotype_col="geno", replicate_col="rep"
+        )
+        blup_table = extract_blup_table(heritability_results)
+        intercept = heritability_results[trait]["intercept"]
+
+        raw_means = df.groupby("geno")[trait].mean()
+
+        low_rep_ratios = []
+        high_rep_ratios = []
+        for geno in meta["low_rep_genotypes"]:
+            raw_gap = abs(raw_means[geno] - intercept)
+            adjusted_gap = abs(blup_table.loc[geno, trait] - intercept)
+            assert adjusted_gap < raw_gap
+            low_rep_ratios.append(adjusted_gap / raw_gap)
+        for geno in meta["high_rep_genotypes"]:
+            raw_gap = abs(raw_means[geno] - intercept)
+            adjusted_gap = abs(blup_table.loc[geno, trait] - intercept)
+            assert adjusted_gap < raw_gap
+            high_rep_ratios.append(adjusted_gap / raw_gap)
+
+        assert np.mean(low_rep_ratios) < np.mean(high_rep_ratios)
 
 
 class TestIdentifyHighHeritabilityTraits:

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -4,6 +4,7 @@ import pytest
 import pandas as pd
 import numpy as np
 import warnings
+from unittest.mock import patch
 
 from sleap_roots_analyze.statistics import (
     calculate_trait_statistics,
@@ -359,6 +360,156 @@ class TestCalculateHeritabilityEstimates:
                 with_rep[trait]["n_observations"]
                 == without_rep[trait]["n_observations"]
             )
+
+
+class TestBLUPExtraction:
+    """Tests for BLUP extraction added to calculate_heritability_estimates (#109)."""
+
+    def test_blup_extracted_for_successful_trait(self, heritability_data_known_h2):
+        """Every successfully-fit (mixed_model) trait gets blup/intercept keys."""
+        df, _ = heritability_data_known_h2
+        trait_cols = ["trait_high_h2", "trait_moderate_h2", "trait_low_h2"]
+        result = calculate_heritability_estimates(
+            df, trait_cols, genotype_col="geno", replicate_col="rep"
+        )
+        genotypes = set(df["geno"].unique())
+
+        for trait in trait_cols:
+            entry = result[trait]
+            assert entry["model_type"] == "mixed_model"
+            assert "blup" in entry
+            assert "intercept" in entry
+            assert set(entry["blup"].keys()) == genotypes
+            assert type(entry["intercept"]) is float
+            for value in entry["blup"].values():
+                assert type(value) is float
+
+    def test_existing_return_shape_unchanged(self, heritability_data_known_h2):
+        """blup/intercept are additive; both return shapes are unchanged."""
+        df, _ = heritability_data_known_h2
+        trait_cols = ["trait_high_h2", "trait_moderate_h2", "trait_low_h2"]
+        existing_keys = [
+            "heritability",
+            "var_genetic",
+            "var_residual",
+            "mean_n_reps",
+            "n_genotypes",
+            "n_observations",
+            "model_type",
+            "reps_per_geno_stats",
+        ]
+
+        result = calculate_heritability_estimates(
+            df, trait_cols, genotype_col="geno", replicate_col="rep"
+        )
+        assert isinstance(result, dict)
+        for trait in trait_cols:
+            entry = result[trait]
+            for key in existing_keys:
+                assert key in entry
+            assert "blup" in entry
+            assert "intercept" in entry
+
+        tup = calculate_heritability_estimates(
+            df,
+            trait_cols,
+            genotype_col="geno",
+            replicate_col="rep",
+            remove_low_h2=True,
+            h2_threshold=0.99,
+        )
+        assert isinstance(tup, tuple)
+        assert len(tup) == 4
+        heritability_results, df_filtered, removed_traits, removal_details = tup
+        assert len(removed_traits) > 0  # confirm at least one trait was really removed
+        for trait in trait_cols:
+            entry = heritability_results[trait]
+            assert "blup" in entry
+            assert "intercept" in entry
+
+    def test_single_genotype_trait_has_no_blup_keys(self):
+        """A trait with < 2 genotypes (error path) has no blup/intercept keys."""
+        df = pd.DataFrame(
+            {
+                "geno": ["G01"] * 5,
+                "rep": range(1, 6),
+                "trait1": [1.0, 2.0, 3.0, 4.0, 5.0],
+            }
+        )
+        result = calculate_heritability_estimates(
+            df, ["trait1"], genotype_col="geno", replicate_col="rep"
+        )
+        entry = result["trait1"]
+        assert "error" in entry
+        assert "blup" not in entry
+        assert "intercept" not in entry
+
+    def test_mixed_model_fit_failure_has_no_blup_keys(self, heritability_data_known_h2):
+        """A trait whose mixed model fit raises has no blup/intercept keys."""
+        df, _ = heritability_data_known_h2
+        with patch("statsmodels.formula.api.mixedlm", side_effect=Exception("boom")):
+            result = calculate_heritability_estimates(
+                df, ["trait_high_h2"], genotype_col="geno", replicate_col="rep"
+            )
+        entry = result["trait_high_h2"]
+        assert entry["model_type"] == "mixed_model_failed"
+        assert "blup" not in entry
+        assert "intercept" not in entry
+
+    def test_anova_based_and_no_variance_traits_have_no_blup_keys_no_crash(
+        self, heritability_data_known_h2
+    ):
+        """ANOVA-based and no-variance success paths never touch a result object.
+
+        Both paths reach (or, for no-variance, bypass) the shared per-trait dict
+        literal without a fitted mixedlm result; neither should crash or produce
+        blup/intercept keys.
+        """
+        df, _ = heritability_data_known_h2
+        anova_result = calculate_heritability_estimates(
+            df,
+            ["trait_high_h2"],
+            genotype_col="geno",
+            replicate_col="rep",
+            force_method="anova_based",
+        )
+        anova_entry = anova_result["trait_high_h2"]
+        assert anova_entry["model_type"] == "anova_based"
+        assert "blup" not in anova_entry
+        assert "intercept" not in anova_entry
+
+        constant_df = pd.DataFrame(
+            {
+                "geno": ["G01"] * 5 + ["G02"] * 5,
+                "rep": list(range(1, 6)) * 2,
+                "trait_constant": [10.0] * 10,
+            }
+        )
+        novar_result = calculate_heritability_estimates(
+            constant_df, ["trait_constant"], genotype_col="geno", replicate_col="rep"
+        )
+        novar_entry = novar_result["trait_constant"]
+        assert novar_entry["model_type"] == "no_variance"
+        assert "blup" not in novar_entry
+        assert "intercept" not in novar_entry
+
+    def test_adjusted_mean_matches_independent_raw_mean(
+        self, heritability_data_known_h2
+    ):
+        """Intercept + blup[g] approximates genotype g's raw trait mean (balanced)."""
+        df, _ = heritability_data_known_h2
+        trait = "trait_high_h2"
+        result = calculate_heritability_estimates(
+            df, [trait], genotype_col="geno", replicate_col="rep"
+        )
+        entry = result[trait]
+        intercept = entry["intercept"]
+        blup = entry["blup"]
+        raw_means = df.groupby("geno")[trait].mean()
+
+        for geno, raw_mean in raw_means.items():
+            adjusted_mean = intercept + blup[geno]
+            assert adjusted_mean == pytest.approx(raw_mean, abs=0.3)
 
 
 class TestIdentifyHighHeritabilityTraits:

--- a/tests/test_step_statistical_analysis.py
+++ b/tests/test_step_statistical_analysis.py
@@ -547,6 +547,31 @@ class TestBLUPTableOutput:
         assert not (tmp_path / "data" / "08_blup_adjusted_means.csv").exists()
         assert caught == []
 
+    def test_blup_csv_absent_when_both_disabled(
+        self, sample_data, prev_result, tmp_path
+    ):
+        """No BLUP CSV, no exception, when both flags are False.
+
+        Completes the calculate_heritability x generate_blup_table cross
+        product alongside the both-True, heritability-only-False, and
+        blup-only-False cases above.
+        """
+        config = VizPipelineConfig(
+            pipeline_name="test_viz",
+            columns=ColumnConfig(
+                barcode="Barcode", genotype="Genotype", replicate="Replicate"
+            ),
+            data=DataConfig(csv_path="dummy.csv"),
+            statistics=StatisticsConfig(
+                calculate_heritability=False, generate_blup_table=False
+            ),
+        )
+        step = StatisticalAnalysisStep()
+        step.execute(sample_data, config, tmp_path, prev_result)
+
+        assert not (tmp_path / "data" / "08_blup_adjusted_means.csv").exists()
+        assert not (tmp_path / "data" / "08_heritability_results.csv").exists()
+
     def test_blup_table_works_with_qc_config_no_statistics(
         self, sample_data, config, prev_result, tmp_path
     ):

--- a/tests/test_step_statistical_analysis.py
+++ b/tests/test_step_statistical_analysis.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from unittest.mock import patch
 
 import numpy as np
@@ -89,6 +90,10 @@ class TestStatisticalAnalysisStepBasic:
         step.execute(sample_data, config, tmp_path, prev_result)
 
         assert (tmp_path / "data" / "08_heritability_results.csv").exists()
+
+    def test_generate_blup_table_default_true(self):
+        """StatisticsConfig.generate_blup_table defaults to True (#109)."""
+        assert StatisticsConfig().generate_blup_table is True
 
     def test_data_unchanged(self, sample_data, config, prev_result, tmp_path):
         """Test data unchanged."""
@@ -482,6 +487,78 @@ class TestHeritabilityFlagRespected:
 
         # THEN heritability should be calculated (default True)
         assert result.metadata["heritability_results"] != {}
+
+
+class TestBLUPTableOutput:
+    """Test the BLUP-adjusted-means CSV output (#109)."""
+
+    def test_blup_csv_written_when_both_enabled(
+        self, sample_data, viz_config_heritability_enabled, prev_result, tmp_path
+    ):
+        """08_blup_adjusted_means.csv is written when both flags are enabled."""
+        step = StatisticalAnalysisStep()
+        step.execute(
+            sample_data, viz_config_heritability_enabled, tmp_path, prev_result
+        )
+
+        blup_path = tmp_path / "data" / "08_blup_adjusted_means.csv"
+        assert blup_path.exists()
+        blup_df = pd.read_csv(blup_path, index_col=0)
+        assert len(blup_df) == sample_data["Genotype"].nunique()
+
+    def test_blup_csv_absent_when_generate_blup_table_false(
+        self, sample_data, prev_result, tmp_path
+    ):
+        """No BLUP CSV when generate_blup_table=False; heritability CSV unaffected."""
+        config = VizPipelineConfig(
+            pipeline_name="test_viz",
+            columns=ColumnConfig(
+                barcode="Barcode", genotype="Genotype", replicate="Replicate"
+            ),
+            data=DataConfig(csv_path="dummy.csv"),
+            statistics=StatisticsConfig(
+                calculate_heritability=True, generate_blup_table=False
+            ),
+        )
+        step = StatisticalAnalysisStep()
+        step.execute(sample_data, config, tmp_path, prev_result)
+
+        assert not (tmp_path / "data" / "08_blup_adjusted_means.csv").exists()
+        assert (tmp_path / "data" / "08_heritability_results.csv").exists()
+
+    def test_blup_csv_absent_when_heritability_disabled(
+        self, sample_data, viz_config_heritability_disabled, prev_result, tmp_path
+    ):
+        """No CSV, no exception, no warning when heritability is disabled.
+
+        This is an ordinary, legitimate configuration; a warning here would be
+        noise, not a useful signal (see design.md Decision 5).
+        """
+        step = StatisticalAnalysisStep()
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            step.execute(
+                sample_data, viz_config_heritability_disabled, tmp_path, prev_result
+            )
+
+        assert not (tmp_path / "data" / "08_blup_adjusted_means.csv").exists()
+        assert caught == []
+
+    def test_blup_table_works_with_qc_config_no_statistics(
+        self, sample_data, config, prev_result, tmp_path
+    ):
+        """Works with a bare QCPipelineConfig (no statistics attribute), no crash.
+
+        Regression guard for the QC-pipeline AttributeError risk found in
+        review: generate_blup_table must be resolved via the same
+        getattr(config, "statistics", None) fallback calculate_heritability
+        already uses.
+        """
+        step = StatisticalAnalysisStep()
+        step.execute(sample_data, config, tmp_path, prev_result)
+
+        assert (tmp_path / "data" / "08_blup_adjusted_means.csv").exists()
 
 
 # --- Task 2: Tests for metadata and summary ---

--- a/tests/test_step_statistical_analysis.py
+++ b/tests/test_step_statistical_analysis.py
@@ -503,8 +503,10 @@ class TestBLUPTableOutput:
 
         blup_path = tmp_path / "data" / "08_blup_adjusted_means.csv"
         assert blup_path.exists()
-        blup_df = pd.read_csv(blup_path, index_col=0)
+        blup_df = pd.read_csv(blup_path)
+        assert "Genotype" in blup_df.columns
         assert len(blup_df) == sample_data["Genotype"].nunique()
+        assert set(blup_df["Genotype"]) == set(sample_data["Genotype"].unique())
 
     def test_blup_csv_absent_when_generate_blup_table_false(
         self, sample_data, prev_result, tmp_path


### PR DESCRIPTION
## Summary

Tier 1 of the cross-platform genotype-prediction program (#109): extracts BLUP (Best Linear Unbiased Prediction) adjusted genotype means from the existing heritability mixed-model fit. BLUP-adjusted means are the predictor substrate later tiers use to test whether one phenotyping platform's genotype effects predict another's.

- `calculate_heritability_estimates` additively returns `blup`/`intercept` per trait when its mixed model succeeds (both existing return shapes unchanged).
- New `extract_blup_table(heritability_results) -> pd.DataFrame`: genotype x trait BLUP-adjusted-means table, with genuine `NaN` (not zero-filled, not dropped) for any trait/genotype that didn't succeed.
- New `BLUPResult` dataclass + `BLUPResult.from_blup_table(df, *, intercepts=None)` adapter — frozen, JSON-serializable, mirrors `HeritabilityResult`'s per-trait/failed_traits split one level up.
- New `StatisticsConfig.generate_blup_table` (default `True`) — pipeline writes `08_blup_adjusted_means.csv` alongside `08_heritability_results.csv` when both it and `calculate_heritability` are enabled; setting it `True` while `calculate_heritability=False` is a silent no-op (see `design.md` Decision 5).
- `extract_blup_table` + `BLUPResult` exported from the package root.

OpenSpec proposal: `openspec/changes/add-blup-extraction/` (validated `--strict`).

### Fixes from pre-PR self-review

A 5-agent adversarial review (code quality, testing, statistical rigor, performance/cross-platform, behavioural correctness) independently surfaced two real bugs, both fixed on this branch before opening the PR:

1. **Genotype identity was silently dropped from `08_blup_adjusted_means.csv`.** `extract_blup_table()` returns a genotype-indexed DataFrame, but the pipeline's shared `save_dataframe()` writes with `index=False` — the CSV had no genotype column at all. Fixed by resetting the index into a named `Genotype` column before saving; strengthened the regression test to assert the column and its values are present, not just row count.
2. **`BLUPResult.adjusted_means` broke its documented `(n_genotypes, n_traits)` shape** when every trait failed via a cell-level gap (not a zero-row DataFrame) — `genotype_names` stayed populated but `adjusted_means` collapsed to `[]` instead of one empty row per genotype. Fixed by removing an unnecessary/wrong special case; added a regression test.

Also added: the missing `calculate_heritability=False, generate_blup_table=False` config combination test, and a trivial unnecessary-quote cleanup on a type hint.

## Test plan

- [x] `black --check` / `ruff check` clean
- [x] `openspec validate add-blup-extraction --strict` → valid
- [x] Full suite: `uv run pytest --cov=src/sleap_roots_analyze --cov-report=term-missing tests/` → 2617 passed, 31 skipped, 0 failed
- [x] `result_types.py` (new `BLUPResult`) at 100% coverage; `pipeline/steps/statistical_analysis.py` 94%, `pipeline/config/components.py` 99%
- [x] 5-subagent pre-PR self-review completed; both BLOCKING findings fixed and covered by new regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)