### PR TITLE
chore: add giftol pennycress analysis config + wire /review-openspec into new-feature docs

### DIFF
--- a/.claude/commands/new-feature.md
+++ b/.claude/commands/new-feature.md
@@ -25,16 +25,20 @@ as the single entry point so every feature starts the same way.
    ```
    Respect the approval gate — do not start implementing until the proposal is approved.
 
-4. **Plan the work.** For small changes, `tasks.md` is the plan. For larger ones, expand each
+4. **Review the proposal.** Run `/review-openspec` to have the proposal critically reviewed by a
+   team of specialized subagents. Fix any blocking findings and re-run until the verdict is clear,
+   then respect the approval gate — do not start implementing until the proposal is approved.
+
+5. **Plan the work.** For small changes, `tasks.md` is the plan. For larger ones, expand each
    task into bite-sized TDD steps (one failing test → minimal code → commit).
 
-5. **Implement task-by-task with `/tdd`.** Red → green → refactor → commit, one task at a time.
+6. **Implement task-by-task with `/tdd`.** Red → green → refactor → commit, one task at a time.
    Keep `tasks.md` in sync as you go via `/openspec:apply`.
 
-6. **Pre-merge.** Run `/pre-merge-check` (black + ruff + full pytest + coverage, pre-PR
+7. **Pre-merge.** Run `/pre-merge-check` (black + ruff + full pytest + coverage, pre-PR
    self-review, OpenSpec validation, Copilot triage). Then `/pr-description` and open the PR.
 
-7. **Archive after merge.** Run `/openspec:archive <feature>` to fold the change into the specs.
+8. **Archive after merge.** Run `/openspec:archive <feature>` to fold the change into the specs.
 
 ## Conventions (this repo)
 

--- a/configs/active/qc/giftol_pennycress_s32_2026_05_11.yaml
+++ b/configs/active/qc/giftol_pennycress_s32_2026_05_11.yaml
@@ -1,0 +1,79 @@
+# QC Pipeline Configuration: GIFTOL Pennycress S32 2026-05-11
+#
+# Dataset: traits_summary_with_genotype_no_root_widths.csv (979 cols, 140 rows)
+#          root_widths cols pre-filtered (81 removed) — bug #113 workaround
+# Analysis date: 2026-07-13
+# Generated from: qc_template_grouped.yaml
+#
+# Key choices:
+#   heritability.threshold: 0.0 — first-pass exploratory; compute H² for all traits, no filtering
+#   group_by: plant_age_days — Day 7 (70 plants) and Day 17 (70 plants) analyzed independently
+#   columns.replicate: null — H² model is value~1+(1|genotype); replicate value unused (#142 fixed)
+
+pipeline_name: "giftol_pennycress_s32_2026_05_11"
+version: "1.0"
+enable_parallel: false
+
+data:
+  csv_path: "Z:/users/eberrigan/20260709_Emily_Shane_Pennycress_S32_GIFTOL_2026-05-11/sleap_roots_traits_output/traits_summary_with_genotype_no_root_widths.csv"
+  image_dir: null
+  additional_exclude_cols: []
+  validate_input: warn
+  group_by: "plant_age_days"
+
+columns:
+  barcode: "plant_qr_code"
+  genotype: "genotype"
+  # replicate omitted — null by default (#142 fixed; value never used in heritability model)
+
+cleanup:
+  max_zeros_per_trait: 0.5
+  max_nans_per_trait: 0.2
+  max_nan_fraction: 0.0
+  min_samples_per_trait: 17
+
+outlier_detection:
+  traditional_methods:
+    - mahalanobis
+  clustering_methods: []
+  mahalanobis:
+    variance_threshold: 0.95
+    use_chi_squared: true
+    chi2_percentile: 99.0
+
+outlier_removal:
+  strategy: "single"
+  method: "mahalanobis"
+
+pca:
+  n_components: 0.75
+  feature_selection_strategy: "extreme"
+
+heritability:
+  enabled: true
+  threshold: 0.0
+  generate_diagnostics: true
+
+visualization:
+  dpi: 300
+  figsize: [12, 8]
+  figure_format: "png"
+  enable_batched_plots: true
+  batched_plot_threshold: 16
+  batch_size: 16
+
+adaptive_sizing:
+  enabled: true
+  base_width: 8.0
+  base_height: 6.0
+  width_per_item: 2.0
+  height_per_item: 2.0
+  min_width: 6.0
+  max_width: 20.0
+  min_height: 4.0
+  max_height: 16.0
+
+logging:
+  level: "INFO"
+  log_to_file: true
+  log_file: "pipeline.log"

--- a/configs/active/run_manifest_giftol_pennycress_s32_2026_05_11.yaml
+++ b/configs/active/run_manifest_giftol_pennycress_s32_2026_05_11.yaml
@@ -1,0 +1,22 @@
+# Run Manifest: GIFTOL Pennycress S32 2026-05-11
+#
+# Dataset: Z:/users/eberrigan/20260709_Emily_Shane_Pennycress_S32_GIFTOL_2026-05-11/...
+# Analysis date: 2026-07-13
+# Generated from: run_manifest_template.yaml
+#
+# Reproduce this run:
+#   uv run python -m sleap_roots_analyze run-all configs/active/run_manifest_giftol_pennycress_s32_2026_05_11.yaml -o Z:/users/eberrigan/20260709_Emily_Shane_Pennycress_S32_GIFTOL_2026-05-11/sleap-roots-analyze-output
+#
+# All paths are relative to configs/active/
+
+run_name: "giftol_pennycress_s32_2026_05_11"
+description: "QC and Viz for Emily Shane Pennycress S32 GIFTOL 2026-05-11. Groups: plant_age_days (Day 7: 70 plants, Day 17: 70 plants)."
+
+qc_configs:
+  - qc/giftol_pennycress_s32_2026_05_11.yaml
+
+viz_configs:
+  - viz/giftol_pennycress_s32_2026_05_11.yaml
+
+qc_mapping:
+  "viz/giftol_pennycress_s32_2026_05_11.yaml": "qc/giftol_pennycress_s32_2026_05_11.yaml"

--- a/configs/active/viz/giftol_pennycress_s32_2026_05_11.yaml
+++ b/configs/active/viz/giftol_pennycress_s32_2026_05_11.yaml
@@ -1,0 +1,105 @@
+# Visualization Pipeline Configuration: GIFTOL Pennycress S32 2026-05-11
+#
+# Dataset: QC output from qc/giftol_pennycress_s32_2026_05_11.yaml
+# Analysis date: 2026-07-13
+# Generated from: viz_template_no_images.yaml
+#
+# Note: csv_path will be auto-updated to QC output when run via run-all.
+
+pipeline_name: "giftol_pennycress_s32_2026_05_11"
+version: "1.0"
+
+data:
+  csv_path: "FILL_IN_CSV_PATH"
+  image_dir: null
+
+columns:
+  barcode: "Barcode"
+  genotype: "Genotype"
+  replicate: null
+  image_path: null
+
+statistics:
+  calculate_anova: true
+  calculate_heritability: true
+  alpha: 0.05
+
+pca:
+  n_components: 0.75
+  standardize: true
+  feature_selection_strategy: "extreme"
+  n_top_features: 5
+
+umap:
+  enabled: true
+  n_neighbors: 15
+  min_dist: 0.1
+  metric: "euclidean"
+  random_state: 42
+
+clustering:
+  enabled: false
+
+heritability:
+  enabled: true
+  threshold: 0.0
+
+interesting_genotypes:
+  enabled: true
+  methods:
+    - pc_extreme
+    - trait_extreme
+    - heritable_extreme
+  pc_threshold: 2.0
+  trait_percentile: 95.0
+  min_heritability: 0.30
+  max_genotypes: 6
+  generate_image_grids: false
+  images_per_genotype: 9
+
+adaptive_sizing:
+  enabled: true
+  base_width: 8.0
+  base_height: 6.0
+  width_per_item: 2.0
+  height_per_item: 2.0
+  min_width: 6.0
+  max_width: 20.0
+  min_height: 4.0
+  max_height: 16.0
+
+static_viz:
+  enabled: true
+  formats:
+    - png
+    - pdf
+  dpi: 300
+  create_pca_plots: true
+  create_umap_plots: true
+  create_cluster_plots: false
+  create_trait_distributions: true
+  create_trait_correlations: true
+  create_heritability_plots: true
+  create_genotype_comparisons: true
+  pca_biplot_top_features: 1
+
+interactive_viz:
+  enabled: true
+  create_pca_plots: true
+  create_umap_plots: true
+  create_cluster_plots: false
+  show_images_on_hover: false
+
+dashboard:
+  enabled: false
+
+summary:
+  enabled: true
+  formats:
+    - markdown
+    - json
+
+logging:
+  level: "INFO"
+  log_to_file: true
+  log_file: "viz_pipeline.log"


### PR DESCRIPTION
## Summary

Two small, independent pieces of previously-unpushed work recovered from stale local branches during this session's git cleanup:

- **Analysis config** (commit `5b9b62d`, originally `e85d288` on the old `feat/180-umapresult-dataclass` branch): configures the `giftol_pennycress_s32_2026_05_11` QC + viz analysis.
  - Dataset: `traits_summary_with_genotype_no_root_widths.csv` (979 cols, 140 rows); `root_widths` pre-filtered (81 cols removed, bug #113 workaround).
  - Groups: `plant_age_days` — Day 7 (70), Day 17 (70).
  - Key choices: H² threshold=0.0 (first-pass, no filtering), PCA `n_components=0.75`, `feature_selection_strategy=extreme`, `columns.replicate=null` (#142 fixed).
  - Adds `configs/active/qc/giftol_pennycress_s32_2026_05_11.yaml`, `configs/active/viz/giftol_pennycress_s32_2026_05_11.yaml`, `configs/active/run_manifest_giftol_pennycress_s32_2026_05_11.yaml`.
- **Docs** (commit `013a863`, originally `12335bd`): wires `/review-openspec` into the `/new-feature` workflow's proposal-review step, in `.claude/commands/new-feature.md`.

## Test plan
- [x] `uv run python -m sleap_roots_analyze.cli config validate` on both new QC and viz configs — both valid
- [x] `black --check` / `ruff check` clean (no Python files touched)
- [x] Confirmed neither commit conflicts with anything merged since — cherry-picked cleanly onto current `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)