### PR TITLE
feat(#114): fixed_effects param for heritability mixed model (Tier 2 cross-platform prediction)

### DIFF
--- a/configs/templates/viz_template_no_images.yaml
+++ b/configs/templates/viz_template_no_images.yaml
@@ -35,6 +35,12 @@ statistics:
   calculate_anova: true
   calculate_heritability: true
   alpha: 0.05
+  # Optional metadata covariates (e.g. batch/experiment/block/scanner -- not
+  # biological traits) to add as fixed effects to the heritability mixed
+  # model (issue #114). Automatically excluded from the trait_cols scan, so
+  # listing a name here does not also require adding it to
+  # data.additional_exclude_cols.
+  # fixed_effects: ["experiment"]
 
 # PCA configuration
 pca:

--- a/configs/templates/viz_template_with_images.yaml
+++ b/configs/templates/viz_template_with_images.yaml
@@ -44,6 +44,13 @@ statistics:
   # Significance level for ANOVA
   alpha: 0.05
 
+  # Optional metadata covariates (e.g. batch/experiment/block/scanner -- not
+  # biological traits) to add as fixed effects to the heritability mixed
+  # model (issue #114). Automatically excluded from the trait_cols scan, so
+  # listing a name here does not also require adding it to
+  # data.additional_exclude_cols.
+  # fixed_effects: ["experiment"]
+
 # PCA configuration
 pca:
   # Number of PCs to retain (should match QC config)

--- a/docs/API.md
+++ b/docs/API.md
@@ -362,6 +362,21 @@ Calculate broad-sense heritability (H²) for traits using mixed models.
   experiment, wave, batch, scanner) to add as fixed effects, changing the
   model formula from `value ~ 1` to `value ~ C(fe_1) + C(fe_2) + ...`
   (issue #114). Default `None` reproduces pre-existing behavior exactly.
+  A duplicate name within `fixed_effects` (e.g. `["experiment",
+  "experiment"]`) is rejected with a structural `{"error": ...}`, same as a
+  missing or invalid column name. When a mixed-model fit succeeds with zero
+  `ConvergenceWarning`s but a genotype's observations are confined to a
+  single level of a fixed effect that has more than one level overall
+  (a confound `statsmodels` doesn't reliably warn about on its own), a
+  `UserWarning` is emitted describing the possible confound; the trait
+  still returns a normal successful result (this is diagnostic only, not a
+  failure classification).
+- `StatisticsConfig.fixed_effects` (the pipeline config equivalent, used by
+  `VizPipelineConfig`) must be `None` or a `list` of `str` -- a bare string
+  is rejected at config-construction time. Names listed there are also
+  automatically unioned into `VizPipelineConfig.data.additional_exclude_cols`,
+  so a fixed-effect column is never mistaken for a phenotypic trait by the
+  pipeline's upstream `trait_cols` scan.
 
 **Returns:**
 - If `remove_low_h2=False`: Dictionary with heritability results

--- a/docs/API.md
+++ b/docs/API.md
@@ -341,7 +341,8 @@ calculate_heritability_estimates(
     remove_low_h2: bool = False,
     h2_threshold: float = 0.3,
     barcode_col: str = "Barcode",
-    additional_exclude: Optional[List[str]] = None
+    additional_exclude: Optional[List[str]] = None,
+    fixed_effects: Optional[List[str]] = None
 ) -> Union[Dict, Tuple[Dict, pd.DataFrame, List[str], Dict]]
 ```
 
@@ -357,6 +358,10 @@ Calculate broad-sense heritability (H²) for traits using mixed models.
 - `h2_threshold`: Heritability threshold for filtering (default: 0.3)
 - `barcode_col`: Name of sample ID column for preservation
 - `additional_exclude`: Additional columns to exclude from filtering
+- `fixed_effects`: Optional list of metadata-style covariate columns (e.g.
+  experiment, wave, batch, scanner) to add as fixed effects, changing the
+  model formula from `value ~ 1` to `value ~ C(fe_1) + C(fe_2) + ...`
+  (issue #114). Default `None` reproduces pre-existing behavior exactly.
 
 **Returns:**
 - If `remove_low_h2=False`: Dictionary with heritability results

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   pipeline's `StatisticalAnalysisStep` writes `08_blup_adjusted_means.csv` alongside
   `08_heritability_results.csv`. Only takes effect when `calculate_heritability` is
   also `True` — free once the model is fit.
+- `StatisticsConfig.fixed_effects` must now be `None` or a `list[str]` — a bare
+  string is rejected with `ValueError` at config-construction time instead of
+  silently degrading to a per-character `fixed_effects` list (PR #193 review).
+- A `UserWarning` is now emitted when a fixed effect is confounded with genotype
+  (every observation for some genotype confined to a single level of that fixed
+  effect), even when the fit converges cleanly with zero `ConvergenceWarning`s —
+  diagnostic only, does not reclassify the trait's result (PR #193 review).
+- A duplicate name within `fixed_effects` (e.g. `["experiment", "experiment"]`) is
+  now rejected with a structural `{"error": ...}`, matching the existing
+  missing-column/reused-name error shape, instead of an obscure `patsy` failure
+  (PR #193 review).
+
+### Fixed
+- `VizPipelineConfig` now automatically unions `statistics.fixed_effects` into
+  `data.additional_exclude_cols` at construction time, so a fixed-effect column
+  named outside the hardcoded metadata-substring list (e.g. `"block"`) is no
+  longer silently treated as a phenotypic trait by the pipeline's upstream
+  `trait_cols` scan. The existing `remove_low_h2=True` fix for direct API callers
+  never reached the pipeline, since `StatisticalAnalysisStep` always calls with
+  `remove_low_h2=False` (PR #193 review).
 
 ### Changed
 - `calculate_heritability_estimates` additively returns `blup` (`dict[str, float]`) and

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `calculate_heritability_estimates(fixed_effects=...)` (#114): optional list of
+  metadata-style covariate columns (experiment, wave, batch, scanner) added as
+  fixed effects to the mixed model, changing the formula from `value ~ 1` to
+  `value ~ C(fe_1) + C(fe_2) + ...` — every name is `C(...)`-wrapped
+  unconditionally (always categorical). Corrects a heritability-inflation bug
+  where a batch/experiment confound gets absorbed into the genotype term when
+  genotypes aren't balanced across batches. Default `None` reproduces
+  pre-existing behavior exactly. Tier 2 of the cross-platform
+  genotype-prediction program (Tier 1: #109).
+- `StatisticsConfig.fixed_effects` (default `None`): threads the above into the
+  QC/Viz pipeline's `StatisticalAnalysisStep`.
 - `extract_blup_table(heritability_results)` (#109): builds a genotype x trait
   BLUP-adjusted-means `pd.DataFrame` from a `calculate_heritability_estimates` result —
   `adjusted_mean = intercept + blup[genotype]` for each trait whose mixed model
@@ -33,6 +44,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   existing return shapes (plain dict, or the `remove_low_h2=True` 4-tuple) are
   unchanged. A trait solved via the ANOVA-based or no-variance path carries no such
   keys, since no fitted mixed-model result exists for those paths.
+- When `fixed_effects` is used (#114), the `intercept` key becomes an empirical,
+  sample frequency-weighted value instead of the raw model intercept — a
+  sample-composition-dependent quantity that can differ trait-to-trait, not a
+  population-typical value. A captured `ConvergenceWarning` during the fit (only
+  when `fixed_effects` is set) is now treated as a trait-level failure, since
+  `statsmodels` does not reliably raise on a fixed effect confounded with
+  genotype. No change when `fixed_effects` is unset.
 
 ## [0.1.0a5] - 2026-07-13 (Pre-release)
 

--- a/docs/result-types.md
+++ b/docs/result-types.md
@@ -92,6 +92,15 @@ dict directly if you need that mapping. (`feature_names` on `KMeansResult`/
 `GMMResult`/`HierarchicalResult` is derived from the columns actually used for
 fitting, not a pre-filter snapshot — #183 fixed this at the producer level.)
 
+**`BLUPResult.intercepts` semantics depend on the source call (#114).** When the
+`calculate_heritability_estimates` call backing `extract_blup_table()` used a
+non-empty `fixed_effects`, a trait's `intercepts` value is an empirical, sample
+frequency-weighted quantity (see that function's docstring) rather than the
+plain model intercept — it can differ trait-to-trait and is not a
+population-typical value. `BLUPResult`/`from_blup_table` are unaware of
+`fixed_effects` and store whatever `intercept` float each trait's source dict
+carries, unchanged.
+
 ## Backwards compatibility
 
 **Additive only.** Existing callers (`result["loadings"]`, the wheat EDPIE paper, the

--- a/openspec/changes/add-heritability-fixed-effects/design.md
+++ b/openspec/changes/add-heritability-fixed-effects/design.md
@@ -730,3 +730,55 @@ surfaced 4 more real, fixed issues:
   `fixed_effects=None` caller would still see such a warning). Not required
   by any spec scenario; left as a candidate follow-up rather than expanding
   this tier's scope further.
+
+## PR Review Follow-up (`/review-pr` on PR #193, after the pre-merge review above)
+
+A `/review-pr` pass on the already-open PR reproduced one BLOCKING crash
+(fixed immediately, see `tasks.md` 7.1/7.2) plus four IMPORTANT/minor items
+initially deferred as candidate follow-up issues. On explicit user request,
+all four were fixed in this same PR instead of filed separately (see
+`tasks.md` 7.3–7.6 for the full description and tests of each):
+
+- **7.3 — the pipeline never benefited from the `remove_low_h2=True` fix
+  above.** That fix (pre-merge review, this file) unions `fixed_effects`
+  into `additional_exclude` for direct API callers, but
+  `StatisticalAnalysisStep` always calls with `remove_low_h2=False` — a
+  literal, intentional hardcoded value (this step only *calculates*
+  results; a separate, later step owns actual trait removal), not a
+  configurable flag and not the right lever to fix this regardless. The
+  real gap is upstream: `trait_cols` is fixed once at pipeline step 1
+  (`LoadDataAndImagesStep`), using only `data.additional_exclude_cols`, with
+  no knowledge of `statistics.fixed_effects` at all. **Design choice: auto-
+  derive**, over validating disjointness and requiring the user to name a
+  column in both places (which only makes the trap loud, not gone).
+  `VizPipelineConfig.__post_init__` now unions `statistics.fixed_effects`
+  into `data.additional_exclude_cols` at config-construction time.
+  `QCPipelineConfig` has no `statistics` field, so this fix's reach is
+  `VizPipelineConfig` — the only config class composing both components
+  today.
+- **7.4 — no config-schema validation.** A bare string (itself iterable)
+  passed as `fixed_effects` would silently become a per-character list.
+  Fixed with a `StatisticsConfig.__post_init__` type check. The
+  nonexistent-column half needed no new code — already caught at runtime by
+  the existing missing-column check, which is as early as it can be since
+  column names aren't knowable until data loads.
+- **7.5 — the `ConvergenceWarning` false-negative (documented as a
+  limitation in the pre-merge review above) is now also an actual
+  `UserWarning`.** After a clean fit with `fixed_effects` set, if any
+  genotype's observations are confined to a single level of a fixed effect
+  with more than one level overall, a `UserWarning` fires — purely
+  diagnostic, doesn't reclassify the fit as failed. Confirmed to generalize
+  correctly by re-running the existing test suite: it fires (correctly, not
+  a false positive) on the pre-existing `heritability_data_field_block`
+  fixture (1.2), where several of the 7 low-rep (n=2) genotypes round to
+  100% of their reps in one block under the fixture's 80/20 skew spec —
+  a real, previously-silent confound for those specific genotypes that this
+  heuristic now surfaces without changing any fixture or existing
+  assertion.
+- **7.6 — duplicate names within `fixed_effects` and the single-level
+  case.** A repeated name (e.g. `["experiment", "experiment"]`) now returns
+  the same structural `{"error": ...}` shape as the missing-column/
+  reused-name checks, instead of an obscure patsy failure. The single-level
+  (zero-variance) fixed-effect case needed no code change — a new
+  regression test confirms `_marginal_intercept`'s existing identity check
+  already handles zero recovered non-reference coefficients correctly.

--- a/openspec/changes/add-heritability-fixed-effects/design.md
+++ b/openspec/changes/add-heritability-fixed-effects/design.md
@@ -1,0 +1,732 @@
+## Context
+
+`calculate_heritability_estimates` (`statistics.py:195-479`) fits
+`smf.mixedlm("value ~ 1", model_data, groups=genotype)` per trait with REML,
+genotype-only. Issue #114 (tracking this tier) documents a concrete case where
+this inflates apparent H²: Mauricio Chiurazzi's combined alfalfa GWAS (35
+accessions × 6 Bloom experiments) reports H² ≈ 0.83 for a trait whose naive
+within-genotype ICC is 0.087–0.318, because genotypes are unbalanced across
+experiments and a per-experiment scanner-calibration shift is confounded with
+the genotype term.
+
+Tier 1 (`add-blup-extraction`, merged) extracted `result.random_effects` into
+a `blup`/`intercept` pair per successful trait and built `extract_blup_table()`
+/ `BLUPResult` on top of it. Tier 1's proposal flagged the `R_j` (field
+block/replicate) design question as tentatively resolved in favor of a fixed
+effect, not a second random effect, for continuity into this tier — confirmed
+during this session's brainstorm (see Decision 4).
+
+## Goals / Non-Goals
+
+- **Goals:** `fixed_effects: Optional[List[str]] = None` parameter on
+  `calculate_heritability_estimates`; categorical (`C()`-wrapped) treatment for
+  every fixed-effect column; missing-column validation consistent with the
+  existing `genotype_col`/`replicate_col` pattern; a marginal (frequency-
+  weighted) intercept so `extract_blup_table()`'s adjusted means stay
+  report-ready rather than pinned to an arbitrary reference level;
+  `StatisticsConfig.fixed_effects` threaded through `StatisticalAnalysisStep`;
+  the roadmap's oracle (synthetic batch-confounded data: uncorrected H² >
+  corrected H²; field BLUPs with block correction differ from genotype-only
+  BLUPs).
+- **Non-Goals:** changing the H² formula itself or genotype variance-component
+  extraction; any LOGO-CV, ridge/PLS, or prediction machinery (Tier 3+);
+  identifiability/collinearity pre-validation for `fixed_effects` (reuses the
+  existing per-trait `try/except`); coupling `fixed_effects` to
+  `replicate_col`; a new `blup.py`/formula-building module (stays inline in
+  `statistics.py`, matching Tier 1's placement decision).
+
+## Decisions
+
+### Decision 1: Config lives on `StatisticsConfig`, not `HeritabilityConfig`
+
+**What:** `fixed_effects: Optional[List[str]] = None` is added to
+`StatisticsConfig` (`components.py:532`). Issue #114's illustrative YAML
+(`heritability.fixed_effects`) is not followed literally.
+
+**Why:** `HeritabilityConfig` (`components.py:216`) is documented as
+"Heritability analysis and **filtering** configuration" and is consumed by a
+later,
+separate step (`FilterHeritabilityStep`, gated by `HeritabilityConfig.enabled`)
+that has no relationship to how `calculate_heritability_estimates` itself is
+invoked. `StatisticsConfig` is the dataclass `StatisticalAnalysisStep` actually
+reads to build the `calculate_heritability_estimates(...)` call
+(`statistical_analysis.py:172-179`) — it already owns `calculate_heritability`
+and `generate_blup_table` (Tier 1), the two flags this new parameter is most
+directly related to. Issue #114's YAML sketch was written for readability
+before either config dataclass's actual wiring was inspected; no other issue
+mandates the literal `heritability.*` placement.
+
+**Alternatives considered:**
+- **Add it to `HeritabilityConfig` and thread a new value through to
+  `StatisticalAnalysisStep`.** Rejected: matches the issue's YAML literally,
+  but requires new plumbing to move a value from a filtering-step config into
+  a calculation-step call, and couples two config dataclasses that currently
+  have no relationship — added complexity for no behavioral benefit.
+
+### Decision 2: Every fixed-effect column is wrapped in `C()` unconditionally
+
+**What:** The formula is built as `"value ~ " + " + ".join(f"C({fe})" for fe
+in fixed_effects)`. No dtype inspection; every column is always coded as
+categorical, regardless of whether its underlying dtype is numeric or object.
+
+**Why:** Fixed effects in this context are metadata-style confounders
+(experiment, wave, batch, scanner) — issue #114's own acceptance criteria
+say so explicitly. A column like `wave_number` (values `1, 2, 3`) is
+numeric-*looking* but categorical in meaning; without `C()`, patsy would treat
+it as a continuous covariate (one linear-slope coefficient instead of one
+coefficient per wave), silently changing what the model estimates. Since this
+whole tier exists to stop a categorical confounder from leaking into the
+genotype term, defaulting to the interpretation that actually removes the
+confound — and making it unconditional rather than configurable — closes the
+exact failure mode the issue describes rather than reintroducing a milder
+version of it.
+
+**Alternatives considered:**
+- **Infer from dtype (`C()` only for object/category columns).** Rejected:
+  more flexible (would allow a genuinely continuous covariate), but
+  reintroduces the silent-misinterpretation risk for a numeric-looking
+  metadata column, and adds a code path with its own edge cases (e.g. an
+  integer-coded categorical that a naive dtype check would treat as
+  continuous) for a flexibility this tier's use cases don't need.
+
+### Decision 3: Empirical frequency-weighted intercept, not a reference-level pin
+
+**What:** When `fixed_effects` is set, `intercept` is computed as a
+frequency-weighted average across each fixed effect's *observed* levels — for
+each fixed effect, each level's fitted contribution (`0` for the reference
+level, its own coefficient in `result.fe_params` for every other level) is
+weighted by that level's share of the fitted `model_data`, then summed across
+all fixed effects and added to the base `Intercept` coefficient. When
+`fixed_effects` is `None`, this is exactly `result.fe_params["Intercept"]` —
+today's behavior, unchanged.
+
+**Why:** Patsy's default treatment coding drops one level per fixed effect as
+a reference (the first level in sorted order for a plain column, or the first
+declared category for a pandas `Categorical` — not reliably "alphabetical," a
+looser claim than an earlier draft of this decision made), so
+`result.fe_params["Intercept"]` alone represents "the fitted value when every
+fixed effect is at its reference level" — not a value with any particular
+scientific meaning, since the reference level is a naming artifact, not a
+chosen baseline. For any *relative* use of `extract_blup_table()`'s adjusted
+means (Tier 3's ridge/PLS, rankings, correlations), the choice of intercept is
+irrelevant — it is a single scalar added identically to every genotype (proof
+in the Risks section below), so it cancels out of every comparison. It only
+matters when the raw adjusted-mean numbers are read directly (e.g. in the
+EDPIE paper's supplementary tables), where "value under the reference level's
+specific condition" is a narrower, more surprising claim than "value under
+typical/average conditions." The frequency-weighted average is cheap — it
+reuses coefficients `fe_params` already contains, no additional model fit —
+and removes this caveat entirely rather than documenting around it.
+
+**Revised after adversarial review — naming precision matters here.** The
+quantity computed is *not* a population-typical or EMM/lsmeans-style marginal
+mean (the standard biometrics convention, e.g. R's `emmeans`, deliberately
+uses *equal* weighting across levels precisely to avoid baking incidental
+sample composition into a "typical" value). What's actually computed is an
+**empirical, sample-frequency-weighted average over that specific trait's own
+post-`dropna()` fitted rows** — an "observed-margins" quantity. Two concrete
+consequences, now stated explicitly rather than left implicit: (1) if one
+experiment has more scans purely for logistical reasons, the intercept skews
+toward it regardless of biological representativeness; (2) since `model_data`
+is trait-specific (each trait computes its own `dropna()`), two traits sharing
+the same `fixed_effects` columns can get *different* level weights purely
+from differing missing-data patterns — the intercept is not a single stable
+per-dataset quantity. Documented in the docstring and the statistics-api spec
+delta as "empirical frequency-weighted," not "population-typical," to avoid
+misleading a future reader of raw `adjusted_mean`/`BLUPResult.intercepts`
+values (e.g. in a paper table). An equally-weighted (true EMM-style) variant
+is called out as a non-goal for a future tier, not conflated with what ships
+here.
+
+**Also revised — coefficient lookup must not reconstruct keys forward.** The
+per-level coefficient is retrieved by parsing `result.fe_params`'s actual
+fitted parameter index (regex `^C\({fe}\)\[T\.(.*)\]$` per fixed effect) to
+recover the set of levels patsy actually fit non-reference coefficients for,
+rather than building the expected key string forward from each observed
+level's raw value (e.g. `f"C({fe})[T.{level}]"` for `level` enumerated from
+`model_data[fe].unique()`). The forward-reconstruction approach was the
+original draft of this decision; adversarial review found it has no way to
+distinguish "this level genuinely is the reference level" from "the
+reconstructed key string didn't match `fe_params`'s actual key due to a
+dtype/formatting difference" (concretely: a `float64`-dtype fixed-effect
+column, or a level whose `str()` representation doesn't exactly match
+patsy's internal label). Both cases fall through the same `dict.get(key,
+0.0)`-style default, silently misattributing a real, non-reference,
+non-zero-coefficient level to the reference level's implicit contribution —
+a silent-corruption risk with no error signal, which is a serious defect for
+a change whose whole purpose is eliminating a different silent-corruption
+risk (batch effects leaking into H²). Parsing the fitted index forward,
+matching each recovered level string back to `model_data[fe]`'s values by
+equality (not by positional pairing against a separately-sorted level list —
+round-2 review found a `pandas.Categorical` with a non-default `categories=`
+order would break a positional-pairing implementation without breaking a
+count-only check), and asserting the recovered level count equals `n_levels -
+1` (raising rather than silently defaulting otherwise) closes this gap.
+**`n_levels` is `model_data[fe].nunique()` — that trait's own
+post-`dropna()` fitted subset, not the raw input `df`** (clarified after
+round-2 review found this was ambiguous): a level present in `df` can be
+entirely absent from a specific trait's `model_data` due to that trait's own
+missingness pattern, so using the raw `df` count would make an entirely
+correct implementation raise a false `ValueError`.
+
+**Alternatives considered:**
+- **Keep the reference-level intercept, document the caveat.** Considered
+  first; rejected after establishing the marginal version is a few lines over
+  existing `fe_params`, not a new statistical method, so there is little cost
+  to removing the caveat rather than living with it, given these BLUP tables
+  may be read directly in paper-facing outputs.
+- **True equal-weighted EMM/lsmeans-style intercept.** Considered during
+  review; rejected for this tier as more statistical machinery than the
+  oracle requires (the oracle only needs corrected vs. uncorrected H² to
+  differ in the right direction, and BLUP tables to differ from
+  genotype-only) — recorded as an explicit non-goal rather than silently
+  approximated by the empirical-frequency version.
+
+### Decision 4: `fixed_effects` and `replicate_col` are fully independent
+
+**What:** `replicate_col` is unchanged — validated for presence (when
+truthy), never read in the model. A block/replicate fixed effect (`R_j`) is
+expressed by naming that column in `fixed_effects` (e.g.
+`fixed_effects=["block"]`); no new validation or auto-inclusion links the two
+parameters.
+
+**Why:** This is Tier 1's tentative design note, confirmed here: `R_j` as a
+fixed effect (this tier's mechanism) rather than a second random effect. Once
+`fixed_effects` is a generic list of column names, "a block/replicate fixed
+effect" is already fully expressible without any special-casing — adding
+coupling (e.g. auto-including `replicate_col`, or validating it isn't
+duplicated in `fixed_effects`) would add surface area for a scenario the
+generic mechanism already covers.
+
+**Alternatives considered:**
+- **Special-case coupling between the two parameters.** Rejected: no
+  behavior it would enable isn't already reachable by passing the column name
+  into `fixed_effects` directly.
+
+### Decision 5: Model-fit failures reuse the existing per-trait `try/except`, extended to capture `ConvergenceWarning`
+
+**What:** No new upfront identifiability/collinearity pre-validation for
+`fixed_effects`. A fixed effect fully confounded with genotype, or any other
+convergence failure introduced by adding fixed effects, is caught by the
+existing `except Exception as e:` block around the mixed-model fit
+(`statistics.py:392-398`) and recorded as `{"error": "Mixed model failed:
+...", "model_type": "mixed_model_failed"}` for that trait — identical handling
+to today's non-convergence failures. **Revised after adversarial review:**
+**only when `fixed_effects` is non-empty**, the fit call is additionally
+wrapped in `warnings.catch_warnings(record=True)` with
+`warnings.simplefilter("always")` called immediately inside that block, and
+if a convergence warning is captured, that trait is treated as failed (same
+error dict shape) even though `statsmodels` did not raise. **The
+`fixed_effects`-non-empty gate on this specific behavior was caught during
+implementation, not by any of the four review rounds**: earlier drafts of
+this decision and the corresponding spec text described the warning-capture
+without explicitly stating it was conditional, even though this decision's
+own "byte-for-byte identical when `fixed_effects=None`" guarantee (shared
+with every other behavior change in this tier) logically requires it — an
+unconditional check would newly fail an existing, non-`fixed_effects` caller
+whose fit happens to emit a convergence warning today and currently
+succeeds. Fixed by making the gate explicit in the spec's requirement
+prose and adding a dedicated regression test (tasks.md 1.9b). The
+`simplefilter("always")` call is required, not optional (added after round-2
+review): Python's default warning filter is once-per-source-location, and
+`statsmodels` raises its `ConvergenceWarning` from the same internal source
+line every time — without forcing "always," a *second* trait hitting the
+same non-convergent code path in the same process could have its identical
+warning silently dropped by the registry, reintroducing exactly the silent-
+failure risk this decision exists to close, just for later traits. This bug
+would not be caught by a test that observes only one warning occurrence in
+isolation, since pytest's own warnings plugin already applies
+`simplefilter("always")` around every test and would mask a missing call in
+production code (see tasks.md 1.13, added specifically to exercise the
+two-trait case). **Also required (added after round-3 review): the check
+SHALL filter by warning *category* —
+`issubclass(w.category, statsmodels.tools.sm_exceptions.ConvergenceWarning)`
+— not by matching the warning's message text.** Several real `statsmodels`
+convergence-related warning messages do not contain the word "convergence"
+at all (e.g. "The MLE may be on the boundary of the parameter space." and
+"The Hessian matrix at the estimated parameter values is not positive
+definite."), which a message-substring implementation would silently miss —
+defeating this decision's purpose on exactly the messages a near-confounded
+fixed effect is most likely to trigger. Symmetrically, a warning of any
+*other* category captured in the same block (a stray `RuntimeWarning` or
+`FutureWarning` from an unrelated dependency) SHALL NOT be treated as a fit
+failure — tasks.md 1.9a adds the false-positive counterpart test.
+
+**Why:** The existing per-trait error path already tolerates model-fit
+failure gracefully (records the error, continues to the next trait), so
+reusing it for a *raised* exception needs no new machinery. But adversarial
+review found a real gap: `statsmodels.MixedLM.fit()` does not reliably raise
+on a fixed effect that is (near-)fully confounded with genotype — exactly the
+scenario the batch-confounded oracle fixture (tasks.md 1.1) deliberately
+constructs. It can instead emit a `ConvergenceWarning` via Python's `warnings`
+machinery and still return a `result` with plausible-looking (but
+potentially degenerate) `blup`/`intercept`/`heritability` values — no
+exception, so the existing `try/except` alone would let it through silently.
+Shipping a mechanism that can silently produce a plausible-but-wrong H² from
+over-fitting/aliasing would reintroduce, via a different mechanism, the same
+class of problem (silently-wrong H² from unmodeled structure) that issue #114
+exists to fix. Capturing the warning and treating it as a failure closes this
+without adding a new upfront validation layer — it still relies on
+`statsmodels`' own signal, just observes both channels (exceptions and
+warnings) instead of only exceptions.
+
+**Alternatives considered:**
+- **Pre-validate that no fixed effect is a deterministic function of
+  genotype** (i.e. perfectly confounded), checked before fitting. Rejected:
+  adds a new validation surface (what counts as "too confounded" is itself a
+  judgment call) for a case `statsmodels`' own convergence diagnostics already
+  signal, once that signal is actually observed (see revision above) — no
+  oracle-driven need to distinguish "failed because of a fixed effect" from
+  "failed for any other reason" in the returned error.
+- **Rely on raised exceptions only (the original draft of this decision).**
+  Rejected after adversarial review established this leaves the exact
+  batch-confounded scenario this tier targets able to silently succeed with a
+  degenerate fit.
+
+## Risks / Trade-offs
+
+- **Marginal intercept computation must handle multiple fixed effects
+  correctly.** With `fixed_effects = ["experiment", "block"]`, `fe_params`
+  contains additive main-effect offsets for both (patsy's `+` composes
+  additively, not as an interaction) — the marginal-intercept helper must sum
+  each effect's own frequency-weighted contribution independently and add
+  both to the base `Intercept`, not conflate them. Re-derived independently
+  during adversarial review by linearity of expectation:
+  `mean_i[Intercept + β_exp[e_i] + β_block[b_i]] = Intercept +
+  Σ_e freq_exp[e]·β_exp[e] + Σ_b freq_block[b]·β_block[b]` — this
+  decomposition holds regardless of whether `experiment` and `block` are
+  correlated/nested with each other in the data (no orthogonality assumption
+  needed), so the "contribute independently" requirement is on solid ground.
+  Covered by a dedicated multi-fixed-effect test (tasks.md §2).
+- **Choice of intercept convention (reference-level vs. empirical
+  frequency-weighted) shifts every genotype's `adjusted_mean` by the same
+  additive constant, preserving Tier 1's ranking/shrinkage properties.**
+  Re-derived during adversarial review: `blup[g]` comes solely from
+  `result.random_effects`, fixed once the model is fit and independent of how
+  `intercept` is reported afterward (pure post-hoc arithmetic on already-fit
+  coefficients, touching no fitting step). So `adjusted_mean[g] = intercept +
+  blup[g]` shifts by exactly `(I_marginal - I_reference)` for *every*
+  genotype, regardless of which fixed-effect levels that genotype happened to
+  appear in — rankings and pairwise differences are invariant. This confirms
+  Decision 3 is safe without needing an explicit new regression scenario for
+  this specific property, since it holds structurally rather than
+  empirically. (This is a distinct question from Decision 3's own concern
+  about the *level* of the intercept value being sample-composition-
+  dependent — that concern is about the value's absolute interpretation, not
+  about whether the shift is uniform across genotypes.)
+- **`fixed_effects` changes which rows survive `dropna()`, identically for
+  both the mixed-model and ANOVA-based (`force_method="anova_based"`)
+  paths.** A row with a valid trait value and genotype but a missing
+  fixed-effect value is now dropped from the model fit — a real behavior
+  change from today, but only when `fixed_effects` is explicitly set; `None`
+  (default) is unaffected. The subset computation happens once, before the
+  `if use_mixed_model:` branch, so both paths see the same filtered rows;
+  only the mixed-model path uses `fixed_effects` in its formula — the
+  ANOVA-based path continues to ignore it for modeling purposes. Documented
+  in the parameter's docstring and covered by a dedicated test, plus an
+  explicit test that the `force_method="anova_based"` combination applies
+  the same row-filtering without attempting to use `fixed_effects` in that
+  branch's variance-component arithmetic (added after adversarial review
+  flagged this combination as untested).
+- **Silent convergence failure under genotype-confounded fixed effects** —
+  see Decision 5's revision above. Mitigated by capturing
+  `ConvergenceWarning` rather than relying solely on raised exceptions.
+  Tasks.md adds one *organic* (non-mocked) test with a fixed effect that is a
+  near-deterministic function of genotype, to observe and document actual
+  `statsmodels` behavior on this fixture, in addition to the existing mocked
+  test for the raised-exception path (`test_mixed_model_fit_failure_has_no_blup_keys`-style, from Tier 1's precedent).
+- **Reusing Tier 1's shrinkage-property scenarios unmodified on a
+  fixed-effects run risks an ambiguous reference point.** Tier 1's existing
+  "BLUP Shrinkage and Balanced-Design Properties" requirement compares
+  shrinkage against the naive, unconditional grand/raw mean
+  (`df.groupby(genotype)[trait].mean()`). Once `fixed_effects` is set on a
+  design unbalanced across fixed-effect levels (this tier's core use case), a
+  genotype's naive raw mean is itself confounded by the fixed effect —
+  shrinkage is properly toward the model's fixed-effects-adjusted intercept,
+  not the naive unconditional grand mean. The shrinkage math itself isn't
+  mechanically threatened by adding correctly-specified fixed effects (REML
+  shrinkage of a random effect is a generic MixedLM property, independent of
+  which fixed effects are in the formula), but no scenario re-verifies
+  shrinkage-scales-with-`n_i` under `fixed_effects` using the *correct*
+  reference point. Added as an explicit task (tasks.md §3) after adversarial
+  review flagged the gap.
+
+## Migration Plan
+
+Purely additive — no existing caller changes required:
+- `calculate_heritability_estimates(df, trait_cols, ...)` without
+  `fixed_effects` (the default, `None`) produces byte-for-byte identical
+  output to today, including the `intercept` value.
+- `StatisticalAnalysisStep` gains one new optional config field
+  (`fixed_effects`, default `None`); existing configs that don't set it are
+  unaffected.
+- `extract_blup_table()` and `BLUPResult` require no *code* changes — both
+  already consume whatever `intercept` float
+  `calculate_heritability_estimates` produces. `BLUPResult.intercepts`'s
+  docstring (`result_types.py`) is updated to describe the new semantics of a
+  value it already stores verbatim — a docs-only change, not a logic change
+  (corrected after adversarial review found this docstring update, and the
+  matching `docs/result-types.md` caveat, were listed in `proposal.md`'s
+  Impact section but missing from `tasks.md` entirely; both are now tracked).
+
+No rollback concerns beyond reverting the additive commits.
+
+## Open Questions
+
+None blocking Tier 2. Tier 3's design questions (PLS component count,
+representative-clustering aggregation level, permutation runtime) are
+unaffected by this tier and remain open there.
+
+## Adversarial Review Reconciliation (round 1)
+
+`/review-openspec` ran 5 parallel reviewers (spec quality, TDD/testing,
+statistical correctness, documentation, git workflow). 3 BLOCKING and 7
+IMPORTANT findings, all reconciled into this document, `proposal.md`, and
+`tasks.md`:
+
+- **BLOCKING** — Impact section promised a `result_types.py`/
+  `docs/result-types.md` update with no corresponding task, plus a factual
+  error (referenced a nonexistent `HeritabilityResult` per-trait `intercept`
+  field). Fixed: proposal.md corrected, tasks.md gains explicit tasks
+  (§2.7–2.8).
+- **BLOCKING** — forward-reconstructed `fe_params` key lookup could silently
+  misattribute a real level to the reference level on a dtype/formatting
+  mismatch. Fixed: Decision 3 revised to parse `fe_params`'s actual fitted
+  index instead.
+- **BLOCKING** — `statsmodels.MixedLM.fit()` doesn't reliably raise on a
+  fixed effect confounded with genotype; could silently ship a degenerate fit
+  in exactly this tier's target scenario. Fixed: Decision 5 revised to
+  capture `ConvergenceWarning` and treat it as a fit failure.
+- **IMPORTANT** — "marginal intercept" mislabeled as population-typical;
+  it's actually a per-trait, sample-frequency-weighted quantity. Fixed:
+  Decision 3 and proposal.md reworded to "empirical frequency-weighted,"
+  with the per-trait-instability caveat stated explicitly.
+- **IMPORTANT** — no test for `fixed_effects` + `force_method="anova_based"`;
+  no test for shrinkage-property regression under `fixed_effects`; no test
+  for `BLUPResult.from_blup_table()` pass-through of fixed-effects-derived
+  intercepts. Fixed: tasks.md gains 1.12, 3.2, 2.7 respectively (see
+  tasks.md).
+- **IMPORTANT** — fixture 1.1 lacked pinned numeric parameters (unlike Tier
+  1's precedent), risking CI flakiness across the 3-OS matrix. Fixed: tasks.md
+  1.1 now specifies concrete variance components, shift magnitude, seed, and
+  confounding split.
+- **IMPORTANT** — `calculate_heritability_estimates`'s `Returns:` docstring
+  sentence describing `intercept` as unconditionally
+  `result.fe_params["Intercept"]` would go stale. Fixed: folded into tasks.md
+  2.6's implementation task.
+- **IMPORTANT** — task 1.5's fallback plan ("if direct result access isn't
+  practical...") was a live open decision. Fixed: resolved directly — the
+  fitted `result` object is not exposed by
+  `calculate_heritability_estimates`'s return value, so the test independently
+  re-fits via `smf.mixedlm` on the same `model_data`, matching tasks 2.2-2.4's
+  approach; tasks.md 1.5 updated to state this directly instead of offering
+  two options.
+- **SUGGESTION** — added non-goal bullets (continuous covariates,
+  equal-weighted EMM variant) to proposal.md's "Explicitly out of scope."
+- **SUGGESTION** — added an assertion that `fixed_effects=[]` behaves
+  identically to `None`, folded into tasks.md 1.3.
+- Not reconciled (deliberately, low severity per the documentation
+  reviewer): `docs/QC_PIPELINE_GUIDE.md`'s `statistics:` block documentation
+  gap pre-dates this tier (Tier 1's `generate_blup_table` isn't documented
+  there either) — left as a candidate follow-up issue, not blocking this
+  change.
+
+## Adversarial Review Reconciliation (round 2)
+
+A second, targeted round re-checked round 1's fixes specifically (not a full
+re-review). Found the substantive fixes were correct, but surfaced 5 more
+issues — all reconciled:
+
+- **Real gap (statistical correctness)** — `warnings.catch_warnings(record=True)`
+  alone doesn't force every occurrence of an identical warning to be
+  recorded; Python's default once-per-location filter can silently drop a
+  *second* trait's identical `ConvergenceWarning` in the same process, and no
+  test could have caught it (pytest's own warnings plugin masks the gap in
+  any single-occurrence test). Fixed: Decision 5 now requires
+  `warnings.simplefilter("always")` inside the block; tasks.md gains 1.13
+  (two-trait repeat-warning test).
+- **Real gap (statistical correctness)** — the coefficient-lookup fix's
+  "match recovered level to frequency" step was ambiguous about
+  equality-matching vs. positional pairing, and `n_levels` was never defined
+  as `model_data[fe]` (post-`dropna()`) vs. raw `df`. Fixed: Decision 3 and
+  tasks.md 2.6 now state both explicitly; tasks.md gains 2.5a (non-sorted
+  `pd.Categorical` test, the one case that would expose a positional-pairing
+  bug that count-only or sorted-order-assuming code would pass).
+- **Spec-quality gap** — task 1.10 (organic near-confounded test) is a
+  characterization/regression-pinning test whose assertion content cannot be
+  known before implementation exists, which doesn't fit "(test-first)"'s
+  red-green framing and had no scenario documenting it. Fixed: added an
+  explicit sequencing note to task 1.10 stating it's written after 1.11
+  lands, and a note that it's intentionally spec-exempt (nothing to
+  prescribe in advance, only to pin).
+- **Mechanical** — task 1.12 (the `anova_based` combination test, itself a
+  round-1 addition) was missing its "(New — added after review)" tag; this
+  reconciliation section's own citations pointed at stale task numbers after
+  tasks.md was renumbered mid-revision (`§2.6`→`§2.7–2.8`, `2.5`→`2.6`,
+  `1.10`→`1.12` in the bullets above — already corrected in place rather than
+  left as a visible diff, since the citations were simply wrong, not a
+  design change). Fixed: 1.12 tagged; citations corrected.
+- **Structural nit** — tasks.md's 5.3 was a checkbox that did nothing
+  (pure cross-reference to 2.8). Fixed: converted to a blockquote note,
+  consistent with the file's existing meta-commentary convention.
+
+## Adversarial Review Reconciliation (round 3)
+
+A third round did a fresh cold-read (assuming no memory of rounds 1–2) plus
+targeted stress-tests of the newest round-2 material, including running an
+actual `statsmodels` simulation rather than reasoning about fixture behavior
+analytically. This surfaced one CRITICAL, previously-undetected defect and
+several smaller gaps — all reconciled:
+
+- **CRITICAL (statistical correctness) — task 1.1's batch-confounded fixture
+  was verified, by direct simulation, to produce the OPPOSITE of the
+  intended effect.** The pre-round-3 fixture (σ_G=3.0, shift=8.0, n=4 reps,
+  a 16/4-genotype 3:1/1:3 partial mix) gave uncorrected H² *below* corrected
+  H² by 0.36–0.85 across seeds — reliably wrong-signed, not merely
+  occasionally short of the 0.05 margin. Root cause (confirmed by exact
+  variance decomposition, then by simulation across dozens of parameter
+  combinations): at n=4 reps, any genuinely partial per-genotype batch mix
+  necessarily injects more *within*-genotype variance (from mixing a
+  genotype's own reps across batches) than *between*-genotype variance
+  (from the two genotype groups' differing batch composition) — a
+  mathematical property of the 3:1/1:3 split at that rep count, not fixable
+  by increasing the shift magnitude (the task's own stated remedy, now
+  known to be wrong: both variance terms scale identically with shift², so
+  the sign never flips). Fixed: task 1.1 rewritten with an empirically
+  verified design (σ_G=0.4, σ_E=1.0, shift=+10.0, n=20 genotypes × n=10
+  reps, a symmetric 10/10-genotype 90%/10% split — genuinely partial, not
+  deterministic) that reliably clears the 0.05 threshold with more than 2x
+  margin at the worst of 50 tested seeds under `np.random.default_rng`
+  (min gap 0.109, mean 0.36). **Corrected during implementation**: this
+  verification pass used `np.random.default_rng(seed)`, but the fixture
+  file's actual convention is the legacy global `np.random.seed()` +
+  `np.random.normal()` API, which produces a different stream for the same
+  seed number — task 1.1's own text already flagged this exact risk
+  ("an RNG-construction mismatch versus the verification script"). Re-run
+  under the legacy API before writing the real fixture: still correctly
+  and robustly signed (10-seed check: min gap 0.2138, mean 0.3756; at
+  seed=42 specifically, gap≈0.2211), just different exact numbers — task
+  1.1 now records the legacy-API numbers and specifies the exact draw order
+  needed to reproduce them. The general lesson — a genuinely partial
+  confound's sign depends on whether between-group variance exceeds
+  within-genotype mixing variance, which
+  requires an extreme, *symmetric* group split, not merely "genotypes
+  unevenly distributed" — is now stated in task 1.1 itself so a future
+  reader understands why these exact numbers were chosen, not just what
+  they are.
+- **Confirmed gap — task 3.2's shrinkage oracle had no rep-count variation
+  to draw on.** Task 1.2, as literally written pre-round-3, specified
+  uniform n=3 reps for all 15 genotypes; 3.2's "if 1.2 doesn't already vary
+  rep count" hedge deferred rather than resolved this. Fixed at the time:
+  task 1.2 pinned an explicit 7-low-rep(n=2)/8-high-rep(n=6) split and a
+  previously-unspecified residual noise term. **Superseded by round 4
+  below**: this fix resolved the "no rep-count variation" gap but did not
+  catch a deeper problem in how 3.2's oracle compared values, which
+  empirical verification (prompted by a follow-up question, not a formal
+  review round) caught afterward.
+- **Real gap (statistical correctness) — the `ConvergenceWarning` capture
+  never specified filtering by warning *category*, only by "a convergence
+  warning" in prose.** Several real `statsmodels` convergence-related
+  warning messages don't contain the word "convergence" at all (e.g. "The
+  MLE may be on the boundary of the parameter space."), so a
+  message-text-matching implementation would silently miss exactly the
+  warnings this decision exists to catch. Fixed: Decision 5, the
+  statistics-api spec delta, and tasks.md 1.11 now require
+  `issubclass(w.category, statsmodels.tools.sm_exceptions.ConvergenceWarning)`
+  explicitly; tasks.md gains 1.9a (false-positive counterpart: an unrelated
+  warning category must not fail a trait).
+- **Minor (defensive, judgment call) — no guard against a `fixed_effects`
+  column name containing a patsy formula operator** (e.g. `"rep*block"`,
+  which combined with the coincidental presence of separate `"rep"`/`"block"`
+  columns could silently misparse as elementwise multiplication rather than
+  a literal column reference). Narrow tail case requiring two contrived
+  conditions at once, but the guard is nearly free. Fixed: tasks.md gains
+  1.4a (`fe.isidentifier()` validation, extending the existing
+  missing-column check).
+- **Mechanical fixes** — task 1.1's own text cited the wrong task number
+  for "full determinism" (said 1.9, meant 1.10 — 1.9 mocks the fit directly
+  and builds no confounded fixture); tasks.md 5.2's CHANGELOG-placement
+  guidance said "last `### Added` bullet, mirroring Tier 1's placement,"
+  which was backwards — Tier 1's actual rationale sentence sits on its
+  *first* `### Added` bullet; this design.md's Decision 1 misquoted
+  `HeritabilityConfig`'s docstring (dropped "analysis and"); tasks.md's top
+  blockquote note and task 6.4 still referenced only "round 1" after round
+  2 had already landed. All corrected in place.
+- Confirmed **not** a defect (verified, no change needed): the
+  multi-fixed-effect additive-composition proof (linearity of expectation,
+  order-independent regardless of correlation between effects) — re-derived
+  independently in round 3 and found correct; the uniform-additive-shift
+  proof for intercept-convention choice — same, confirmed correct including
+  its handling of a genotype with zero reference-level appearances.
+- **Noted, not acted on (proportionality, not a defect):** the review
+  process has produced a large design.md (400+ lines) and 35 tasks for a
+  capability that is, in the end, one new parameter, one new config field,
+  and one new helper function. Every addition traces to a specific defect
+  or ambiguity an adversarial reviewer actually found and none are
+  speculative scope growth — but the volume itself is worth naming to the
+  user before approval as a reflection of how statistically subtle this
+  feature turned out to be, not as feature creep. Some duplication between
+  the Decision-level rationale and the three reconciliation sections'
+  changelog-style bullets could be trimmed for future-reader maintainability
+  (e.g. the `simplefilter`/equality-matching mechanism is now explained in
+  full in at least two places each) — flagged as a documentation-quality
+  nit, not requested as a required edit.
+
+## Adversarial Review Reconciliation (round 4 — targeted empirical follow-up, not a formal panel)
+
+After round 3, a direct question ("what's the minimum number of reps this
+will work on?") prompted empirically re-verifying the one fixture round 3's
+own numeric-verification pattern hadn't yet been applied to:
+`heritability_data_field_block` (task 1.2), which backs both the
+BLUP-difference oracle (3.1) and the shrinkage-regression oracle (3.2).
+Round 3 had already pinned concrete numbers for it by analogy to Tier 1's
+precedent, but — unlike task 1.1's fixture — had not run it. This surfaced
+one further real, non-mechanical defect:
+
+- **Real gap (statistical correctness), same root cause as round 3's
+  headline finding — task 3.2's shrinkage oracle, as designed post-round-3,
+  failed empirically 40% of the time.** Simulated the exact round-3 design
+  (7-low-rep(n=2)/8-high-rep(n=6), block skew applied by genotype ID in a
+  way that happened to correlate with the rep-count grouping): the
+  BLUP-difference oracle (3.1) was robust (0/20 failures), but the
+  shrinkage-scales-with-replication oracle (3.2) failed 8/20 seeds (40%).
+  Root cause, confirmed by directly testing the stronger per-genotype
+  assertion (Tier 1's own original shrinkage property — every genotype's
+  adjusted gap smaller than its raw gap, not just a group-mean-ratio
+  comparison): that per-genotype property failed **100% of the time**
+  (50/50 seeds) under the naive raw-mean comparison. Diagnosis: the naive
+  `df.groupby(genotype)[trait].mean()` used as 3.2's raw-mean reference
+  point is itself contaminated by each genotype's own block composition —
+  the exact systematic effect `fixed_effects=["block"]` corrects for — so
+  comparing it directly against the corrected BLUP conflates two different
+  phenomena (genuine mixed-model shrinkage of random noise, which Tier 1's
+  original oracle tested on a design with no fixed-effect confound at all;
+  and removal of a systematic per-genotype bias, which is what the fixed
+  effect actually does). These aren't the same comparison, and nothing in
+  round 1–3's design or spec text distinguished them. Fixed, verified by
+  the same simulation: detrending the raw mean — subtracting each
+  observation's fitted `C(block)` coefficient before averaging within
+  genotype — makes both the per-genotype assertion and the group-mean-ratio
+  assertion hold reliably (0/50 failures each, vs. 50/50 and 6+/30 failures
+  respectively without detrending). Task 1.2's fixture numbers were also
+  revised alongside this (n_high raised from 6 to 10 for a starker
+  contrast, and block skew changed to apply orthogonally to the
+  replicate-count grouping rather than correlating with it by genotype ID)
+  — orthogonality is now required, not incidental, per an explicit note in
+  task 1.2. Task 3.2 and the statistics-api spec's corresponding scenario
+  now specify the detrending step precisely rather than leaving it
+  implementation-discoverable.
+- **Confirmed, not a defect:** the BLUP-difference oracle (3.1) needed no
+  changes — it was robust (0/50 failures) under both the pre- and
+  post-round-4 fixture designs, since it only asks whether *any* value
+  differs, not a directional/magnitude comparison sensitive to the
+  detrending issue above.
+- **Process note, not a proposal defect:** this round was not a formal
+  5-reviewer panel — it was one targeted empirical check, run because round
+  3 had established that reasoning about this kind of fixture without
+  simulating it is unreliable, and that lesson hadn't yet been applied to
+  every fixture in the proposal. No further un-simulated fixtures remain in
+  this change: both `heritability_data_batch_confounded` (1.1) and
+  `heritability_data_field_block` (1.2) are now empirically verified against
+  real `statsmodels`, not just reasoned about.
+
+## Implementation-Time Correction (task 3.2 × task 2.6 interaction)
+
+Writing task 3.2's test against the actual task 2.6 implementation (not
+caught by any of the 4 prior rounds, since round 4's fixture verification
+predated 2.6's existence and used the raw reference-level intercept
+directly) surfaced one more real bug: task 3.2's spec text said to center
+the shrinkage comparison on "the run's own returned `intercept`," but once
+2.6 lands, that value is the *marginal* (frequency-weighted) intercept, not
+the reference-level one the detrended raw mean is naturally expressed
+relative to. Because `adjusted_mean = intercept + blup[g]`,
+`|adjusted_mean - intercept|` always collapses to `|blup[g]|` regardless of
+intercept convention (the two cancel structurally) — but
+`raw_mean_detrended[g]` has no such dependency, so centering it on the
+marginal intercept instead introduced a constant offset that broke the
+per-genotype assertion for a subset of genotypes (confirmed by running the
+test: it failed with a >2x gap violation). Fixed by comparing `blup[g]`
+directly (not `extract_blup_table()`'s already-summed `adjusted_mean`)
+against the raw-mean, both centered on the reference-level `Intercept` from
+an independent re-fit — tasks.md 3.2 and the statistics-api spec's
+corresponding scenario updated accordingly. Re-verified: both assertions
+pass on the actual fixture and implementation.
+
+A second, smaller implementation-time catch: task 1.4a's test
+(`test_fixed_effect_column_name_with_patsy_metacharacter_rejected`) built a
+fixed-effects name (`"rep_col*block_col"`) that was never actually a column
+in the test DataFrame — so the pre-existing missing-column check intercepted
+it before the new `isidentifier()` validation was ever reached, making the
+test pass for the wrong reason (confirmed via coverage: the `isidentifier()`
+branch showed as uncovered despite a passing test asserting on its error
+message). Fixed by using a column that genuinely exists in the DataFrame
+(pandas column names aren't required to be valid Python identifiers) but
+still fails `isidentifier()` — coverage confirmed the branch is now
+genuinely exercised.
+
+## Pre-Merge Review (5-agent `/review-pr` team, pre-PR local diff)
+
+A 5-subagent adversarial review of the complete implementation (Code
+Quality, Testing, Statistical Rigor, Performance/Memory, Behavioural
+Correctness) found no BLOCKING issues in code quality or performance, but
+surfaced 4 more real, fixed issues:
+
+- **Real bug (behavioural correctness) — `remove_low_h2=True` combined with
+  `fixed_effects` could silently drop the fixed-effect column from
+  `df_filtered`.** `calculate_heritability_estimates` never told
+  `remove_low_heritability_traits` (via `additional_exclude`) that
+  `fixed_effects` columns aren't candidate traits; `get_trait_columns`'s
+  hardcoded metadata-name heuristic doesn't cover every plausible fixed-effect
+  name (confirmed with `fixed_effects=["block"]`, the proposal's own running
+  example). Not reachable via the current pipeline (`StatisticalAnalysisStep`
+  always passes `remove_low_h2=False`), but directly reachable by any
+  script/notebook caller of the public function. Fixed: `fixed_effects` is
+  now unioned into `additional_exclude` before filtering.
+- **Real gap (statistical rigor) — `_marginal_intercept`'s validation was a
+  count check, not an identity check.** `len(level_coefficients) != n_levels
+  - 1` can pass even when a real level's string silently failed to match its
+  own coefficient (falling through to the `0.0` default) while an unrelated
+  mismatch happened to keep the count the same. The reviewer found a genuine
+  (if currently non-reachable with realistic pandas dtypes) theoretical
+  vulnerability: patsy's level-labeling uses `repr()` for some value types,
+  which can diverge from this code's `str()`-based matching for certain
+  numpy scalar types. Fixed: the check now verifies every recovered
+  coefficient key matches an actually-observed level string, and that
+  exactly one observed level lacks a coefficient (the true reference) —
+  closing the gap structurally rather than relying on incidental pandas
+  boxing behavior to keep it safe.
+- **Confirmed limitation (statistical rigor + behavioural correctness) — the
+  `ConvergenceWarning` capture does not catch its own motivating scenario in
+  all cases.** The reviewer reproduced a fixed effect confounded with
+  genotype that converges cleanly with zero warnings, returning a normal
+  success dict with an arbitrary, non-identifiable variance-component split
+  — exactly the "plausible-but-degenerate fit with no error signal" Decision
+  5 was written to prevent. This is not a code bug to fix (Decision 5
+  already declared "no upfront identifiability pre-validation" a deliberate
+  non-goal, and detecting this class of near-confounding programmatically
+  would require design-matrix collinearity analysis well beyond this tier's
+  scope) — it's a real, now-empirically-confirmed limit on what the
+  warning-capture mechanism delivers. Fixed by making the docstring honest
+  about this rather than implying the mechanism prevents silent degenerate
+  fits categorically.
+- **Test-quality gap — the organic characterization test
+  (`test_near_fully_confounded_fixed_effect_organic_behavior`) pinned an
+  exact heritability value (`abs=0.01`) that had never run on the
+  Ubuntu/Windows/macOS CI matrix**, for a fit type (near-singular) most
+  sensitive to BLAS/LAPACK differences across platforms. Fixed: the exact
+  value is no longer pinned tightly — only that it's a valid probability in
+  `[0, 1]`; the qualitative outcome (no `ConvergenceWarning`, successful
+  fit) remains the pinned assertion, which is what this characterization
+  test actually exists to catch drift on.
+- **Minor, cheap fix — naming `genotype_col`/`replicate_col` inside
+  `fixed_effects` produced a confusing pandas-internal error** ("Grouper for
+  'geno' not 1-dimensional") deep inside the per-trait loop rather than a
+  clear structural error. Fixed: rejected upfront with the same structural-
+  error shape as the missing-column and `isidentifier()` checks.
+- **Noted, not fixed (low priority, deferred):** a captured warning during a
+  `fixed_effects` fit that is NOT a `ConvergenceWarning` is read and
+  discarded rather than re-emitted via `warnings.warn` — a minor
+  observability regression only for `fixed_effects` callers (an
+  `fixed_effects=None` caller would still see such a warning). Not required
+  by any spec scenario; left as a candidate follow-up rather than expanding
+  this tier's scope further.

--- a/openspec/changes/add-heritability-fixed-effects/proposal.md
+++ b/openspec/changes/add-heritability-fixed-effects/proposal.md
@@ -1,0 +1,223 @@
+## Why
+
+`calculate_heritability_estimates` (`src/sleap_roots_analyze/statistics.py:195-479`)
+fits a genotype-only mixed model, `smf.mixedlm("value ~ 1", model_data,
+groups=genotype)`. There is no way to add fixed-effect covariates (experiment,
+wave, batch, scanner). For multi-experiment GWAS panels where genotypes are not
+balanced across experiments, any systematic per-experiment shift (scanner
+calibration drift, cylinder placement, image pre-processing batch differences)
+gets absorbed into the genotype term and inflates apparent H². Mauricio
+Chiurazzi's combined alfalfa GWAS (35 accessions × 6 Bloom experiments) shows
+this concretely: `Scanline First Ind P25` reports H² ≈ 0.83 despite
+within-genotype variance dominating (naive ICC 0.087–0.318), because genotypes
+are not balanced across the 6 experiments and there is no way to add a fixed
+covariate to absorb the batch shift.
+
+This is Tier 2 (`add-heritability-fixed-effects`, tracking issue
+[talmolab/sleap-roots-analyze#114](https://github.com/talmolab/sleap-roots-analyze/issues/114))
+of the wheat EDPIE cross-platform genotype-prediction program, unblocked by
+Tier 1 (`add-blup-extraction`, merged as #189/#190). See the program roadmap
+and statistical grounding at
+`c:\vaults\sleap-roots\wheat-edpie-paper\cross-platform-prediction\{roadmap,theory}.md`
+(external to this repo; referenced here for provenance only).
+
+## What Changes
+
+- **Add `fixed_effects` parameter to `calculate_heritability_estimates`.**
+  `fixed_effects: Optional[List[str]] = None`. When provided, the mixed-model
+  formula becomes `"value ~ " + " + ".join(f"C({fe})" for fe in
+  fixed_effects)` instead of `"value ~ 1"` — every fixed effect is wrapped in
+  `C()` unconditionally (always treated as categorical, no dtype inference),
+  since fixed effects in this context are metadata-style confounders
+  (experiment, wave, batch, scanner), not continuous covariates. Missing
+  `fixed_effects` columns extend the existing top-level `required_cols`
+  validation (`{"error": "Missing required columns: [...]"}`), alongside
+  `genotype_col`/`replicate_col`. The per-trait model subset becomes `df[[trait,
+  genotype_col] + fixed_effects].dropna()` (today: `df[[trait,
+  genotype_col]].dropna()`) — only changes behavior when `fixed_effects` is
+  set; `None` (the default) is byte-for-byte identical to current behavior.
+  Model-fit failures raised by `statsmodels` (non-convergence, a fixed effect
+  fully confounded with genotype, etc.) are caught by the existing per-trait
+  `try/except`, recorded as `{"error": "Mixed model failed: ...",
+  "model_type": "mixed_model_failed"}`. Additionally, since `MixedLM.fit()`
+  does not reliably *raise* on a fixed effect that is (near-)fully confounded
+  with genotype — it can instead emit a `ConvergenceWarning` and still return
+  a plausible-looking `result` — the fit is wrapped in
+  `warnings.catch_warnings(record=True)` with `warnings.simplefilter("always")`
+  (required so a repeat identical warning for a later trait isn't silently
+  dropped by Python's default once-per-location filter), and a warning
+  matching `ConvergenceWarning`'s category (checked via `issubclass`, not by
+  matching message text — several real convergence-related messages don't
+  contain the word "convergence") is treated as a fit failure for that trait,
+  surfaced the same way as a raised exception. Without this, the exact
+  batch-confounded scenario this tier
+  targets could silently produce a plausible-but-degenerate fit with no error
+  signal — reproducing, via over-fitting/aliasing, the same class of
+  silently-wrong-H² problem this tier exists to fix.
+- **Empirical frequency-weighted intercept when fixed effects are present.**
+  With fixed effects in the formula, `result.fe_params` holds `Intercept` plus
+  one treatment-coded offset per non-reference level per fixed effect —
+  `Intercept` alone represents "value at patsy's reference level" (the first
+  level in sorted order for a plain column, or the first declared category
+  for a pandas `Categorical` — not reliably "alphabetical"), not a
+  panel-typical value. `intercept` is instead computed as a **sample
+  frequency-weighted average** across each fixed effect's levels *as observed
+  in that trait's own post-`dropna()` fitted rows* (weighting each level's
+  fitted contribution by its share of `model_data`), summed with the base
+  `Intercept`. This is deliberately described as an empirical/sample-margin
+  quantity, not a population-typical or EMM/lsmeans-style value: it is
+  sensitive to each trait's own missing-data pattern (two traits sharing the
+  same `fixed_effects` columns can get different weights if their `dropna()`
+  drops different rows) and to incidental sample-size imbalance across levels
+  (e.g. an experiment with more scans purely for logistical reasons pulls the
+  intercept toward it, regardless of biological representativeness). The
+  coefficient lookup for each level is done by parsing `result.fe_params`'s
+  actual fitted parameter names (regex `^C\({fe}\)\[T\.(.*)\]$`), not by
+  reconstructing the expected key string forward from the observed level
+  value — the latter risks a silent dtype/formatting mismatch (e.g. a
+  `float64` fixed-effect column) being misattributed to the reference level's
+  implicit `0.0` contribution with no error. When `fixed_effects` is `None`,
+  this collapses to today's plain `result.fe_params["Intercept"]` — no
+  behavior change for existing callers. This value flows unchanged into
+  `extract_blup_table()`'s existing `adjusted_mean = intercept + blup[g]`
+  formula and into `BLUPResult.intercepts` (no code changes needed in either —
+  both already just consume whatever `intercept` float
+  `calculate_heritability_estimates` produces; `BLUPResult`'s docstring is
+  updated to describe the new semantics of a value it already stores
+  verbatim).
+- **`replicate_col` is untouched, and independent of `fixed_effects`.** A
+  block/replicate fixed effect (R_j, confirming Tier 1's tentative design
+  note) is expressed by passing that column's name into `fixed_effects` (e.g.
+  `fixed_effects=["block"]`) — no coupling between the two parameters, no new
+  validation linking them.
+- **Add `StatisticsConfig.fixed_effects: Optional[List[str]] = None`**
+  (`pipeline/config/components.py`) — not `HeritabilityConfig`, which gates
+  the later low-H² filtering step (`FilterHeritabilityStep`) and has no
+  relationship to how the model itself is fit. This deviates from issue
+  #114's illustrative YAML sketch (`heritability.fixed_effects`), which
+  predates inspection of how the config is actually wired;
+  `StatisticalAnalysisStep` is the only caller of
+  `calculate_heritability_estimates`, and it already reads
+  `config.statistics`. `StatisticalAnalysisStep` resolves `fixed_effects` via
+  the same `getattr(config, "statistics", None)` fallback already used for
+  `calculate_heritability`/`generate_blup_table`, defaulting to `None` when
+  `config.statistics` is absent (the QC-pipeline case).
+- **Documentation note** (per issue #114's acceptance criteria): `fixed_effects`
+  should only contain metadata-style covariates that confound with genotype
+  (experiment, wave, batch, scanner), not biological/phenotypic traits — stated
+  in the docstring, not runtime-enforced (unenforceable semantically).
+
+No breaking changes — `fixed_effects=None` (default) reproduces today's
+formula, subset, and intercept computation exactly. Existing callers of
+`calculate_heritability_estimates`, `StatisticalAnalysisStep`, and
+`StatisticsConfig` continue to work unchanged.
+
+## Design decisions (resolved via brainstorming this session — full rationale and alternatives in `design.md`)
+
+- Config lives on `StatisticsConfig`, not `HeritabilityConfig` — matches where
+  the calculation actually happens, deviating deliberately from issue #114's
+  YAML sketch.
+- Every `fixed_effects` column is wrapped in `C()` unconditionally — no dtype
+  inference, since a numeric-looking metadata column (e.g. `wave_number`)
+  must still be treated as categorical, not a continuous covariate.
+- The BLUP-adjusted-mean intercept becomes an empirical, sample
+  frequency-weighted average across each trait's own observed fixed-effect
+  levels, rather than pinned to patsy's arbitrary reference level — cheap to
+  compute (a weighted sum over coefficients `fe_params` already contains),
+  and removes the "value under an arbitrary baseline category" caveat for
+  the EDPIE paper's supplementary tables. Explicitly documented as a
+  sample-margin quantity (sensitive to each trait's own missing-data pattern
+  and to incidental level-frequency imbalance), not a population-typical or
+  EMM/lsmeans-style value — the distinction matters if anyone later reads
+  `adjusted_mean` as "this genotype's typical phenotype."
+- The per-level coefficient lookup for the marginal intercept parses
+  `result.fe_params`'s actual fitted parameter names rather than
+  reconstructing the expected key string forward from raw level values — the
+  latter risks silently misattributing a real, non-reference level to the
+  reference level's implicit `0.0` on a dtype/formatting mismatch (revised
+  after review found the forward-reconstruction approach could fail silently
+  on a `float64`-dtype fixed-effect column).
+- `fixed_effects` and `replicate_col` are fully independent parameters — `R_j`
+  (field block/replicate as a fixed effect) is expressed by naming that column
+  in `fixed_effects`; no special-casing added.
+- Model-fit failures from fixed effects (non-convergence, confounding with
+  genotype) reuse the existing per-trait `try/except`, extended to also treat
+  a captured `ConvergenceWarning` as a fit failure — no new upfront
+  identifiability validation layer, but no longer relying solely on
+  `statsmodels` raising (revised after review found `MixedLM.fit()` does not
+  reliably raise on a fixed effect confounded with genotype).
+
+## Impact
+
+### Affected specs
+
+- `statistics-api` (MODIFIED) — new `fixed_effects` parameter and formula
+  behavior on `calculate_heritability_estimates`; `intercept`'s marginal-average
+  semantics when fixed effects are present, threading into the existing "BLUP
+  Adjusted-Means Table Extraction" requirement's `intercept + blup[g]` formula
+  (the formula text is unchanged; what `intercept` represents is clarified).
+- `serializable-result-types` (MODIFIED) — `BLUPResult.intercepts`'s field
+  description updated to note the empirical frequency-weighted semantics when
+  the underlying `calculate_heritability_estimates` call used `fixed_effects`
+  (corrected after review: the previous draft of this section incorrectly
+  referenced a nonexistent `HeritabilityResult` per-trait `intercept` field —
+  `TraitHeritability` has no such field; only `BLUPResult.intercepts` carries
+  intercept values). No field-shape or adapter-logic changes — `BLUPResult`
+  and `from_blup_table()` already pass through whatever `intercept` float
+  each trait's source dict carries, unchanged.
+- `config-management` (ADDED) — `StatisticsConfig.fixed_effects` and its
+  threading through `StatisticalAnalysisStep`.
+
+### Affected code
+
+- `src/sleap_roots_analyze/statistics.py` — `fixed_effects` parameter,
+  formula/subset changes, marginal-intercept helper (with regex-based
+  coefficient lookup and `ConvergenceWarning` capture) in
+  `calculate_heritability_estimates`; update the function's own `Returns:`
+  docstring section, whose current `intercept` description
+  (`result.fe_params["Intercept"]`, unconditionally) becomes inaccurate once
+  the marginal-intercept branch lands.
+- `src/sleap_roots_analyze/result_types.py` — update `BLUPResult.intercepts`'s
+  docstring (`Attributes:` block, currently at line ~832) to describe the
+  empirical frequency-weighted semantics when the source used
+  `fixed_effects`. No code change — the dataclass and its adapter already
+  store/pass through whatever `intercept` float they're given.
+- `src/sleap_roots_analyze/pipeline/config/components.py` — add
+  `StatisticsConfig.fixed_effects`.
+- `src/sleap_roots_analyze/pipeline/steps/statistical_analysis.py` — thread
+  `fixed_effects` into the `calculate_heritability_estimates(...)` call.
+- `docs/API.md`, `docs/CHANGELOG.md`, `docs/result-types.md` (added after
+  review: the `BLUPResult` row needs the same intercepts caveat, mirroring
+  existing per-type caveat bullets already in that file) — signature/behavior
+  updates.
+- `tests/test_statistics.py`, `tests/fixtures.py` (new batch-confounded and
+  field-block fixtures), `tests/test_step_statistical_analysis.py`,
+  `tests/test_blup_result.py` (pass-through test for fixed-effects-derived
+  intercepts).
+
+### Explicitly out of scope
+
+- Tier 3+ (LOGO-CV, prediction pipeline, permutation nulls, figures): separate
+  future changes.
+- Any change to the H² formula itself, or to variance-component extraction
+  for the genotype random effect.
+- Coupling or validation between `fixed_effects` and `replicate_col` (e.g.
+  auto-inclusion, duplicate-name guards) — fully independent by design.
+- Identifiability/collinearity pre-validation for `fixed_effects` beyond
+  `ConvergenceWarning` capture — no upfront check that a fixed effect is a
+  deterministic function of genotype before fitting; the fit is allowed to
+  attempt and its warning/failure is what's caught.
+- Continuous/ordinal fixed-effect covariates — `fixed_effects` is `List[str]`
+  and every entry is always `C()`-wrapped; supporting a genuinely continuous
+  covariate (e.g. a linear drift term) would require a future, likely
+  signature-breaking change (e.g. a typed mapping of column → coding scheme)
+  and is not addressed here.
+- Equal-weighted (EMM/lsmeans-style) marginal intercepts — the shipped
+  intercept is sample-frequency-weighted over each trait's own fitted rows,
+  not equally weighted across levels; a future tier could add an
+  equally-weighted variant if a genuinely design-invariant "population
+  typical" value is needed.
+- Follow-up issue [#192](https://github.com/talmolab/sleap-roots-analyze/issues/192)
+  (whether `replicate_col`'s presence-validation still earns its keep in
+  `calculate_heritability_estimates`/`analyze_trait_variance`) — surfaced
+  during this brainstorm, filed separately, not part of this change.

--- a/openspec/changes/add-heritability-fixed-effects/specs/config-management/spec.md
+++ b/openspec/changes/add-heritability-fixed-effects/specs/config-management/spec.md
@@ -1,0 +1,49 @@
+## ADDED Requirements
+
+### Requirement: Heritability Fixed-Effects Config Field
+
+`StatisticsConfig` SHALL expose `fixed_effects: Optional[List[str]] = None`,
+threaded into the `calculate_heritability_estimates(...)` call made by
+`StatisticalAnalysisStep`. This field SHALL live on `StatisticsConfig` — the
+dataclass `StatisticalAnalysisStep` already reads to control
+`calculate_heritability`/`generate_blup_table` — not on `HeritabilityConfig`,
+which gates the separate, later low-H² filtering step
+(`FilterHeritabilityStep`) and has no relationship to how the model itself is
+fit.
+
+`StatisticalAnalysisStep` SHALL resolve `fixed_effects` via the same
+`getattr(config, "statistics", None)` fallback already used for
+`calculate_heritability` and `generate_blup_table`, defaulting to `None` when
+`config.statistics` is absent (the `QCPipelineConfig` case, which has no
+`statistics` field at all) — a QC-pipeline run SHALL NOT raise
+`AttributeError` and SHALL behave identically to `fixed_effects=None`.
+
+#### Scenario: Default StatisticsConfig has no fixed effects
+
+- **WHEN** a `StatisticsConfig` is constructed with default values
+- **THEN** `fixed_effects` SHALL be `None`
+- **AND** `StatisticalAnalysisStep` SHALL call
+  `calculate_heritability_estimates` without `fixed_effects` set (or with it
+  explicitly `None`), reproducing pre-existing behavior exactly
+
+#### Scenario: Configured fixed_effects are threaded into the heritability call
+
+- **WHEN** a pipeline runs `StatisticalAnalysisStep` with
+  `statistics.fixed_effects=["experiment"]` and the input data has an
+  `"experiment"` column
+- **THEN** `calculate_heritability_estimates` SHALL be called with
+  `fixed_effects=["experiment"]`
+- **AND** the resulting `08_heritability_results.csv` and
+  `08_blup_adjusted_means.csv` (when `generate_blup_table` is also enabled)
+  SHALL reflect the fixed-effects-corrected model, differing from a run with
+  `fixed_effects=None` on the same data
+
+#### Scenario: QC-pipeline config has no way to configure fixed_effects, resolves to None
+
+- **WHEN** `StatisticalAnalysisStep.execute()` runs with a `QCPipelineConfig`
+  (which has no `statistics` field)
+- **THEN** `fixed_effects` SHALL resolve to `None` (the same default fallback
+  already used for `calculate_heritability`/`generate_blup_table` when
+  `config.statistics` is absent)
+- **AND** `StatisticalAnalysisStep.execute()` SHALL NOT raise `AttributeError`
+  when run with such a config

--- a/openspec/changes/add-heritability-fixed-effects/specs/serializable-result-types/spec.md
+++ b/openspec/changes/add-heritability-fixed-effects/specs/serializable-result-types/spec.md
@@ -1,0 +1,185 @@
+## MODIFIED Requirements
+
+### Requirement: Non-Breaking Heritability Return Shape
+
+`calculate_heritability_estimates()` SHALL keep its return shape unchanged by `HeritabilityResult`, BLUP extraction, or the `fixed_effects` parameter.
+The function SHALL keep returning its
+existing dict / tuple (a plain `dict` when `remove_low_h2=False`, or a 4-tuple
+`(heritability_results, df_filtered, removed_traits, removal_details)` when
+`remove_low_h2=True`) so all current callers continue to work unchanged. BLUP
+extraction MAY add `blup` (`dict[str, float]`) and `intercept` (`float`) keys
+to a trait's own per-trait dict, but only when that trait's mixed model fit
+succeeds (`model_type == "mixed_model"`); a trait solved via the ANOVA-based
+path (`model_type == "anova_based"`), the no-variance short-circuit
+(`model_type == "no_variance"`), or any error path SHALL NOT carry
+`blup`/`intercept` keys, since no fitted mixed-model `result` object exists
+for those paths. `result.random_effects` SHALL be accessed exactly once per
+successful trait fit. When the call used a non-empty `fixed_effects`,
+`intercept` SHALL be the empirical frequency-weighted value described under
+`statistics-api`'s "Heritability Model Fixed Effects" requirement rather than
+the raw `result.fe_params["Intercept"]` — this SHALL NOT change the key's
+type (`float`) or its presence condition (mixed-model success only).
+
+#### Scenario: Existing heritability return is preserved and not mutated
+
+- **WHEN** `calculate_heritability_estimates()` is called with
+  `remove_low_h2=False`
+- **THEN** it SHALL return the existing trait-keyed dict (including the
+  `__calculation_metadata__` entry)
+- **AND** calling `HeritabilityResult.from_heritability_dict(d, threshold)` SHALL
+  leave `d`'s keys and values unchanged
+- **AND** the `HeritabilityResult` view SHALL be opt-in, built only via
+  `HeritabilityResult.from_heritability_dict()`
+
+#### Scenario: Existing dict return is preserved and only additively extended with BLUPs
+
+- **WHEN** `calculate_heritability_estimates(df, trait_cols, ...)` is called
+  with `remove_low_h2=False` (the default) and a trait's mixed model succeeds
+- **THEN** the returned `dict`'s per-trait entry SHALL still contain the
+  existing keys (`heritability`, `var_genetic`, `var_residual`, `mean_n_reps`,
+  `n_genotypes`, `n_observations`, `model_type`, `reps_per_geno_stats`)
+- **AND** it SHALL additionally contain `blup` (a `dict[str, float]` keyed by
+  genotype label) and `intercept` (a `float`)
+- **AND** the top-level return type SHALL remain a plain `dict`
+
+#### Scenario: remove_low_h2=True keeps its 4-tuple shape with BLUP keys
+
+- **WHEN** `calculate_heritability_estimates(df, trait_cols, ..., remove_low_h2=True)`
+  is called
+- **THEN** the return value SHALL still be a 4-tuple
+  `(heritability_results, df_filtered, removed_traits, removal_details)`
+- **AND** `heritability_results`'s per-trait entries SHALL carry the same
+  additive `blup`/`intercept` keys as the `remove_low_h2=False` case, even for
+  traits later dropped from `df_filtered`/`removed_traits` (heritability-based
+  trait removal filters the DataFrame; it does not strip keys from
+  `heritability_results`)
+
+#### Scenario: A trait whose mixed model fit fails carries no blup/intercept keys
+
+- **WHEN** a trait's mixed model fit raises (caught internally, recorded as
+  `{"error": ..., "model_type": "mixed_model_failed"}`)
+- **THEN** that trait's per-trait dict SHALL NOT contain a `blup` or
+  `intercept` key
+
+#### Scenario: A trait solved via the ANOVA-based or no-variance path carries no blup/intercept keys
+
+- **WHEN** a trait succeeds via `force_method="anova_based"` (`model_type ==
+  "anova_based"`) or via the no-variance short-circuit (`model_type ==
+  "no_variance"`, all values identical)
+- **THEN** that trait's per-trait dict SHALL NOT contain a `blup` or
+  `intercept` key
+- **AND** no exception SHALL be raised while producing that trait's result,
+  even though no fitted mixed-model `result` object exists for it
+
+#### Scenario: fixed_effects does not change which traits carry blup/intercept keys
+
+- **WHEN** `calculate_heritability_estimates(df, trait_cols,
+  fixed_effects=[...])` is called
+- **THEN** the same condition governs `blup`/`intercept` presence as without
+  `fixed_effects` — `model_type == "mixed_model"` for that trait — with
+  `intercept`'s value computed per the marginal-intercept rule instead of the
+  raw `fe_params["Intercept"]`
+
+### Requirement: Serializable BLUP Result Type
+
+The package SHALL provide a frozen stdlib `@dataclass` `BLUPResult` in
+`result_types.py` that captures only the JSON-serializable science of an
+`extract_blup_table()` run: the genotype × trait adjusted-means matrix for
+traits whose mixed model succeeded, plus the names of traits that failed.
+Every scalar field SHALL be a native Python type (`int`, `float`, `str`) —
+not a numpy or pandas scalar — and every array field a (nested) list thereof,
+so that `json.dumps(dataclasses.asdict(result))` succeeds without a custom
+serializer. `BLUPResult` SHALL provide `to_dict()` and `to_json()` (the
+`allow_nan=False` finite-floats contract, matching `PCAResult`/
+`HeritabilityResult`/`UMAPResult`).
+
+`BLUPResult`'s fields are: `genotype_names: list[str]`, `trait_names: list[str]`
+(only traits whose model succeeded — failed traits are excluded from this list
+and from `adjusted_means`), `adjusted_means: list[list[float]]` (shape
+`(n_genotypes, n_traits)`, aligned to `genotype_names` × `trait_names`, always
+finite), `failed_traits: list[str]` (names only, no values — mirrors
+`HeritabilityResult.failed_traits`), and `intercepts: dict[str, float]` (one
+entry per succeeded trait in `trait_names`). When the source
+`heritability_results` was produced with a non-empty `fixed_effects`,
+`intercepts`' values are the empirical frequency-weighted intercepts described
+under `statistics-api`'s "Heritability Model Fixed Effects" requirement,
+rather than a raw reference-level coefficient — `BLUPResult` and its adapter
+are unaware of `fixed_effects` and store whatever `intercept` float each
+trait's source dict carries, unchanged.
+
+#### Scenario: BLUPResult round-trips through JSON as native types
+
+- **WHEN** a `BLUPResult` is built from an `extract_blup_table()` DataFrame via
+  `BLUPResult.from_blup_table()` and passed to
+  `json.dumps(dataclasses.asdict(result))`
+- **THEN** the call SHALL succeed without raising
+- **AND** parsing the string back with `json.loads` SHALL yield every element of
+  `genotype_names` and `trait_names` and `failed_traits` as a Python `str`,
+  every element of `adjusted_means` as a Python `float`, and every value in
+  `intercepts` as a Python `float`
+- **AND** the round-tripped `adjusted_means` values SHALL equal the input
+  values within floating-point tolerance
+
+#### Scenario: Fields are native types before serialization
+
+- **WHEN** the `BLUPResult` dataclass fields are inspected directly, before any
+  JSON serialization
+- **THEN** every element of `genotype_names`, `trait_names`, and
+  `failed_traits` SHALL be a native `str`, every element of `adjusted_means` a
+  native `float`, and every value of `intercepts` a native `float` — not a
+  numpy or pandas scalar (a JSON round-trip would silently cast a leaked
+  `np.float64` to `float`, so this check MUST be pre-serialization)
+
+#### Scenario: A failed trait never appears as NaN in the dataclass
+
+- **GIVEN** an `extract_blup_table()` DataFrame with a genuine `NaN` column for
+  a failed trait
+- **WHEN** `BLUPResult.from_blup_table()` builds the result
+- **THEN** that trait's name SHALL appear in `failed_traits`
+- **AND** that trait SHALL NOT appear in `trait_names`
+- **AND** `adjusted_means` SHALL contain no `NaN`/`Infinity` value contributed
+  by that trait
+- **AND** `to_json()` SHALL succeed without raising (the finite-floats
+  contract is satisfied even though the source table has a NaN column)
+
+#### Scenario: A cell-level NaN (partial genotype coverage) also excludes that trait as failed
+
+- **GIVEN** an `extract_blup_table()` DataFrame where a trait's column has
+  finite values for most genotypes but `NaN` for one genotype absent from that
+  trait's `blup` dict (see the cell-level-NaN scenario under "BLUP
+  Adjusted-Means Table Extraction")
+- **WHEN** `BLUPResult.from_blup_table()` builds the result
+- **THEN** that trait SHALL be classified as failed (its name in
+  `failed_traits`, excluded from `trait_names` and `adjusted_means`) — a
+  partially-finite column is not eligible to appear in the always-finite
+  matrix
+
+#### Scenario: Zero succeeded traits produce an empty (not misclassified) result
+
+- **GIVEN** an `extract_blup_table()` DataFrame with zero rows (no genotype
+  universe, because every trait failed) and one column per input trait
+- **WHEN** `BLUPResult.from_blup_table()` builds the result
+- **THEN** every column SHALL be classified as failed (`failed_traits`
+  contains all trait names, `trait_names` and `adjusted_means` are empty) —
+  a zero-row column SHALL NOT be treated as vacuously finite
+- **AND** `genotype_names` SHALL be an empty list
+- **AND** `to_json()` SHALL succeed without raising
+
+#### Scenario: to_json rejects a non-finite adjusted mean
+
+- **WHEN** `to_json()` is called on a `BLUPResult` constructed directly (not via
+  the adapter) with a non-finite value (`NaN` or `Infinity`) in
+  `adjusted_means`
+- **THEN** a `ValueError` SHALL be raised (under the default `allow_nan=False`)
+  rather than emitting the non-standard `NaN`/`Infinity` tokens a strict JSON
+  consumer rejects
+
+#### Scenario: intercepts values pass through unchanged when the source used fixed_effects
+
+- **GIVEN** an `extract_blup_table()`-shaped DataFrame and an `intercepts`
+  mapping produced from a `heritability_results` dict whose
+  `calculate_heritability_estimates` call used a non-empty `fixed_effects`
+- **WHEN** `BLUPResult.from_blup_table(df, intercepts=...)` is called
+- **THEN** `result.intercepts` SHALL contain exactly those marginal-intercept
+  values, unchanged — `BLUPResult`/`from_blup_table` SHALL NOT recompute or
+  reinterpret them

--- a/openspec/changes/add-heritability-fixed-effects/specs/statistics-api/spec.md
+++ b/openspec/changes/add-heritability-fixed-effects/specs/statistics-api/spec.md
@@ -1,0 +1,441 @@
+## MODIFIED Requirements
+
+### Requirement: BLUP Adjusted-Means Table Extraction
+
+The package SHALL provide `extract_blup_table(heritability_results)` in
+`statistics.py` that builds a genotype × trait adjusted-means table from the
+dict returned by `calculate_heritability_estimates()`. For each trait whose
+per-trait entry carries a `blup` dict and an `intercept` float (i.e. the mixed
+model succeeded), the adjusted mean for genotype `g` SHALL be
+`intercept + blup[g]`. `intercept` is supplied by
+`calculate_heritability_estimates()` and MAY be a frequency-weighted marginal
+value (see "Heritability Model Fixed Effects") when that call used
+`fixed_effects`; `extract_blup_table()` itself is unaware of `fixed_effects`
+and applies the same `intercept + blup[g]` formula regardless of how
+`intercept` was computed. For a trait with no `blup`/`intercept` (the model
+failed, errored, used the ANOVA-based or no-variance path, or was skipped),
+the entire column SHALL be `NaN` — not omitted from the table and not
+zero-filled. A genotype absent from one succeeded trait's `blup` dict but
+present in another's (a real possibility, since
+`calculate_heritability_estimates` computes each trait's genotype set
+independently via a per-trait `dropna()`) SHALL produce a cell-level `NaN` for
+that genotype/trait combination, not a row drop or a column-level failure. The
+function SHALL NOT mutate its input, and SHALL NOT raise when
+`heritability_results` is a run-level short-circuit (`{"error": "..."}`, no
+per-trait entries) or when every trait failed (zero succeeded traits).
+
+#### Scenario: Successful traits populate adjusted means
+
+- **GIVEN** a `heritability_results` dict where trait `"trait_a"` has
+  `heritability_results["trait_a"]["blup"] == {"G01": 0.5, "G02": -0.5}` and
+  `heritability_results["trait_a"]["intercept"] == 10.0`
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the returned `pd.DataFrame` SHALL have a row per genotype (`"G01"`,
+  `"G02"`) and a `"trait_a"` column
+- **AND** `df.loc["G01", "trait_a"] == pytest.approx(10.5)` and
+  `df.loc["G02", "trait_a"] == pytest.approx(9.5)`
+
+#### Scenario: Failed-model trait produces a NaN column, not a dropped or zero column
+
+- **GIVEN** a `heritability_results` dict where trait `"trait_failed"` has no
+  `blup` key (e.g. `{"error": "Mixed model failed: ..."}`) while at least one
+  other trait succeeded
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the returned `pd.DataFrame` SHALL still contain a `"trait_failed"`
+  column
+- **AND** every value in that column SHALL be `NaN` (`pd.isna(...).all()`)
+- **AND** no value in that column SHALL be `0.0`
+
+#### Scenario: A trait solved via the ANOVA-based or no-variance path has no BLUP column, without raising
+
+- **GIVEN** a `heritability_results` dict where trait `"trait_anova"` succeeded
+  with `model_type == "anova_based"` (no fitted mixed model exists for this
+  trait, since `force_method="anova_based"` never calls `smf.mixedlm`) or
+  `model_type == "no_variance"` (the trait short-circuited before any model
+  fit), and therefore carries no `blup`/`intercept` keys
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the call SHALL NOT raise
+- **AND** the `"trait_anova"` column SHALL be entirely `NaN`, identically to a
+  failed trait's column
+
+#### Scenario: Row and column shape matches genotypes and traits
+
+- **GIVEN** a `heritability_results` dict where the union of every succeeded
+  trait's `blup.keys()` contains `N` distinct genotypes, and `T` total traits
+  are present (including failed, ANOVA-based, no-variance, and skipped ones)
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the returned `pd.DataFrame` SHALL have exactly `N` rows (indexed by
+  that genotype union, not any single trait's own genotype set) and `T`
+  columns (one per trait, in `trait_cols` order, excluding the
+  `__calculation_metadata__` key)
+
+#### Scenario: A genotype missing from one succeeded trait's blup dict gets a cell-level NaN
+
+- **GIVEN** two traits that both succeed (`model_type == "mixed_model"`), where
+  trait `"trait_a"`'s `blup` dict covers genotypes `{"G01", "G02"}` and trait
+  `"trait_b"`'s `blup` dict covers `{"G01", "G02", "G03"}` (e.g. `"trait_a"`
+  dropped `"G03"`'s only observation as NaN before the model was fit)
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the returned `pd.DataFrame` SHALL have a `"G03"` row
+- **AND** `df.loc["G03", "trait_a"]` SHALL be `NaN` while `df.loc["G03",
+  "trait_b"]` SHALL be a finite adjusted mean — a cell-level gap, distinct from
+  the whole-column `NaN` of a failed trait
+
+#### Scenario: A run-level short-circuit dict produces an empty table without raising
+
+- **GIVEN** `heritability_results == {"error": "Missing required columns: ['geno']"}`
+  (the run-level short-circuit form `calculate_heritability_estimates` returns
+  when required columns are absent, carrying no per-trait entries)
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the call SHALL NOT raise
+- **AND** the returned `pd.DataFrame` SHALL be empty (zero rows, zero columns)
+
+#### Scenario: Zero succeeded traits produce an all-NaN table, not a misclassified one
+
+- **GIVEN** a `heritability_results` dict where every trait failed (no trait
+  carries a `blup` key), so the genotype universe collected from succeeded
+  traits is empty
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** the returned `pd.DataFrame` SHALL have zero rows (no genotype
+  universe to index by) and one column per input trait
+- **AND** every column SHALL be treated as failed, not as vacuously "all
+  finite" by virtue of having zero rows
+
+#### Scenario: Input dict is not mutated
+
+- **WHEN** `extract_blup_table(heritability_results)` is called
+- **THEN** `heritability_results`'s keys and values SHALL be unchanged after the
+  call
+
+## ADDED Requirements
+
+### Requirement: Heritability Model Fixed Effects
+
+`calculate_heritability_estimates()` SHALL accept an optional
+`fixed_effects: Optional[List[str]] = None` parameter. When `None` (the
+default), behavior SHALL be byte-for-byte identical to a call without this
+parameter — the model formula remains `"value ~ 1"` and `intercept` remains
+`float(result.fe_params["Intercept"])`.
+
+When `fixed_effects` is a non-empty list, the mixed-model formula for the
+`mixed_model` path SHALL become `"value ~ " + " + ".join(f"C({fe})" for fe in
+fixed_effects)`, wrapping every named column in `C(...)` unconditionally —
+every fixed effect SHALL be treated as categorical regardless of its pandas
+dtype, with no dtype-based inference. Every name in `fixed_effects` SHALL be
+validated for presence in `df`, extending the existing top-level
+`required_cols` check (alongside `genotype_col` and, when truthy,
+`replicate_col`): a missing fixed-effect column SHALL produce the same
+run-level `{"error": "Missing required columns: [...]"}` short-circuit as a
+missing `genotype_col`, listing every missing column. Every name in
+`fixed_effects` SHALL also be validated with `fe.isidentifier()` before being
+interpolated into the formula string; a name that is not a valid Python
+identifier (e.g. one containing a patsy formula operator such as `*` or `:`)
+SHALL produce a run-level structural error rather than being interpolated —
+without this, a column name containing an operator character could silently
+misparse as a patsy expression over other, differently-named columns rather
+than a literal reference to itself. The per-trait model
+subset SHALL become `df[[trait, genotype_col] + fixed_effects].dropna()`
+(dropping rows with a `NaN` in any fixed-effect column, in addition to the
+existing trait/genotype `NaN` handling) — this subset change SHALL only take
+effect when `fixed_effects` is non-empty.
+
+A mixed-model fit failure introduced by `fixed_effects` (non-convergence, a
+fixed effect confounded with genotype, or any other `statsmodels` exception)
+SHALL be caught by the existing per-trait `try/except` around the model fit,
+recorded as `{"error": "Mixed model failed: ...", "model_type":
+"mixed_model_failed"}` for that trait — identical handling to a
+non-`fixed_effects`-related fit failure (this reuse of the existing
+`try/except` applies regardless of whether `fixed_effects` is set, since it
+requires no new code). **The additional warning-capture behavior below,
+however, SHALL apply only when `fixed_effects` is non-empty** — this is
+required for the "byte-for-byte identical when `fixed_effects=None`"
+guarantee earlier in this requirement: an unconditional warning-to-failure
+check would be a behavior change for existing, non-`fixed_effects` callers
+(a convergence warning on a plain `"value ~ 1"` fit would newly become a
+failure where it previously succeeded), which this requirement's opening
+paragraph explicitly rules out. When `fixed_effects` is non-empty, the fit
+call SHALL be wrapped in `warnings.catch_warnings(record=True)` with
+`warnings.simplefilter("always")` called immediately inside that block (NOT
+`record=True` alone — Python's default once-per-source-location filter can
+otherwise silently drop a repeat occurrence of the same warning for a later
+trait in the same process). A captured warning SHALL be treated as a fit
+failure for that trait (same error dict shape) only when
+`issubclass(warning.category, statsmodels.tools.sm_exceptions.ConvergenceWarning)`
+— checked by category, NOT by matching the warning's message text (several
+real `statsmodels` convergence-related warning messages do not contain the
+word "convergence" at all). A captured warning of any other category SHALL
+NOT be treated as a fit failure. This is required even though `statsmodels`
+did not raise — `MixedLM.fit()` does not reliably raise on a fixed effect
+that is (near-)fully confounded with genotype, so relying on raised
+exceptions alone would let such a fit silently succeed with degenerate
+parameters. No new upfront identifiability or collinearity pre-validation
+(checked before fitting) SHALL be added; only the fit's own exception/warning
+signals are observed.
+
+`fixed_effects` and `replicate_col` SHALL be fully independent: `replicate_col`
+SHALL NOT be automatically included in `fixed_effects`, and no validation
+SHALL link the two parameters. A block/replicate fixed effect SHALL be
+expressed by naming that column directly in `fixed_effects`.
+
+When `fixed_effects` is non-empty and a trait's mixed model succeeds,
+`intercept` SHALL be computed as an empirical, sample frequency-weighted
+value rather than the raw `result.fe_params["Intercept"]`: for each fixed
+effect, each level's fitted contribution (`0.0` for the reference level
+dropped by patsy's treatment coding; its own coefficient in
+`result.fe_params` for every other level) SHALL be weighted by that level's
+share of the fitted `model_data` rows (that trait's own post-`dropna()`
+subset), summed across levels within that fixed effect, then summed across
+all fixed effects and added to the base `Intercept` coefficient. This value
+is a sample-margin quantity, not a population-typical or EMM/lsmeans-style
+equally-weighted marginal mean — it is sensitive to that trait's own
+missing-data pattern and to incidental level-frequency imbalance, and two
+traits sharing the same `fixed_effects` columns MAY receive different
+per-level weights. The per-level coefficient SHALL be recovered by parsing
+`result.fe_params`'s actual fitted parameter names (matching
+`^C\({fe}\)\[T\.(.*)\]$` for each fixed effect `fe`), not by reconstructing
+the expected key string forward from each observed level's raw value; each
+recovered level string SHALL be matched back to `model_data[fe]`'s values by
+equality, not by positional pairing against a separately-sorted list of
+levels (positional pairing silently mispairs frequencies when a fixed effect
+is a `pandas.Categorical` with a non-default `categories=` order, since
+patsy's reference level is then the first *declared* category, not the first
+in sorted order). The implementation SHALL assert the number of
+non-reference coefficients recovered for a fixed effect equals
+`model_data[fe].nunique() - 1` — computed on that trait's own
+post-`dropna()` fitted subset, not the raw input `df` (a level present in
+`df` can be entirely absent from a specific trait's `model_data` due to that
+trait's own missingness pattern) — raising rather than silently defaulting a
+mismatched level's contribution to `0.0`.
+
+The docstring SHALL document that `fixed_effects` is intended for
+metadata-style covariates that confound with genotype (experiment, wave,
+batch, scanner), not biological/phenotypic traits — a documentation
+convention, not a runtime-enforced check. It SHALL also document that
+`intercept` is an empirical frequency-weighted (not population-typical)
+value when `fixed_effects` is set, and that the row-filtering subset change
+applies identically regardless of `force_method` (the ANOVA-based path
+still ignores `fixed_effects` in its own variance-component computation).
+
+#### Scenario: fixed_effects=None reproduces current behavior exactly
+
+- **WHEN** `calculate_heritability_estimates(df, trait_cols, ...)` is called
+  without `fixed_effects` (or with `fixed_effects=None`)
+- **THEN** the returned dict SHALL be identical, key-for-key and value-for-value,
+  to a call made before this parameter existed — including the `"value ~ 1"`
+  formula and `intercept == float(result.fe_params["Intercept"])`
+
+#### Scenario: A missing fixed-effect column produces a structural error
+
+- **GIVEN** `fixed_effects=["experiment"]` where `"experiment"` is not a column
+  in `df`
+- **WHEN** `calculate_heritability_estimates(df, trait_cols, fixed_effects=["experiment"])`
+  is called
+- **THEN** the return value SHALL be `{"error": "Missing required columns:
+  [...]"}` listing `"experiment"`, with no per-trait entries — the same
+  run-level short-circuit shape as a missing `genotype_col`
+
+#### Scenario: A fixed-effect column name containing a patsy operator is rejected, not silently misparsed
+
+- **GIVEN** `fixed_effects=["rep*block"]` on a `df` that also has separate
+  `"rep"` and `"block"` columns
+- **WHEN** `calculate_heritability_estimates(df, trait_cols,
+  fixed_effects=["rep*block"])` is called
+- **THEN** the call SHALL produce a loud, run-level structural error (the
+  name fails `fe.isidentifier()`)
+- **AND** the formula SHALL NOT be constructed with `"rep*block"`
+  interpolated as if it were a literal column reference — it SHALL NOT
+  silently evaluate as elementwise multiplication of the separate `"rep"`
+  and `"block"` columns
+
+#### Scenario: Fixed-effect columns are always treated as categorical
+
+- **GIVEN** a fixed-effect column whose values are numeric-looking (e.g.
+  `wave_number` with values `1`, `2`, `3`) but represent discrete metadata
+  groups
+- **WHEN** the mixed model is fit with that column in `fixed_effects`
+- **THEN** the fitted formula SHALL wrap the column in `C(...)`, producing one
+  coefficient per non-reference level in `result.fe_params` (treatment
+  coding), NOT a single continuous-slope coefficient
+
+#### Scenario: Rows with a NaN fixed-effect value are dropped from the model fit
+
+- **GIVEN** a row with valid `trait` and `genotype_col` values but a `NaN` in a
+  named `fixed_effects` column
+- **WHEN** `calculate_heritability_estimates(df, trait_cols,
+  fixed_effects=[...])` is called with that column included
+- **THEN** that row SHALL be excluded from the per-trait model subset
+- **AND** the same row SHALL NOT be excluded when the same call is made with
+  `fixed_effects=None`
+
+#### Scenario: A batch-confounded synthetic fixture shows corrected H² below uncorrected H²
+
+- **GIVEN** a synthetic dataset where genotypes are unevenly distributed
+  across two or more "experiment" batches, with a systematic per-batch shift
+  baked into the trait values (mirroring issue #114's Bloom-experiment
+  scenario)
+- **WHEN** `calculate_heritability_estimates` is called once with
+  `fixed_effects=None` and once with `fixed_effects=["experiment"]`
+- **THEN** the `fixed_effects=None` run's heritability estimate SHALL be
+  greater than the `fixed_effects=["experiment"]` run's estimate for the
+  batch-confounded trait
+
+#### Scenario: A model-fit failure from fixed effects is recorded like any other failure
+
+- **GIVEN** a trait whose mixed-model fit raises when `fixed_effects` is set
+  (e.g. a `statsmodels` convergence failure)
+- **WHEN** `calculate_heritability_estimates` processes that trait
+- **THEN** that trait's per-trait dict SHALL be `{"error": "Mixed model
+  failed: ...", "model_type": "mixed_model_failed"}`
+- **AND** no exception SHALL propagate out of `calculate_heritability_estimates`
+- **AND** processing SHALL continue for the remaining traits
+
+#### Scenario: A convergence warning during fit is treated as a failure, not a silent success
+
+- **GIVEN** a trait whose mixed-model fit, with `fixed_effects` set, emits a
+  convergence warning (e.g. `statsmodels`' `ConvergenceWarning`) but does not
+  raise
+- **WHEN** `calculate_heritability_estimates` processes that trait
+- **THEN** that trait's per-trait dict SHALL be classified as failed (the
+  same `{"error": ..., "model_type": "mixed_model_failed"}` shape as a raised
+  exception), NOT returned as a successful `mixed_model` result with
+  `blup`/`intercept`/`heritability` values
+- **AND** processing SHALL continue for the remaining traits
+
+#### Scenario: A warning of an unrelated category does not fail the trait
+
+- **GIVEN** a trait whose mixed-model fit, with `fixed_effects` set, emits a
+  warning of a category other than `ConvergenceWarning` (e.g. a plain
+  `UserWarning`) but does not raise, on otherwise-normal data
+- **WHEN** `calculate_heritability_estimates` processes that trait
+- **THEN** that trait's per-trait dict SHALL be a normal successful
+  `mixed_model` result (`blup`/`intercept`/`heritability` present, no
+  `error` key) — an implementation that treats any captured warning as a
+  failure, regardless of category, violates this scenario
+
+#### Scenario: A convergence warning is not caught when fixed_effects is unset
+
+- **GIVEN** a trait whose mixed-model fit emits a `ConvergenceWarning` but
+  does not raise, called with `fixed_effects=None` (or omitted)
+- **WHEN** `calculate_heritability_estimates` processes that trait
+- **THEN** that trait's per-trait dict SHALL be a normal successful
+  `mixed_model` result, exactly as it would be without this tier's changes —
+  the warning-capture behavior added by this tier SHALL apply only when
+  `fixed_effects` is non-empty, preserving the byte-for-byte compatibility
+  guarantee for `fixed_effects=None` callers
+
+#### Scenario: Empirical frequency-weighted intercept matches a hand-computed average
+
+- **GIVEN** a fixture with a single fixed effect having two levels observed
+  at known, unequal frequencies in the fitted data
+- **WHEN** `calculate_heritability_estimates(df, trait_cols,
+  fixed_effects=["experiment"])` is called and the trait's mixed model
+  succeeds
+- **THEN** the returned `intercept` SHALL equal
+  `fe_params["Intercept"] + level_frequency[level] * offset[level]` summed
+  over the fixed effect's non-reference levels (`offset[level]` from
+  `result.fe_params`, `0.0` implicitly for the reference level), within
+  floating-point tolerance — an independent, hand-computed oracle, not a
+  tautological re-derivation of the implementation
+
+#### Scenario: Multiple fixed effects contribute independently to the intercept
+
+- **GIVEN** `fixed_effects=["experiment", "block"]`, each with its own
+  observed level frequencies
+- **WHEN** the mixed model succeeds
+- **THEN** the returned `intercept` SHALL equal the base `Intercept` plus the
+  independent frequency-weighted contribution of `experiment`'s levels plus
+  the independent frequency-weighted contribution of `block`'s levels (patsy's
+  `+` composes fixed effects additively, not as an interaction) — the two
+  effects' contributions SHALL NOT be conflated or double-counted
+
+#### Scenario: A float-dtype fixed-effect column does not corrupt the coefficient lookup
+
+- **GIVEN** a fixed-effect column stored as `float64` (e.g. `wave_number` with
+  values `1.0`, `2.0`, `3.0`, a realistic case when the source column had a
+  `NaN` elsewhere in the original data before this trait's `dropna()`)
+- **WHEN** the mixed model is fit with that column in `fixed_effects` and the
+  intercept is computed
+- **THEN** every non-reference level's coefficient SHALL be correctly
+  attributed (recovered by parsing `result.fe_params`'s actual fitted
+  parameter names, not by reconstructing a key from the raw `float64` value)
+- **AND** the recovered non-reference coefficient count SHALL equal
+  `model_data[fe].nunique() - 1` — a mismatch SHALL raise rather than
+  silently attribute a real level's contribution as `0.0`
+
+#### Scenario: A non-default categorical level order does not mispair frequencies with coefficients
+
+- **GIVEN** a fixed-effect column declared as `pandas.Categorical` with an
+  explicit, non-alphabetical/non-numeric `categories=[...]` order (so
+  patsy's reference level is the first *declared* category, not the first in
+  sorted order)
+- **WHEN** the mixed model is fit with that column in `fixed_effects` and the
+  intercept is computed
+- **THEN** each recovered level's frequency SHALL be matched to its correct
+  coefficient by equality against `model_data[fe]`'s actual values, NOT by
+  positional pairing against a separately-sorted list of unique levels —
+  the returned `intercept` SHALL match an independent hand-computation using
+  the fixture's known level frequencies and offsets
+
+#### Scenario: A repeated identical convergence warning fails every affected trait, not just the first
+
+- **GIVEN** two different traits in the same
+  `calculate_heritability_estimates` call whose mixed-model fits (with
+  `fixed_effects` set) both emit the same `ConvergenceWarning` (same message,
+  same source location) without raising
+- **WHEN** `calculate_heritability_estimates` processes both traits in the
+  same call
+- **THEN** both traits' per-trait dicts SHALL be classified as failed — the
+  fit-wrapping SHALL force `warnings.simplefilter("always")` so that
+  Python's default once-per-location warning filter does not silently drop
+  the second trait's identical warning
+
+#### Scenario: fixed_effects does not affect the ANOVA-based path's model, only its row filtering
+
+- **GIVEN** `fixed_effects=["experiment"]` and
+  `force_method="anova_based"`
+- **WHEN** `calculate_heritability_estimates` processes a trait
+- **THEN** that trait's per-trait model subset SHALL still exclude rows with
+  a `NaN` in the `"experiment"` column (the same row-filtering as the
+  mixed-model path)
+- **AND** the ANOVA-based variance-component computation SHALL NOT use
+  `fixed_effects` in any way — `model_type` SHALL be `"anova_based"`, with no
+  `C(...)`-wrapped formula ever constructed for this path
+
+#### Scenario: Field-block fixed effect changes BLUP-adjusted means relative to genotype-only
+
+- **GIVEN** a field-block-style fixture with a systematic per-block shift in
+  trait values
+- **WHEN** `calculate_heritability_estimates` is run once with
+  `fixed_effects=None` and once with `fixed_effects=["block"]`, and each
+  result is passed to `extract_blup_table()`
+- **THEN** the two runs' adjusted-means tables SHALL differ for at least one
+  genotype/trait pair beyond floating-point tolerance
+
+#### Scenario: Shrinkage still scales inversely with replication when fixed_effects is set
+
+- **GIVEN** a field-block-style fixture unbalanced across fixed-effect
+  levels, with some genotypes having substantially fewer replicates than
+  others (mirroring Tier 1's unbalanced-design shrinkage oracle), and block
+  composition skew applied orthogonally to the replicate-count grouping (not
+  correlated with which genotypes are low- vs high-replicate)
+- **WHEN** `calculate_heritability_estimates(..., fixed_effects=["block"])`
+  is run
+- **THEN** for every genotype, `abs(blup[genotype])` SHALL be smaller than
+  `|raw_mean_detrended[genotype] - reference_level_intercept|`, where
+  `raw_mean_detrended` is computed by subtracting the fitted `C(block)`
+  coefficient for each observation's (non-reference) block level before
+  averaging within genotype (NOT the naive
+  `df.groupby(genotype)[trait].mean()`, which is itself contaminated by each
+  genotype's own block composition — the exact effect being corrected for),
+  and `reference_level_intercept` is the fitted model's raw
+  `fe_params["Intercept"]` — NOT `calculate_heritability_estimates`'s own
+  returned `intercept`, which for a `fixed_effects` run is the empirical
+  frequency-weighted value (see the "Heritability Model Fixed Effects"
+  requirement), not the reference-level value this comparison needs. Using
+  the empirical frequency-weighted `intercept` here (or comparing against
+  `extract_blup_table()`'s already-summed `adjusted_mean` instead of
+  `blup[genotype]` directly) introduces a constant offset that does not
+  cancel under the absolute-value comparison and breaks this property for a
+  subset of genotypes — confirmed empirically during implementation
+- **AND** this shrinkage gap SHALL be larger for low-replicate genotypes than
+  for high-replicate genotypes, matching Tier 1's existing guarantee

--- a/openspec/changes/add-heritability-fixed-effects/specs/statistics-api/spec.md
+++ b/openspec/changes/add-heritability-fixed-effects/specs/statistics-api/spec.md
@@ -127,13 +127,23 @@ validated for presence in `df`, extending the existing top-level
 `replicate_col`): a missing fixed-effect column SHALL produce the same
 run-level `{"error": "Missing required columns: [...]"}` short-circuit as a
 missing `genotype_col`, listing every missing column. Every name in
-`fixed_effects` SHALL also be validated with `fe.isidentifier()` before being
-interpolated into the formula string; a name that is not a valid Python
-identifier (e.g. one containing a patsy formula operator such as `*` or `:`)
-SHALL produce a run-level structural error rather than being interpolated —
-without this, a column name containing an operator character could silently
-misparse as a patsy expression over other, differently-named columns rather
-than a literal reference to itself. The per-trait model
+`fixed_effects` SHALL also be validated with `isinstance(fe, str) and
+fe.isidentifier()` before being interpolated into the formula string — the
+`isinstance` check SHALL be evaluated first (short-circuiting), so a
+non-`str` element (e.g. an int-labeled column, plausible for a CSV-derived
+batch/wave/scanner code) produces the same run-level structural error rather
+than an uncaught `AttributeError` from calling `.isidentifier()` on a
+non-string. A name that is not a valid Python identifier (e.g. one
+containing a patsy formula operator such as `*` or `:`) SHALL produce a
+run-level structural error rather than being interpolated — without this, a
+column name containing an operator character could silently misparse as a
+patsy expression over other, differently-named columns rather than a
+literal reference to itself. A `fixed_effects` name that duplicates
+`genotype_col` or `replicate_col` SHALL also produce a run-level structural
+error rather than being interpolated — without this, the duplicate column
+selection surfaces as a confusing pandas-internal error deep inside the
+per-trait loop (e.g. `"Grouper for 'geno' not 1-dimensional"`) rather than a
+clear structural error. The per-trait model
 subset SHALL become `df[[trait, genotype_col] + fixed_effects].dropna()`
 (dropping rows with a `NaN` in any fixed-effect column, in addition to the
 existing trait/genotype `NaN` handling) — this subset change SHALL only take
@@ -246,6 +256,30 @@ still ignores `fixed_effects` in its own variance-component computation).
   interpolated as if it were a literal column reference — it SHALL NOT
   silently evaluate as elementwise multiplication of the separate `"rep"`
   and `"block"` columns
+
+#### Scenario: A non-string fixed_effects element is rejected, not crashed
+
+- **GIVEN** `fixed_effects=[5]` where `5` is a valid, int-labeled column in
+  `df` (plausible for a CSV-derived batch/wave/scanner code)
+- **WHEN** `calculate_heritability_estimates(df, trait_cols,
+  fixed_effects=[5])` is called
+- **THEN** the call SHALL produce the same run-level `{"error": "Invalid
+  fixed_effects column name(s): [...]"}` structural error as an
+  invalid-identifier string name
+- **AND** no exception (e.g. `AttributeError` from calling `.isidentifier()`
+  on a non-`str`) SHALL propagate to the caller
+
+#### Scenario: A fixed_effects name duplicating genotype_col or replicate_col is rejected
+
+- **GIVEN** `fixed_effects=["geno"]` where `"geno"` is also `genotype_col`
+  (or, symmetrically, `fixed_effects=[replicate_col]`)
+- **WHEN** `calculate_heritability_estimates` is called
+- **THEN** the call SHALL produce a run-level structural error naming the
+  duplicated column(s)
+- **AND** the per-trait loop SHALL NOT be reached — without this check, the
+  duplicate-column selection surfaces as a confusing pandas-internal error
+  (e.g. `"Grouper for 'geno' not 1-dimensional"`) rather than a clear
+  structural error
 
 #### Scenario: Fixed-effect columns are always treated as categorical
 

--- a/openspec/changes/add-heritability-fixed-effects/tasks.md
+++ b/openspec/changes/add-heritability-fixed-effects/tasks.md
@@ -592,3 +592,48 @@
       task is not satisfied until the user has reviewed and approved the
       reconciled proposal — required before implementation (Sections 1–5
       above) begins, per the roadmap's per-tier loop.
+
+## 7. PR review follow-up (`/review-pr` on PR #193, after merge into main was not done — fixes landed on the open PR)
+
+- [x] 7.1 Fix BLOCKING: `fixed_effects` element that isn't a `str` (e.g. an
+      int-labeled CSV column) crashed with an uncaught `AttributeError` from
+      `fe.isidentifier()`, contradicting the function's own documented
+      "nothing propagates to the caller" contract. Fixed:
+      `isinstance(fe, str)` checked first (short-circuiting) in the same
+      validation line. Test:
+      `test_fixed_effect_non_string_name_rejected_not_crashed`.
+- [x] 7.2 Documented in the statistics-api spec delta: the non-str rejection
+      (7.1) and the pre-existing genotype/replicate-collision rejection
+      (already implemented and tested, but missing from the normative spec
+      text per the review's spec-sync finding) both now have `#### Scenario:`
+      entries.
+- [ ] 7.3 **(Deferred — candidate follow-up issue, not fixed in this PR)**
+      `fixed_effects` columns are excluded from the low-`H2`-filtering trait
+      scan for direct API callers (`remove_low_h2=True`), but
+      `StatisticalAnalysisStep` always calls with `remove_low_h2=False`, so
+      the *pipeline's* upstream `trait_cols` (fixed once in `LoadDataStep`
+      via `get_trait_columns`) has no knowledge of
+      `config.statistics.fixed_effects` and only excludes names matching a
+      hardcoded substring list. A `fixed_effects` name outside that list
+      (e.g. `"block"`) is silently treated as a phenotypic trait everywhere
+      upstream of the statistics step. Needs a config-level design decision
+      (auto-derive `additional_exclude_cols` from `fixed_effects`? validate
+      they're disjoint? document the required manual sync?) — out of scope
+      for a same-PR fix; file as a follow-up issue referencing #114.
+- [ ] 7.4 **(Deferred — candidate follow-up issue)** No config-schema
+      validation for `StatisticsConfig.fixed_effects` (e.g. a bare string
+      instead of a list isn't caught, producing a misleading
+      character-by-character "Missing required columns" error). No golden
+      template documents `fixed_effects` even as a commented example.
+- [ ] 7.5 **(Deferred — candidate follow-up issue)** The `ConvergenceWarning`
+      heuristic's confirmed false-negative (a fixed effect
+      near-deterministically confounded with genotype can fit cleanly with
+      zero warnings) is currently only documented in the docstring. Consider
+      surfacing it as an actual `UserWarning` at call time when
+      `fixed_effects` is used, so it's visible without reading source.
+- [ ] 7.6 **(Deferred, minor)** Duplicate entries *within* `fixed_effects`
+      itself (e.g. `["experiment", "experiment"]`) aren't rejected upfront —
+      degrades to a `mixed_model_failed` error from patsy rather than a
+      clean message. No test for the single-level (zero-variance)
+      fixed-effect case (verified correct by hand-tracing, per pre-merge
+      review, but untested).

--- a/openspec/changes/add-heritability-fixed-effects/tasks.md
+++ b/openspec/changes/add-heritability-fixed-effects/tasks.md
@@ -1,0 +1,594 @@
+> Test fixtures: add two new fixtures to `tests/fixtures.py` — see 1.1 and 1.2.
+> Section 1/2 tests import `from sleap_roots_analyze.statistics import
+> calculate_heritability_estimates, extract_blup_table` directly (no new
+> public API surface is added in this tier — `fixed_effects` is a parameter on
+> an existing exported function).
+>
+> Reconciled after `/review-openspec` rounds 1–3 plus one targeted empirical
+> follow-up (round 1: 5 parallel reviewers; round 2: a targeted re-check of
+> round 1's fixes; round 3: a fresh cold-read plus an empirically-verified
+> fixture correction; round 4: a direct simulation of the second fixture,
+> prompted by a follow-up question, which found and fixed a related
+> methodology gap in the shrinkage oracle — see `design.md`'s four
+> "Adversarial Review Reconciliation" sections for the full synthesis).
+> Changes from the pre-review draft are called out inline where they affect
+> a specific task.
+
+## 1. Fixtures + `fixed_effects` support in `calculate_heritability_estimates` (test-first)
+
+- [x] 1.1 Add `heritability_data_batch_confounded` fixture to `tests/fixtures.py`
+      (mirror `heritability_data_known_h2`'s column names — `geno`/`rep`/
+      `Barcode`, seed 42). **Pin concrete numeric parameters, matching Tier
+      1's `heritability_data_unbalanced_reps` precedent — verified by direct
+      simulation against real `statsmodels` (round-3 review), not derived
+      analytically or eyeballed.** An earlier draft of this fixture (σ_G=3.0,
+      shift=8.0, n=4 reps, a 16/4-genotype 3:1/1:3 partial mix) was
+      **confirmed by simulation to produce the opposite of the intended
+      effect** (uncorrected H² *below* corrected H², by 0.36–0.85 across
+      seeds) — with only n=4 reps, any genuinely partial (not fully
+      deterministic) per-genotype batch mix necessarily injects more
+      *within*-genotype variance than *between*-genotype variance for any
+      shift magnitude, so "increase the shift" (that draft's own stated
+      remedy) could not have fixed it; the confound *pattern* itself was
+      unfixable at n=4. The verified replacement:
+
+      One trait `trait_batch_confounded` with a genotype effect
+      `np.random.normal(0, 0.4)` (σ_G), per-observation noise
+      `np.random.normal(0, 1.0)` (σ_E), base value 50. 20 genotypes total,
+      each with **n=10 reps (200 rows)**. Two synthetic `"experiment"`
+      batches, split symmetrically into two **equal-size** genotype groups
+      (this symmetry is what makes the between-genotype variance from the
+      confound exceed the within-genotype variance from partial mixing —
+      an uneven group split, like the rejected 16/4 draft, does not):
+      genotypes `G01`-`G10` ("mostly-A") have exactly 1 of their 10 reps in
+      `"Bloom_B"` (9 in `"Bloom_A"`); genotypes `G11`-`G20` ("mostly-B") have
+      the reverse (9 of 10 reps in `"Bloom_B"`, 1 in `"Bloom_A"`) — genuinely
+      partial per-genotype mixing (every genotype has at least one rep in
+      each batch), not full determinism (which is exercised separately by
+      task **1.10**, not 1.9 — 1.9 mocks the fit directly and builds no
+      confounded fixture at all). Add a systematic per-batch shift of
+      `+10.0` to every `"Bloom_B"` observation. Return `(df, meta)` where
+      `meta = {"trait": "trait_batch_confounded", "batch_col": "experiment"}`.
+      **Use `np.random.seed(42)` + `np.random.normal(...)` (this file's
+      existing global-state RNG convention, matching every other fixture in
+      this file) — NOT `np.random.default_rng(42)`.** The two APIs produce
+      different streams for the same seed number; the verification below was
+      re-run under the *legacy* API specifically because this distinction
+      matters (an earlier verification pass, done under `default_rng`
+      before this discrepancy was caught, gave different — still
+      correctly-signed — numbers that do not apply to the actual fixture
+      code). Draw each genotype's own effect (one `np.random.normal(0,
+      0.4)` call) immediately before iterating its reps, genotype by
+      genotype in the order `G01..G10` (mostly-A) then `G11..G20`
+      (mostly-B); within each genotype, draw one `np.random.normal(0, 1.0)`
+      noise call per rep, in `Bloom_A`-then-`Bloom_B` order (i.e. the
+      `n_a` `"Bloom_A"` reps come first in the per-genotype rep loop, then
+      the `n_b` `"Bloom_B"` reps) — this exact call order is what the
+      verified numbers below assume; a different loop/draw order will
+      produce different (though, per the 10-seed robustness check below,
+      likely still correctly-signed) numbers. **Verified under this exact
+      legacy-API construction, seed=42: H²_uncorrected≈0.9405,
+      H²_corrected≈0.7194, gap≈0.2211.** Robustness re-checked across 10
+      other legacy seeds (1, 2, 3, 7, 13, 21, 99, 123, 777, plus 42 itself):
+      minimum gap 0.2138, mean 0.3756 — all comfortably clear the 0.05
+      threshold task 1.7 asserts, with 4x+ margin at the worst seed. Do not
+      re-derive these numbers from scratch — they are locked in from this
+      verification; if implementation produces a different result on this
+      exact fixture, treat that as a real discrepancy to investigate (a
+      code bug, or a draw-order/RNG-API mismatch versus this
+      specification), not a reason to re-tune the shift/σ_G values.
+- [x] 1.2 Add `heritability_data_field_block` fixture to `tests/fixtures.py`
+      (mirror `heritability_data_known_h2`'s column names, seed 42). **Pin
+      concrete numeric parameters, empirically verified against real
+      `statsmodels` (round-4 review — a direct follow-up empirical check
+      after round 3, prompted by the same "don't trust eyeballed fixture
+      design" lesson):** one trait with a genotype effect
+      `np.random.normal(0, 2.0)` (σ_G), per-observation noise
+      `np.random.normal(0, 1.0)` (σ_E, pinned explicitly — an earlier draft
+      never specified a residual noise term at all, risking degenerate
+      within-genotype variance for genotypes with all reps in one block),
+      base value 50, and a systematic per-`"block"` shift of `+5.0` for
+      `"block_2"` rows. Use `np.random.seed(42)` + `np.random.normal(...)`
+      (this file's convention, not `default_rng`, per the same RNG-API
+      distinction task 1.1 now calls out explicitly). 15 genotypes total,
+      split into two **replicate-count** groups (needed for task 3.2's
+      shrinkage oracle — an earlier draft specified uniform n=3 for all 15
+      genotypes, which cannot support it at all): 7 "low-rep" genotypes
+      (`G01`-`G07`) with **n=2** reps each, 8 "high-rep" genotypes
+      (`G08`-`G15`) with **n=10** reps each (94 rows total). Block skew
+      SHALL be applied as the same proportion within each replicate-count
+      group, not correlated with which group a genotype is in — pinned
+      concretely: `{G01, G02, G03, G04, G05}` (5 of the 7 low-rep genotypes)
+      and `{G08, G09, G10, G11, G12, G13}` (6 of the 8 high-rep genotypes)
+      get 80% of their reps in `"block_1"` / 20% in `"block_2"`; the
+      remaining genotypes in each group (`{G06, G07}` and `{G14, G15}`) get
+      the reverse (20%/80%) — a ~71% block-1-heavy ratio in both
+      replicate-count groups. Draw each genotype's own effect (one
+      `np.random.normal(0, 2.0)` call) immediately before iterating its
+      reps, genotype by genotype in the order `G01..G07` (low-rep) then
+      `G08..G15` (high-rep); within each genotype, draw one
+      `np.random.normal(0, 1.0)` noise call per rep, in
+      `"block_1"`-then-`"block_2"` order. **This orthogonality
+      is required, not incidental**: an earlier draft skewed block
+      assignment *by genotype ID* (`G01`-`G10` vs `G11`-`G15`), which
+      happened to correlate with the replicate-count grouping (`G01`-`G07`
+      is entirely inside the block-1-heavy range) — verified by simulation
+      to produce an unreliable shrinkage oracle (40% failure rate on 3.2,
+      §below) even though the simpler BLUP-difference oracle (3.1) was
+      unaffected. Used by the field-BLUP oracle (3.1) — not required to show
+      an H² gap, only a measurable BLUP-adjusted-mean difference between
+      `fixed_effects=None` and `fixed_effects=["block"]`, **re-verified
+      under the legacy RNG API and this exact concrete block assignment:
+      0/10 seeds failed to show a difference (max diff 3.7–5.1 across
+      seeds 1,2,3,7,13,21,42,99,123,777)** — and the shrinkage-regression
+      oracle (3.2), **re-verified under the same conditions: 0/10 seeds
+      failed, using the detrended comparison task 3.2 now specifies** (a
+      naive, non-detrended comparison failed the majority of the time on an
+      earlier draft of this fixture — see 3.2's own note for why, and do
+      not skip the detrending step described there).
+- [x] 1.3 Write failing test `test_fixed_effects_none_matches_current_behavior`
+      (`tests/test_statistics.py`, new `TestFixedEffects` class): call
+      `calculate_heritability_estimates` on `heritability_data_known_h2` three
+      ways — without `fixed_effects`, with `fixed_effects=None`, and with
+      `fixed_effects=[]` (empty list) — assert all three are identical to
+      each other and to a hand-computed expectation matching pre-change
+      behavior (formula `"value ~ 1"`, `intercept ==
+      float(result.fe_params["Intercept"])`). Including the empty-list case
+      closes a boundary-value gap flagged in review: `fixed_effects=[]` must
+      behave identically to `None`, not attempt a formula with zero terms.
+- [x] 1.4 Write failing test `test_missing_fixed_effect_column_returns_structural_error`:
+      `calculate_heritability_estimates(df, trait_cols,
+      fixed_effects=["nonexistent_col"])` returns `{"error": "Missing
+      required columns: [...]"}` (top-level short-circuit, no per-trait
+      entries), listing `"nonexistent_col"`.
+- [x] 1.4a **(New — added after round-3 review)** Write failing test
+      `test_fixed_effect_column_name_with_patsy_metacharacter_rejected`:
+      `fixed_effects=["rep*block"]` (a column name containing a patsy
+      formula operator) on a `df` that happens to also have separate
+      `"rep"` and `"block"` columns; assert a clear, loud top-level error
+      (e.g. extending the same `{"error": "Missing required columns:
+      [...]"}` shape, or a distinct validation error — either is
+      acceptable, just not a silent misinterpretation), NOT a silent
+      formula misparse where `C(rep*block)` gets evaluated as elementwise
+      multiplication of the two *different*, unintended columns. Guards a
+      narrow but genuinely silent-corruption tail case round-3 review
+      flagged: near-zero implementation cost (`fe.isidentifier()` check
+      alongside the existing missing-column validation) closes it, even
+      though it requires two contrived conditions simultaneously to trigger
+      the silent-misparse form.
+- [x] 1.5 Write failing test `test_fixed_effect_column_always_treated_as_categorical`:
+      build a small fixture where a fixed-effect column has numeric-looking
+      values (e.g. `wave_number` = 1, 2, 3) but a real per-level shift.
+      **`calculate_heritability_estimates`'s return value never exposes the
+      fitted `result` object** (only `blup`/`intercept` are extracted) — do
+      not attempt to reach it from the public API. Assert indirectly instead:
+      fit the same `model_data` through `smf.mixedlm` twice directly in the
+      test (once with the production formula string `"value ~
+      C(wave_number)"`, once with a deliberately continuous formula
+      `"value ~ wave_number"`), and confirm the two fits' `fe_params` differ
+      in shape (one coefficient per non-reference level vs. a single slope
+      coefficient) — this is the same "fit independently in the test" pattern
+      tasks 2.2/2.4 also use, resolved here rather than left as an open
+      fallback decision (a pre-review draft of this task left the approach
+      undecided; review flagged that as a stall risk).
+- [x] 1.6 Write failing test `test_nan_in_fixed_effect_column_drops_row`:
+      one row has a valid trait value and genotype but `NaN` in a named
+      fixed-effect column; assert that row is excluded from the fitted
+      `n_observations` when `fixed_effects=[...]` includes that column, and
+      NOT excluded when `fixed_effects=None` on the same DataFrame.
+- [x] 1.7 Write failing test `test_batch_confounded_uncorrected_h2_exceeds_corrected`
+      using `heritability_data_batch_confounded` (1.1): assert
+      `calculate_heritability_estimates(df, ["trait_batch_confounded"])["trait_batch_confounded"]["heritability"]`
+      (no fixed effects) is greater than the same call with
+      `fixed_effects=["experiment"]` by at least 0.05 (absolute) — the
+      roadmap's core Tier 2 oracle, with an explicit margin rather than a
+      bare direction-only assertion.
+- [x] 1.8 Write failing test `test_mixed_model_failure_with_fixed_effects_recorded_as_error`
+      (mirror Tier 1's `test_mixed_model_fit_failure_has_no_blup_keys`): mock
+      `statsmodels.formula.api.mixedlm` (patch target confirmed correct —
+      `statistics.py` does `import statsmodels.formula.api as smf` then calls
+      `smf.mixedlm(...)`, so `patch("statsmodels.formula.api.mixedlm",
+      side_effect=Exception("boom"))` is the right target, matching the
+      existing precedent at `tests/test_statistics.py:451`) to raise when
+      `fixed_effects` is set; assert the trait's dict is `{"error": "Mixed
+      model failed: ...", "model_type": "mixed_model_failed"}`, no exception
+      propagates, and the remaining traits in the same call are still
+      processed.
+- [x] 1.9 **(New — added after review)** Write failing test
+      `test_convergence_warning_treated_as_failure`: using
+      `warnings.catch_warnings()`, mock (or otherwise induce)
+      `model.fit(reml=True)` to emit a `ConvergenceWarning` without raising
+      (e.g. `patch.object` the fit method to call `warnings.warn(...,
+      ConvergenceWarning)` and return a real-but-arbitrary fitted `result`);
+      assert the trait's dict is classified as failed
+      (`{"error": ..., "model_type": "mixed_model_failed"}`), NOT returned as
+      a successful `mixed_model` result with `blup`/`intercept` values. This
+      exercises the specific gap review found: `statsmodels.MixedLM.fit()`
+      does not reliably *raise* on a fixed effect confounded with genotype —
+      it can instead warn and still return a plausible-looking `result` — so
+      1.8's raised-exception test alone does not cover this failure mode.
+- [x] 1.9a **(New — added after round-3 review)** Write failing test
+      `test_unrelated_warning_during_fit_does_not_fail_trait`: mock (or
+      otherwise induce) `model.fit(reml=True)` to emit an unrelated warning
+      of a *different* category (e.g. a plain `UserWarning` or `FutureWarning`,
+      not `ConvergenceWarning`) without raising, on otherwise-normal data;
+      assert the trait's dict is a normal successful `mixed_model` result
+      (`blup`/`intercept`/`heritability` present, no `error` key) — the
+      false-positive counterpart to 1.9, guarding against an implementation
+      that treats "any captured warning" as a failure instead of checking
+      specifically for `ConvergenceWarning`'s category.
+- [x] 1.9b **(New — added during implementation)** Write failing test
+      `test_convergence_warning_not_caught_without_fixed_effects`: same
+      mocked-warning setup as 1.9, but call
+      `calculate_heritability_estimates` with `fixed_effects=None` (or
+      omitted); assert the trait's dict is a normal successful
+      `mixed_model` result — the warning-capture behavior added by this
+      tier must be gated on `fixed_effects` being non-empty, or it would
+      silently break the "`fixed_effects=None` reproduces current behavior
+      exactly" guarantee (a real ambiguity caught during implementation:
+      the requirement text describing warning-capture did not explicitly
+      say this was conditional, even though the earlier byte-for-byte
+      guarantee logically required it — see the statistics-api spec's
+      "Heritability Model Fixed Effects" requirement, now stated
+      explicitly).
+- [x] 1.10 **(New — added after review, organic/non-mocked)** Write a test
+      `test_near_fully_confounded_fixed_effect_organic_behavior` that
+      constructs a fixture where a fixed effect is a *near-deterministic*
+      function of genotype (e.g. 18 of 20 genotypes appear in only one of two
+      experiment batches, 2 genotypes split 50/50 as the only source of
+      within-genotype batch variation) and calls
+      `calculate_heritability_estimates` with that fixed effect, with no
+      mocking. Document (via an assertion, not just a comment) whichever of
+      the following `statsmodels` actually does on this fixture: raises
+      (caught by 1.8's path), warns (caught by 1.9's path), or fits without
+      warning (in which case assert on whatever heritability/intercept value
+      results, so a future `statsmodels` version change that alters this
+      behavior is caught as a test failure rather than silently drifting).
+      **Sequencing note (round-2 review): unlike this section's other tasks,
+      this test's assertion content cannot be predicted before 1.11 lands —
+      it is a characterization/regression-pinning test, not a predictive
+      red-green TDD test, despite its position in this "(test-first)"
+      section. Write the test body itself after implementing 1.11: run it
+      once to observe actual `statsmodels` behavior on this fixture, then pin
+      that specific observed outcome as the assertion.** Not required to
+      assert a specific one of the three outcomes in advance of running it —
+      only required to observe and pin down the *actual* current behavior,
+      since review found this is not guaranteed by `statsmodels`'
+      documentation. Not represented by a normative spec scenario for the
+      same reason (there is nothing to prescribe in advance — only to pin).
+- [x] 1.11 Implement `fixed_effects: Optional[List[str]] = None` on
+      `calculate_heritability_estimates` (`statistics.py:195-`): extend
+      `required_cols` with `fixed_effects` (when truthy) for the top-level
+      missing-column check; extend the per-trait `subset` to
+      `df[[trait, genotype_col] + (fixed_effects or [])].dropna()` (computed
+      once, before the `if use_mixed_model:` branch, so both the mixed-model
+      and ANOVA-based paths see the same row-filtering — only the
+      mixed-model path additionally uses `fixed_effects` in its formula);
+      build the mixed-model formula as `"value ~ " + " + ".join(f"C({fe})"
+      for fe in fixed_effects)` when `fixed_effects` is non-empty, else keep
+      `"value ~ 1"`. **Only when `fixed_effects` is non-empty**, wrap
+      `model.fit(reml=True)` in `warnings.catch_warnings(record=True)` and
+      call `warnings.simplefilter("always")` as the first statement inside
+      that block — **gating this on `fixed_effects` is required, not
+      optional (caught during implementation): the requirement text
+      describing this behavior did not originally say it was conditional,
+      but the earlier "`fixed_effects=None` reproduces current behavior
+      exactly" guarantee logically requires it — an unconditional
+      warning-to-failure check would newly fail existing, non-`fixed_effects`
+      callers whose fit happens to emit a convergence warning today and
+      succeeds. See task 1.9b.** Without the `simplefilter("always")` call
+      specifically, Python's
+      default once-per-location warning filter can silently drop a repeat
+      occurrence of the same `ConvergenceWarning` for a later trait in the
+      same process, since `statsmodels` raises it from the same source
+      line every time. `record=True` alone does not force every occurrence
+      to be recorded; only `simplefilter("always")` does. This bug would NOT
+      be caught by a test that checks only one warning occurrence in
+      isolation, because pytest's own warnings plugin already wraps tests in
+      `simplefilter("always")` by default and would mask a missing call
+      inside production code — see task 1.13.** For each captured warning,
+      check `issubclass(w.category,
+      statsmodels.tools.sm_exceptions.ConvergenceWarning)` — **NOT** a
+      substring match on the warning's message text (round-3 review found
+      several real `statsmodels` convergence-related warning messages that
+      do not contain the word "convergence" at all, e.g. "The MLE may be on
+      the boundary of the parameter space." and "The Hessian matrix at the
+      estimated parameter values is not positive definite." — a
+      message-text filter would silently miss exactly the messages a
+      near-confounded fixed effect is most likely to trigger). If any
+      captured warning matches that category, treat the trait identically
+      to a raised exception (same error dict, `model_type:
+      "mixed_model_failed"`); a warning of any OTHER category captured in
+      the same block SHALL NOT be treated as a fit failure — do not use "any
+      captured warning" as the check.
+      Also validate each `fixed_effects` name with `fe.isidentifier()`
+      alongside the existing missing-column check, rejecting a name
+      containing a patsy formula operator before it ever reaches the
+      formula string (closes 1.4a's silent-misparse tail case). Reuse the
+      existing per-trait `try/except` for raised exceptions
+      unchanged. Make 1.3–1.9, 1.9a, 1.9b, 1.4a green (1.10, 1.12, and 1.13 all depend
+      on this implementation too, but are written/verified immediately after
+      — 1.10 per its own sequencing note above, since its assertion content
+      isn't knowable before this implementation exists; 1.12/1.13 are
+      ordinary post-implementation regression checks). Update the function's
+      docstring:
+      document the new parameter, the categorical-only (`C()`) treatment,
+      the subset/dropna change (and that it applies identically regardless
+      of `force_method`), the "metadata covariates only, not biological
+      traits" convention (per issue #114), that `replicate_col` is
+      independent of `fixed_effects`, and that convergence warnings are
+      treated as failures. Do NOT yet update the `Returns:` section's
+      `intercept` description — that's task 2.6, once the marginal-intercept
+      logic exists to describe.
+- [x] 1.12 **(New — added after review)** Write failing test
+      `test_fixed_effects_with_anova_based_force_method`: call
+      `calculate_heritability_estimates(df, trait_cols,
+      fixed_effects=["experiment"], force_method="anova_based")` on
+      `heritability_data_batch_confounded`; assert (a) the trait's
+      `model_type == "anova_based"` (fixed effects do not change which method
+      is used), (b) a row with `NaN` in `"experiment"` is still excluded from
+      that trait's `n_observations` (same row-filtering as the mixed-model
+      path), and (c) no `blup`/`intercept` keys are present (unchanged from
+      today's ANOVA-based behavior). Should already be green once 1.11 lands
+      — if it isn't, that's a real bug in how `fixed_effects` was scoped to
+      the mixed-model branch.
+- [x] 1.13 **(New — added after round-2 review)** Write failing test
+      `test_repeat_convergence_warning_across_traits_both_fail`: mock the fit
+      call so the *same* `ConvergenceWarning` (same message, same
+      simulated source location) is emitted for **two different traits**
+      within a single `calculate_heritability_estimates(df, trait_cols=[...])`
+      call (not two separate calls/processes). Assert **both** traits'
+      dicts are classified as failed. This specifically exercises the gap
+      round-2 review found: Python's default warning filter is
+      once-per-location, so without an explicit
+      `warnings.simplefilter("always")` inside 1.11's `catch_warnings` block,
+      the *second* trait's identical warning could be silently suppressed by
+      the registry and that trait would incorrectly succeed. A test that
+      checks only one warning occurrence in isolation (1.9) cannot expose
+      this, because pytest's own warnings plugin already applies
+      `simplefilter("always")` around every test and would mask a missing
+      call in production code.
+
+## 2. Empirical frequency-weighted intercept (test-first)
+
+- [x] 2.1 Write failing test `test_marginal_intercept_none_equals_plain_intercept`:
+      with `fixed_effects=None`, `intercept` equals
+      `float(result.fe_params["Intercept"])` exactly (already covered by 1.3,
+      but assert explicitly here as the anchor case for this section's
+      helper).
+- [x] 2.2 Write failing test `test_marginal_intercept_matches_hand_computed_weighted_average`:
+      build a small fixture with one fixed effect (`"experiment"`) having two
+      known, unequal observed-frequency levels; **independently re-fit the
+      same `model_data` via a direct `smf.mixedlm(...).fit(reml=True)` call in
+      the test** (the function's return value does not expose `result`, so
+      this is the only way to obtain `fe_params` for a genuinely independent
+      oracle — same pattern as 1.5), then compute the expected intercept by
+      hand from that independently-fit `result.fe_params` and the fixture's
+      known level frequencies (`fe_params["Intercept"] +
+      freq[level] * offset[level]` summed over non-reference levels), and
+      assert the production function's returned `intercept` matches within
+      floating-point tolerance.
+- [x] 2.3 Write failing test `test_marginal_intercept_differs_from_reference_level_when_unbalanced`:
+      same fixture as 2.2 (unequal level frequencies); assert the returned
+      `intercept` differs from the raw `result.fe_params["Intercept"]` (from
+      the same independent re-fit) by more than floating-point tolerance —
+      proves the weighting has an effect, not a silent no-op.
+- [x] 2.4 Write failing test `test_marginal_intercept_multiple_fixed_effects_independent`:
+      `fixed_effects=["experiment", "block"]`, each with its own known level
+      frequencies; independently re-fit and assert the returned `intercept`
+      equals the base `Intercept` plus `experiment`'s independently-computed
+      weighted contribution plus `block`'s independently-computed weighted
+      contribution — guards against conflating or double-counting the two
+      effects.
+- [x] 2.5 **(New — added after review)** Write failing test
+      `test_marginal_intercept_float_dtype_fixed_effect_column`: build a
+      fixture where the fixed-effect column is explicitly `float64`-typed
+      (e.g. `pd.Series([1.0, 2.0, 3.0, ...])`, not `int` or `str`/`category`);
+      assert the intercept computation correctly attributes each level's
+      coefficient (matching an independent hand-computation as in 2.2), not a
+      silently-defaulted `0.0` for a level whose reconstructed key failed to
+      match `fe_params`'s actual key.
+- [x] 2.5a **(New — added after round-2 review)** Write failing test
+      `test_marginal_intercept_non_sorted_categorical_order`: build a fixture
+      where the fixed-effect column is a `pd.Categorical` with an explicit,
+      deliberately non-alphabetical/non-numeric `categories=[...]` order
+      (so patsy's reference level is the first *declared* category, not the
+      first in sorted order — none of 2.2/2.4/2.5's fixtures exercise this,
+      since their levels' sorted order happens to coincide with patsy's
+      fitted order). Assert the intercept computation still attributes each
+      level's frequency to its correct coefficient (matching an independent
+      hand-computation). This specifically catches a positional-pairing bug
+      that count-only or sorted-order-assuming implementations would pass
+      undetected on 2.2/2.4/2.5's fixtures alone.
+- [x] 2.6 Implement a private helper (e.g. `_marginal_intercept(result,
+      model_data, fixed_effects)`) in `statistics.py`. **Revised after
+      review**: do NOT reconstruct the expected `fe_params` key forward from
+      each observed level's raw value (the original draft's
+      `f"C({fe})[T.{level}]"` pattern risks silently misattributing a level
+      to the reference level on a dtype/formatting mismatch — e.g. a
+      `float64` column). Instead: for each fixed effect, parse
+      `result.fe_params`'s actual index with a regex
+      (`^C\({fe}\)\[T\.(.*)\]$`) to recover the set of levels patsy actually
+      fit non-reference coefficients for (the recovered string SHALL be
+      matched back to `model_data[fe]`'s actual values by equality — NOT by
+      positional pairing against a separately-sorted list of unique levels,
+      which would silently mispair frequencies under a non-default category
+      order; see 2.5a); compute each recovered level's frequency in
+      `model_data[fe]` (that trait's own post-`dropna()` fitted subset —
+      NOT the raw input `df`, since a level present in `df` can be entirely
+      absent from a specific trait's `model_data` due to that trait's own
+      missingness pattern, per round-2 review); assert the recovered
+      non-reference coefficient count equals `model_data[fe].nunique() - 1`
+      (raise `ValueError` if not — a silent mismatch is worse than a loud
+      failure here); sum `frequency * coefficient` per fixed effect, sum
+      across fixed effects, add `result.fe_params["Intercept"]`. Call this
+      helper from the mixed-model branch instead of
+      `float(result.fe_params["Intercept"])` whenever `fixed_effects` is
+      non-empty; keep the plain `Intercept` lookup when `fixed_effects` is
+      empty/`None`. Make 2.1–2.5a green. **Also**: update
+      `calculate_heritability_estimates`'s docstring `Returns:` section —
+      the current sentence ("intercept: ... from
+      `result.fe_params["Intercept"]`") becomes inaccurate once this branch
+      exists; describe the empirical frequency-weighted case explicitly,
+      including the caveat that it is sample-composition-dependent and can
+      differ trait-to-trait due to each trait's own `dropna()` (this was
+      flagged in review as a docstring-staleness risk with no task covering
+      it).
+- [x] 2.7 **(New — added after review)** Write failing test
+      `test_blupresult_intercepts_passthrough_fixed_effects`
+      (`tests/test_blup_result.py`): build a `heritability_results`-shaped
+      dict by hand where a trait's `intercept` is a known empirical
+      frequency-weighted value (as if produced by `fixed_effects`), pass it
+      through `extract_blup_table()` then `BLUPResult.from_blup_table(df,
+      intercepts=...)`; assert `result.intercepts[trait]` equals that exact
+      value, unchanged — confirms the pass-through the
+      `serializable-result-types` delta spec's "intercepts values pass
+      through unchanged when the source used fixed_effects" scenario
+      requires. No implementation change expected (should already be green);
+      this is a regression guard, not new logic.
+- [x] 2.8 **(New — added after review)** Update
+      `BLUPResult.intercepts`'s docstring `Attributes:` entry in
+      `result_types.py` (currently ~line 832) to describe the empirical
+      frequency-weighted semantics when the source
+      `calculate_heritability_estimates` call used `fixed_effects` — a
+      docs-only change (`BLUPResult`/`from_blup_table` already store/pass
+      through whatever `intercept` float they're given, per 2.7). Also add a
+      short caveat bullet to the `BLUPResult` row in `docs/result-types.md`,
+      mirroring the existing per-type caveat bullets already in that file
+      (e.g. the hierarchical-clustering "deterministic" caveat).
+
+## 3. Field-block BLUP oracle (test-first, integration-level)
+
+- [x] 3.1 Write failing test `test_field_block_fixed_effect_changes_blup_adjusted_means`
+      using `heritability_data_field_block` (1.2): run
+      `calculate_heritability_estimates` + `extract_blup_table` once with
+      `fixed_effects=None` and once with `fixed_effects=["block"]` (note:
+      independent of `replicate_col`, which stays at its default); assert at
+      least one genotype/trait adjusted-mean value differs between the two
+      runs beyond floating-point tolerance — the roadmap's second oracle half
+      ("field BLUPs with block correction differ from genotype-only BLUPs").
+      No implementation change expected here — this test should pass once
+      Sections 1–2 are implemented; if it doesn't, that's a real integration
+      bug to fix before moving on.
+- [x] 3.2 **(New — added after review)** Write failing test
+      `test_shrinkage_scales_with_replication_under_fixed_effects` using
+      `heritability_data_field_block` (1.2, which provides the
+      7-low-rep(n=2)/8-high-rep(n=10) split this oracle needs).
+      Run `calculate_heritability_estimates(..., fixed_effects=["block"])`
+      then `extract_blup_table()`. **The raw-mean reference point must be
+      the block-detrended per-genotype mean, not the naive
+      `df.groupby(genotype)[trait].mean()` (round-4 review — empirically
+      verified this distinction is required, not stylistic): for each
+      observation, subtract the fitted `C(block)` coefficient for that row's
+      (non-reference) block level before averaging within genotype** — i.e.
+      `raw_mean_detrended[g] = mean(trait_ij - block_coef[block_ij])` where
+      `block_coef["block_1"] = 0` (the reference level) and
+      `block_coef["block_2"]` is the fitted non-reference coefficient. The
+      naive (non-detrended) raw mean is itself contaminated by each
+      genotype's own block composition — the exact thing the fixed effect
+      corrects for — so comparing it directly to the corrected BLUP is not a
+      clean shrinkage test: **verified empirically, the naive comparison
+      failed the per-genotype shrinkage assertion 50/50 times and the
+      group-mean-ratio assertion 6+/30 times on this fixture; the detrended
+      comparison failed 0/50 times on both.** **Revised during implementation
+      (a 5th, code-level catch none of the 4 review rounds surfaced, since
+      it only appears once task 2.6's marginal-intercept logic and this task
+      run together): do NOT center on the run's own returned `intercept`.**
+      Once 2.6 lands, `intercept` for a `fixed_effects` run is the *marginal*
+      (frequency-weighted) value, not the reference-level one. Because
+      `adjusted_mean = intercept + blup[g]`, `|adjusted_mean - intercept|`
+      always simplifies to `|blup[g]|` regardless of which intercept
+      convention is used (the two cancel) — but `raw_mean_detrended[g]` has
+      no such dependency on intercept convention at all, so centering it on
+      the *marginal* intercept (instead of the reference-level intercept
+      the detrending itself is naturally expressed relative to) introduces a
+      constant offset that does not cancel under the absolute-value
+      comparison, and empirically breaks the assertion for a subset of
+      genotypes. Use `blup[g]` directly (from
+      `calculate_heritability_estimates`'s returned dict, not
+      `extract_blup_table()`'s already-summed `adjusted_mean`) and the
+      **reference-level** `Intercept` from an independent re-fit (same
+      pattern as 2.2's fixture) as the shared center for both sides: assert
+      (a) every genotype's `abs(blup[g])` is smaller than
+      `|raw_mean_detrended[g] - reference_level_intercept|` (the stronger,
+      per-genotype property — Tier 1's own original assertion shape, now
+      confirmed to hold reliably once both detrended AND correctly
+      centered), and (b) this shrinkage gap is larger for low-replicate
+      genotypes than high-replicate genotypes — re-verifies Tier 1's
+      existing shrinkage guarantee still holds with `fixed_effects` set.
+
+## 4. Config + pipeline wiring (test-first)
+
+- [x] 4.1 Write failing test `test_statistics_config_fixed_effects_default_none`
+      (`tests/test_step_statistical_analysis.py`, mirroring Tier 1's
+      `test_generate_blup_table_default_true`): `StatisticsConfig().fixed_effects
+      is None`.
+- [x] 4.2 Add `fixed_effects: Optional[List[str]] = None` to `StatisticsConfig`
+      (`pipeline/config/components.py:532`), with a docstring `Attributes:`
+      entry describing the parameter and cross-referencing
+      `calculate_heritability_estimates`'s own docstring for the
+      categorical-treatment, metadata-only, and empirical
+      frequency-weighted-intercept conventions (canonical source stays
+      `calculate_heritability_estimates`'s docstring; this field's docstring
+      cross-references it rather than duplicating the prose). Make 4.1
+      green.
+- [x] 4.3 Write failing test `test_fixed_effects_threaded_into_heritability_call`
+      (mirror Tier 1's `test_blup_csv_written_when_both_enabled`): run
+      `StatisticalAnalysisStep.execute()` twice on the same fixture data
+      (which must include a metadata column suitable as a fixed effect, e.g.
+      an `"experiment"` column) — once with `statistics.fixed_effects=None`,
+      once with `statistics.fixed_effects=["experiment"]` — assert the two
+      runs' `08_heritability_results.csv` (and, if `generate_blup_table=True`,
+      `08_blup_adjusted_means.csv`) differ for the affected trait.
+- [x] 4.4 Write failing test `test_fixed_effects_qc_config_no_statistics_resolves_none`
+      (mirror Tier 1's `test_blup_table_works_with_qc_config_no_statistics`):
+      run `StatisticalAnalysisStep.execute()` with a bare `QCPipelineConfig`
+      (no `statistics` field); assert no `AttributeError` and behavior
+      identical to `fixed_effects=None`.
+- [x] 4.5 Implement threading in `StatisticalAnalysisStep.execute()`
+      (`pipeline/steps/statistical_analysis.py`): resolve `fixed_effects` via
+      the same `getattr(config, "statistics", None)` guard already used for
+      `calculate_heritability`/`generate_blup_table`
+      (`statistical_analysis.py:154-169`), defaulting to `None` when
+      `config.statistics` is absent; pass it into the existing
+      `calculate_heritability_estimates(...)` call
+      (`statistical_analysis.py:172-179`). Make 4.1, 4.3, 4.4 green.
+
+## 5. Docs
+
+- [x] 5.1 Update `docs/API.md`'s `## statistics Module` entry for
+      `calculate_heritability_estimates` to include `fixed_effects` in its
+      documented signature/defaults.
+- [x] 5.2 Add a `docs/CHANGELOG.md` `[Unreleased]` entry: `### Added` —
+      `calculate_heritability_estimates(fixed_effects=...)`,
+      `StatisticsConfig.fixed_effects`; `### Changed` — when `fixed_effects`
+      is used, the BLUP-adjusted-mean `intercept` becomes an empirical
+      frequency-weighted value instead of the raw model intercept, and a
+      captured convergence warning during fit is now treated as a trait-level
+      failure (no change when `fixed_effects` is unset). One-line rationale
+      on the **first** `### Added` bullet — round-3 review checked Tier 1's
+      actual entry and found the rationale sentence there sits on the first
+      `### Added` bullet (`extract_blup_table`), not the last; an earlier
+      draft of this task cited "last," backwards from the actual precedent:
+      Tier 2 of the cross-platform genotype-prediction program (#114).
+> Note: `result_types.py`'s `BLUPResult.intercepts` docstring update and the
+> `docs/result-types.md` caveat bullet are tracked as task 2.8, kept in
+> Section 2 for TDD locality with 2.6/2.7's intercept work — not duplicated
+> as a checkbox here.
+
+## 6. Validation
+
+- [x] 6.1 `openspec validate add-heritability-fixed-effects --strict` —
+      resolve every reported issue before requesting review.
+- [x] 6.2 `/lint` (black + ruff) on all changed files.
+- [x] 6.3 Full `uv run pytest --cov --cov-branch` — confirm no regressions in
+      `test_statistics.py`, `test_step_statistical_analysis.py`,
+      `test_heritability_result.py`, `test_blup_result.py`, and confirm the
+      new fixtures/tests pass, including the organic convergence-behavior
+      test (1.10) on at least the CI platforms it actually runs on.
+- [x] 6.4 `/review-openspec` — adversarial proposal review. Rounds 1–3 plus a
+      targeted round-4 empirical follow-up are complete and reconciled (see
+      `design.md`'s four "Adversarial Review Reconciliation" sections). This
+      task is not satisfied until the user has reviewed and approved the
+      reconciled proposal — required before implementation (Sections 1–5
+      above) begins, per the roadmap's per-tier loop.

--- a/openspec/changes/add-heritability-fixed-effects/tasks.md
+++ b/openspec/changes/add-heritability-fixed-effects/tasks.md
@@ -607,33 +607,69 @@
       (already implemented and tested, but missing from the normative spec
       text per the review's spec-sync finding) both now have `#### Scenario:`
       entries.
-- [ ] 7.3 **(Deferred — candidate follow-up issue, not fixed in this PR)**
+- [x] 7.3 **(Fixed in this PR, on user request rather than deferred)**
       `fixed_effects` columns are excluded from the low-`H2`-filtering trait
       scan for direct API callers (`remove_low_h2=True`), but
       `StatisticalAnalysisStep` always calls with `remove_low_h2=False`, so
-      the *pipeline's* upstream `trait_cols` (fixed once in `LoadDataStep`
-      via `get_trait_columns`) has no knowledge of
-      `config.statistics.fixed_effects` and only excludes names matching a
-      hardcoded substring list. A `fixed_effects` name outside that list
-      (e.g. `"block"`) is silently treated as a phenotypic trait everywhere
-      upstream of the statistics step. Needs a config-level design decision
-      (auto-derive `additional_exclude_cols` from `fixed_effects`? validate
-      they're disjoint? document the required manual sync?) — out of scope
-      for a same-PR fix; file as a follow-up issue referencing #114.
-- [ ] 7.4 **(Deferred — candidate follow-up issue)** No config-schema
-      validation for `StatisticsConfig.fixed_effects` (e.g. a bare string
-      instead of a list isn't caught, producing a misleading
-      character-by-character "Missing required columns" error). No golden
-      template documents `fixed_effects` even as a commented example.
-- [ ] 7.5 **(Deferred — candidate follow-up issue)** The `ConvergenceWarning`
-      heuristic's confirmed false-negative (a fixed effect
-      near-deterministically confounded with genotype can fit cleanly with
-      zero warnings) is currently only documented in the docstring. Consider
-      surfacing it as an actual `UserWarning` at call time when
-      `fixed_effects` is used, so it's visible without reading source.
-- [ ] 7.6 **(Deferred, minor)** Duplicate entries *within* `fixed_effects`
-      itself (e.g. `["experiment", "experiment"]`) aren't rejected upfront —
-      degrades to a `mixed_model_failed` error from patsy rather than a
-      clean message. No test for the single-level (zero-variance)
-      fixed-effect case (verified correct by hand-tracing, per pre-merge
-      review, but untested).
+      the *pipeline's* upstream `trait_cols` (fixed once in
+      `LoadDataAndImagesStep` via `get_trait_columns`) had no knowledge of
+      `config.statistics.fixed_effects` and only excluded names matching a
+      hardcoded substring list. Fixed via the auto-derive design (chosen
+      over validate-disjoint-and-require-manual-sync, which would only make
+      the trap loud instead of removing it): `VizPipelineConfig.__post_init__`
+      (`viz_config.py`) now unions `statistics.fixed_effects` into
+      `data.additional_exclude_cols` at config-construction time, deduped —
+      no step-ordering change needed. `QCPipelineConfig` has no `statistics`
+      field today, so this fix applies to `VizPipelineConfig`, the only
+      config class composing both `data` and `statistics`. Tests:
+      `test_viz_pipeline_config_auto_excludes_fixed_effects`,
+      `test_viz_pipeline_config_auto_exclude_dedups_overlapping_names`,
+      `test_viz_pipeline_config_no_fixed_effects_leaves_additional_exclude_unchanged`,
+      and an integration test,
+      `test_fixed_effect_column_excluded_from_pipeline_trait_cols`, proving
+      `LoadDataAndImagesStep` no longer treats a `"block"`-named fixed effect
+      as a trait.
+- [x] 7.4 **(Fixed in this PR)** Added `StatisticsConfig.__post_init__`
+      (`components.py`) rejecting `fixed_effects` that isn't `None` or a
+      `list[str]` — catches the bare-string case (a `str` is iterable, so it
+      would otherwise silently become a per-character `fixed_effects` list
+      producing a misleading "Missing required columns" error). The
+      nonexistent-column half of this task needed no new code:
+      `calculate_heritability_estimates`'s existing missing-column check
+      already covers it at runtime, since column names can't be validated
+      until data loads. Added a commented `fixed_effects` example to both
+      viz golden templates (`viz_template_with_images.yaml`,
+      `viz_template_no_images.yaml`) and a note in `docs/API.md`. Tests:
+      `test_statistics_config_fixed_effects_rejects_non_list`,
+      `test_statistics_config_fixed_effects_rejects_non_str_elements`.
+- [x] 7.5 **(Fixed in this PR)** The `ConvergenceWarning` heuristic's
+      confirmed false-negative is now also surfaced as a `UserWarning` at
+      call time (`statistics.py`, in the mixed-model success path, gated on
+      `fixed_effects` being set — same gating convention as the
+      `ConvergenceWarning`-capture block above it): after a successful fit
+      with zero `ConvergenceWarning`s, for each fixed effect, if any
+      genotype's observations are confined to a single level of a fixed
+      effect that has more than one level overall, a `UserWarning`
+      describing the possible confound is emitted. Purely diagnostic — does
+      not change `model_type`/`blup`/`intercept` (unlike the
+      `ConvergenceWarning`-as-failure path, a different, already-correct
+      mechanism). Confirmed to fire correctly (not a false positive) on the
+      existing `heritability_data_field_block` fixture (1.2): 7 of its
+      15 genotypes have only n=2 reps at an 80/20 block skew, which rounds
+      to 0 reps in one block for several of them — a real, previously-silent
+      confound this heuristic now surfaces. Tests:
+      `test_confounded_fixed_effect_emits_user_warning`,
+      `test_unconfounded_fixed_effect_emits_no_user_warning`
+      (`TestConfoundWarning` in `test_statistics.py`).
+- [x] 7.6 **(Fixed in this PR)** Duplicate entries *within* `fixed_effects`
+      itself are now rejected upfront with a structural
+      `{"error": "Duplicate fixed_effects column name(s): [...]"}`, matching
+      the existing missing-column/reused-name error shape, instead of
+      degrading to an obscure `mixed_model_failed` error from patsy. Added
+      the single-level (zero-variance) fixed-effect regression test —
+      confirmed green with no implementation change needed (verified
+      correct by hand-tracing in pre-merge review: `_marginal_intercept`'s
+      "exactly one unmatched level" identity check holds even when
+      `fixed_effects` has zero non-reference coefficients). Tests:
+      `test_duplicate_fixed_effects_names_rejected`,
+      `test_single_level_fixed_effect_succeeds`.

--- a/src/sleap_roots_analyze/pipeline/config/components.py
+++ b/src/sleap_roots_analyze/pipeline/config/components.py
@@ -550,7 +550,14 @@ class StatisticsConfig:
             see that function's docstring for the categorical-treatment
             (every name is `C(...)`-wrapped), metadata-only (not biological
             traits), and empirical frequency-weighted-intercept conventions.
-            Defaults to `None` (the pre-existing genotype-only model).
+            Defaults to `None` (the pre-existing genotype-only model). Must
+            be `None` or a list of `str`; a bare string is rejected at
+            construction time rather than silently iterated
+            character-by-character (PR #193 review). Names listed here are
+            also automatically unioned into
+            `VizPipelineConfig.data.additional_exclude_cols`, so they are
+            never mistaken for phenotypic traits upstream of the statistics
+            step (issue #114).
     """
 
     calculate_anova: bool = True
@@ -558,6 +565,17 @@ class StatisticsConfig:
     alpha: float = 0.05
     generate_blup_table: bool = True
     fixed_effects: Optional[List[str]] = None
+
+    def __post_init__(self):
+        """Validate fixed_effects is None or a list of str (issue #114)."""
+        if self.fixed_effects is not None and (
+            not isinstance(self.fixed_effects, list)
+            or not all(isinstance(fe, str) for fe in self.fixed_effects)
+        ):
+            raise ValueError(
+                f"fixed_effects must be None or a list of str, got "
+                f"{self.fixed_effects!r}"
+            )
 
 
 @dataclass

--- a/src/sleap_roots_analyze/pipeline/config/components.py
+++ b/src/sleap_roots_analyze/pipeline/config/components.py
@@ -544,12 +544,20 @@ class StatisticsConfig:
             `calculate_heritability` is False is inert — no exception, no
             warning, just no BLUP output, since there is no model fit to
             extract from.
+        fixed_effects: Optional list of column names to add as fixed effects
+            to the heritability mixed model, passed through to
+            `calculate_heritability_estimates(fixed_effects=...)` (#114) —
+            see that function's docstring for the categorical-treatment
+            (every name is `C(...)`-wrapped), metadata-only (not biological
+            traits), and empirical frequency-weighted-intercept conventions.
+            Defaults to `None` (the pre-existing genotype-only model).
     """
 
     calculate_anova: bool = True
     calculate_heritability: bool = True
     alpha: float = 0.05
     generate_blup_table: bool = True
+    fixed_effects: Optional[List[str]] = None
 
 
 @dataclass

--- a/src/sleap_roots_analyze/pipeline/config/components.py
+++ b/src/sleap_roots_analyze/pipeline/config/components.py
@@ -566,7 +566,7 @@ class StatisticsConfig:
     generate_blup_table: bool = True
     fixed_effects: Optional[List[str]] = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Validate fixed_effects is None or a list of str (issue #114)."""
         if self.fixed_effects is not None and (
             not isinstance(self.fixed_effects, list)

--- a/src/sleap_roots_analyze/pipeline/config/viz_config.py
+++ b/src/sleap_roots_analyze/pipeline/config/viz_config.py
@@ -77,3 +77,26 @@ class VizPipelineConfig:
     dashboard: DashboardConfig = field(default_factory=DashboardConfig)
     summary: SummaryConfig = field(default_factory=SummaryConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
+
+    def __post_init__(self):
+        """Auto-exclude fixed_effects columns from the trait_cols scan (#114, 7.3).
+
+        `LoadDataAndImagesStep` fixes `trait_cols` once, at the very start of
+        the pipeline, using only `data.additional_exclude_cols` plus a
+        hardcoded metadata-substring list -- it has no knowledge of
+        `statistics.fixed_effects` on its own. A fixed_effects name outside
+        that hardcoded list (e.g. "block") would otherwise be silently
+        treated as a phenotypic trait everywhere upstream of the statistics
+        step. Unioning it into `additional_exclude_cols` here, at
+        config-construction time, closes that gap without any step-ordering
+        change. Deduplicates against names already present (e.g. a
+        fixed_effects name that also happens to match the hardcoded
+        substring list, or that a user already listed explicitly).
+        """
+        if self.statistics.fixed_effects:
+            self.data.additional_exclude_cols = list(
+                dict.fromkeys(
+                    (self.data.additional_exclude_cols or [])
+                    + self.statistics.fixed_effects
+                )
+            )

--- a/src/sleap_roots_analyze/pipeline/config/viz_config.py
+++ b/src/sleap_roots_analyze/pipeline/config/viz_config.py
@@ -78,7 +78,7 @@ class VizPipelineConfig:
     summary: SummaryConfig = field(default_factory=SummaryConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Auto-exclude fixed_effects columns from the trait_cols scan (#114, 7.3).
 
         `LoadDataAndImagesStep` fixes `trait_cols` once, at the very start of

--- a/src/sleap_roots_analyze/pipeline/steps/statistical_analysis.py
+++ b/src/sleap_roots_analyze/pipeline/steps/statistical_analysis.py
@@ -167,6 +167,12 @@ class StatisticalAnalysisStep(BaseStep):
             if statistics_config is not None
             else True
         )
+        # fixed_effects (#114) resolved with the same getattr fallback,
+        # defaulting to None (genotype-only model) when config.statistics is
+        # absent (the QC-pipeline case).
+        fixed_effects = (
+            statistics_config.fixed_effects if statistics_config is not None else None
+        )
 
         if calculate_heritability:
             heritability_results = calculate_heritability_estimates(
@@ -176,6 +182,7 @@ class StatisticalAnalysisStep(BaseStep):
                 replicate_col=replicate_col,
                 force_method=None,  # Use default mixed model approach
                 remove_low_h2=False,  # Don't remove yet, that's Step 9
+                fixed_effects=fixed_effects,
             )
 
             # Convert heritability results to DataFrame for saving

--- a/src/sleap_roots_analyze/result_types.py
+++ b/src/sleap_roots_analyze/result_types.py
@@ -830,7 +830,15 @@ class BLUPResult:
         failed_traits: Names of traits excluded from ``trait_names`` — no
             model fit, or at least one cell-level gap. Names only, no values.
         intercepts: Fixed-effect intercept per succeeded trait in
-            ``trait_names``; empty if not supplied to the adapter.
+            ``trait_names``; empty if not supplied to the adapter. When the
+            source ``calculate_heritability_estimates`` call used a
+            non-empty ``fixed_effects`` (#114), a value here is the
+            empirical, sample frequency-weighted intercept described in
+            that function's docstring — a sample-composition-dependent
+            quantity that can differ trait-to-trait, not a population-typical
+            or EMM/lsmeans-style equally-weighted value. ``BLUPResult`` and
+            its adapter are unaware of ``fixed_effects`` and store whatever
+            ``intercept`` float each trait's source dict carries, unchanged.
     """
 
     genotype_names: list[str]

--- a/src/sleap_roots_analyze/statistics.py
+++ b/src/sleap_roots_analyze/statistics.py
@@ -467,6 +467,21 @@ def calculate_heritability_estimates(
             )
         }
 
+    # A name repeated within fixed_effects itself (e.g. ["experiment",
+    # "experiment"]) produces a duplicate C(...) term in the formula below,
+    # which degrades to an obscure patsy failure deep inside the per-trait
+    # try/except rather than a clear structural error (PR #193 review).
+    seen_fe_names = set()
+    duplicate_fe_names = []
+    for fe in fixed_effects:
+        if fe in seen_fe_names and fe not in duplicate_fe_names:
+            duplicate_fe_names.append(fe)
+        seen_fe_names.add(fe)
+    if duplicate_fe_names:
+        return {
+            "error": f"Duplicate fixed_effects column name(s): {duplicate_fe_names}"
+        }
+
     for trait in trait_cols:
         if trait not in df.columns:
             heritability_results[trait] = {"error": f"Trait column '{trait}' not found"}
@@ -602,6 +617,43 @@ def calculate_heritability_estimates(
                         intercept = _marginal_intercept(
                             result, model_data, fixed_effects
                         )
+                        # statsmodels' own convergence-warning check (above)
+                        # is a confirmed false-negative for a fixed effect
+                        # near-deterministically confounded with genotype --
+                        # a fit can succeed cleanly with zero warnings (PR
+                        # #193 review, 7.5). Surface an independent, cheap
+                        # diagnostic instead of leaving that case silent: if
+                        # every observation for a genotype sits in a single
+                        # level of a fixed effect that has more than one
+                        # level overall, that genotype contributes no
+                        # within-genotype information for separating the two
+                        # effects, inflating apparent heritability.
+                        for fe in fixed_effects:
+                            if model_data[fe].nunique() < 2:
+                                continue
+                            levels_per_genotype = model_data.groupby("genotype")[
+                                fe
+                            ].nunique()
+                            confounded_genotypes = levels_per_genotype[
+                                levels_per_genotype < 2
+                            ].index.tolist()
+                            if confounded_genotypes:
+                                shown = confounded_genotypes[:5]
+                                more = (
+                                    f" (+{len(confounded_genotypes) - 5} more)"
+                                    if len(confounded_genotypes) > 5
+                                    else ""
+                                )
+                                warnings.warn(
+                                    f"Trait '{trait}': fixed effect '{fe}' "
+                                    f"may be confounded with genotype -- "
+                                    f"{len(confounded_genotypes)} genotype(s) "
+                                    f"appear in only one level of '{fe}': "
+                                    f"{shown}{more}. Heritability may be "
+                                    f"inflated by attributing '{fe}' "
+                                    f"variation to genotype.",
+                                    UserWarning,
+                                )
                     else:
                         intercept = float(result.fe_params["Intercept"])
 

--- a/src/sleap_roots_analyze/statistics.py
+++ b/src/sleap_roots_analyze/statistics.py
@@ -441,8 +441,14 @@ def calculate_heritability_estimates(
     # Every fixed_effects name is interpolated directly into the formula
     # string below (issue #114); a name that isn't a valid identifier (e.g.
     # containing a patsy operator like `*` or `:`) could otherwise silently
-    # misparse as an expression over other, differently-named columns.
-    invalid_fe_names = [fe for fe in fixed_effects if not fe.isidentifier()]
+    # misparse as an expression over other, differently-named columns. A
+    # non-str element (e.g. an int-labeled CSV column) has no
+    # .isidentifier() at all -- checked first so this returns the same
+    # structural error instead of an uncaught AttributeError (PR #193
+    # review).
+    invalid_fe_names = [
+        fe for fe in fixed_effects if not isinstance(fe, str) or not fe.isidentifier()
+    ]
     if invalid_fe_names:
         return {"error": f"Invalid fixed_effects column name(s): {invalid_fe_names}"}
 

--- a/src/sleap_roots_analyze/statistics.py
+++ b/src/sleap_roots_analyze/statistics.py
@@ -14,6 +14,7 @@ module when analyzing one experiment's replicated measurements; use
 
 from __future__ import annotations
 
+import re
 import numpy as np
 import pandas as pd
 import warnings
@@ -21,6 +22,7 @@ import statsmodels.api as sm
 import statsmodels.formula.api as smf
 
 from statsmodels.regression.mixed_linear_model import MixedLM
+from statsmodels.tools.sm_exceptions import ConvergenceWarning
 from scipy import stats
 from scipy.stats import f_oneway
 from typing import Any, Dict, List, Tuple, Optional, Union
@@ -192,6 +194,97 @@ def perform_anova_by_genotype(
     return anova_results
 
 
+def _marginal_intercept(
+    result: Any, model_data: pd.DataFrame, fixed_effects: List[str]
+) -> float:
+    """Empirical, sample frequency-weighted intercept for a fixed-effects fit (#114).
+
+    ``result.fe_params["Intercept"]`` alone represents the fitted value when
+    every fixed effect is at patsy's reference level -- a naming artifact
+    (the first level in sorted order, or the first declared category for a
+    ``pandas.Categorical``), not a scientifically meaningful baseline. This
+    computes an empirical frequency-weighted average across each fixed
+    effect's *observed* levels instead: for each fixed effect, each level's
+    fitted contribution (0.0 for the reference level; its own coefficient in
+    ``result.fe_params`` for every other level) is weighted by that level's
+    share of ``model_data`` rows, summed across levels within that fixed
+    effect, then summed across all fixed effects and added to the base
+    ``Intercept`` coefficient.
+
+    This is a sample-margin quantity, not a population-typical or
+    EMM/lsmeans-style equally-weighted marginal mean: it depends on each
+    trait's own observed level frequencies (post-``dropna()``), so two
+    traits sharing the same ``fixed_effects`` columns may get different
+    values.
+
+    Per-level coefficients are recovered by parsing ``result.fe_params``'s
+    actual fitted parameter names, not by reconstructing the expected key
+    string forward from each observed level's raw value -- the latter risks
+    silently misattributing a real level to the reference level's implicit
+    ``0.0`` on a dtype/formatting mismatch (e.g. a ``float64`` column).
+
+    Args:
+        result: The fitted ``MixedLMResults`` object.
+        model_data: The DataFrame the model was fit on (post-``dropna()``),
+            containing one column per name in ``fixed_effects``.
+        fixed_effects: Names of the fixed-effect columns in the fitted
+            formula.
+
+    Returns:
+        float: The empirical frequency-weighted intercept.
+
+    Raises:
+        ValueError: If a fixed effect's recovered coefficients don't form an
+            exact identity with its observed levels -- either a coefficient
+            doesn't match any observed level string (a dtype/formatting
+            mismatch), or more than one observed level lacks a coefficient
+            (more than one apparent "reference" level). Either case indicates
+            a level failed to match back to its coefficient, which must not
+            be silently defaulted to 0.0.
+    """
+    intercept = float(result.fe_params["Intercept"])
+    for fe in fixed_effects:
+        pattern = re.compile(rf"^C\({re.escape(fe)}\)\[T\.(.*)\]$")
+        level_coefficients = {}
+        for key in result.fe_params.index:
+            match = pattern.match(key)
+            if match:
+                level_coefficients[match.group(1)] = float(result.fe_params[key])
+
+        level_frequencies = model_data[fe].value_counts(normalize=True)
+        observed_level_strs = {str(v) for v in level_frequencies.index}
+        coefficient_keys = set(level_coefficients.keys())
+
+        # An identity check, not just a count check: every recovered
+        # coefficient must correspond to an actually-observed level (a
+        # coefficient key that doesn't match any observed level string would
+        # indicate a dtype/formatting mismatch, not a real reference level),
+        # and exactly one observed level must lack a coefficient (the true
+        # reference level patsy dropped). A count-only check (matching
+        # len(level_coefficients) to n_levels - 1) can pass even when a real
+        # level's string silently failed to match its own coefficient while
+        # an unrelated mismatch happened to keep the count the same.
+        if not coefficient_keys.issubset(observed_level_strs):
+            raise ValueError(
+                f"Fixed effect '{fe}' has fitted coefficient(s) for level(s) "
+                f"not found in the fitted data: "
+                f"{coefficient_keys - observed_level_strs}"
+            )
+        unmatched_levels = observed_level_strs - coefficient_keys
+        if len(unmatched_levels) != 1:
+            raise ValueError(
+                f"Expected exactly one reference level (no fitted "
+                f"coefficient) for fixed effect '{fe}', found "
+                f"{len(unmatched_levels)}: {unmatched_levels}"
+            )
+
+        for level_value, frequency in level_frequencies.items():
+            coefficient = level_coefficients.get(str(level_value), 0.0)
+            intercept += float(frequency) * coefficient
+
+    return intercept
+
+
 def calculate_heritability_estimates(
     df: pd.DataFrame,
     trait_cols: List[str],
@@ -202,6 +295,7 @@ def calculate_heritability_estimates(
     h2_threshold: float = 0.3,
     barcode_col: str = "Barcode",
     additional_exclude: Optional[List[str]] = None,
+    fixed_effects: Optional[List[str]] = None,
 ) -> Union[Dict, Tuple[Dict, pd.DataFrame, List[str], Dict]]:
     """Calculate broad-sense heritability estimates for traits using mixed model approach.
 
@@ -235,6 +329,41 @@ def calculate_heritability_estimates(
         h2_threshold: Heritability threshold for filtering (default: 0.3, only used if remove_low_h2=True)
         barcode_col: Name of barcode column (default: "Barcode", only used if remove_low_h2=True)
         additional_exclude: Additional columns to exclude from traits (only used if remove_low_h2=True)
+        fixed_effects: Optional list of column names to add as fixed effects to
+            the mixed model, changing the formula from ``value ~ 1`` to
+            ``value ~ C(fe_1) + C(fe_2) + ...``. Every name is wrapped in
+            ``C(...)`` unconditionally — always treated as categorical,
+            regardless of pandas dtype, since fixed effects in this context
+            are metadata-style confounders (experiment, wave, batch, scanner),
+            not biological/phenotypic traits and not continuous covariates.
+            Each name must be a valid Python identifier (validated with
+            ``str.isidentifier()``); a name containing a patsy formula
+            operator (``*``, ``:``, etc.) produces a structural error instead
+            of being interpolated into the formula string, since that could
+            otherwise silently misparse as an expression over other columns.
+            Missing columns produce the same structural error as a missing
+            ``genotype_col``. When set, the per-trait model subset additionally
+            drops rows with a ``NaN`` in any fixed-effect column — this only
+            changes behavior when ``fixed_effects`` is non-empty; ``None``
+            (the default) reproduces this function's pre-existing behavior
+            exactly, including the ANOVA-based path, which never uses
+            ``fixed_effects`` in its own variance-component computation
+            (only the row-filtering subset change applies to it). Also only
+            when non-empty: a captured ``ConvergenceWarning`` during the fit
+            (checked by category, not message text) is treated as a fit
+            failure for that trait, since ``statsmodels`` does not always
+            *raise* on a fixed effect confounded with genotype. This is a
+            best-effort signal, not a guarantee: a fixed effect that is
+            confounded with genotype but not enough to trigger a numerical
+            convergence problem can converge cleanly with no warning at all,
+            silently producing a non-identifiable variance-component split
+            between the genotype random effect and the fixed effect. No
+            upfront identifiability/collinearity pre-validation is performed
+            — a fixed effect chosen as a metadata covariate should still be
+            reviewed for how it's distributed across genotypes.
+            ``fixed_effects`` is independent of ``replicate_col`` — a
+            block/replicate fixed effect is expressed by naming that column
+            here directly.
 
     Returns:
         If remove_low_h2=False:
@@ -252,10 +381,17 @@ def calculate_heritability_estimates(
               ``model_type == "mixed_model"`` — the ANOVA-based and
               no-variance paths never fit a mixedlm model, so they carry no
               ``blup``/``intercept`` keys.
-            - intercept: The fixed-effect intercept
-              (``result.fe_params["Intercept"]``) from the same fit. The
-              genotype-adjusted mean is ``intercept + blup[genotype]``.
-              Present under the same condition as ``blup``.
+            - intercept: The fixed-effect intercept from the same fit. When
+              ``fixed_effects`` is empty/``None``, this is exactly
+              ``result.fe_params["Intercept"]``. When ``fixed_effects`` is
+              non-empty, this is instead the empirical, sample
+              frequency-weighted intercept computed by
+              :func:`_marginal_intercept` — a sample-composition-dependent
+              value that can differ trait-to-trait (each trait computes its
+              own ``dropna()`` subset), not a population-typical or
+              EMM/lsmeans-style equally-weighted value. The genotype-adjusted
+              mean is ``intercept + blup[genotype]`` either way. Present
+              under the same condition as ``blup``.
 
         If remove_low_h2=True:
             Tuple of:
@@ -263,6 +399,15 @@ def calculate_heritability_estimates(
             - DataFrame with low heritability traits removed
             - List of removed trait names
             - Dictionary with removal details
+
+    Raises:
+        Nothing propagates to the caller. When ``fixed_effects`` is
+        non-empty, a captured ``ConvergenceWarning`` is converted to an
+        internal ``RuntimeError`` to route it through the same handling as a
+        raised model-fit exception — both are caught by this function's own
+        per-trait ``try/except`` and recorded as that trait's
+        ``{"error": ..., "model_type": "mixed_model_failed"}`` entry, never
+        raised to the caller.
     """
     heritability_results = {}
 
@@ -284,12 +429,37 @@ def calculate_heritability_estimates(
     # replicate_col is optional and its values are never used in the model
     # (value ~ 1 + (1|genotype)). Only require the column when a (truthy) name was
     # provided; treat None or "" identically as "no replicate column" (issue #142).
+    fixed_effects = fixed_effects or []
     required_cols = [genotype_col]
     if replicate_col:
         required_cols.append(replicate_col)
+    required_cols.extend(fixed_effects)
     missing_cols = [col for col in required_cols if col not in df.columns]
     if missing_cols:
         return {"error": f"Missing required columns: {missing_cols}"}
+
+    # Every fixed_effects name is interpolated directly into the formula
+    # string below (issue #114); a name that isn't a valid identifier (e.g.
+    # containing a patsy operator like `*` or `:`) could otherwise silently
+    # misparse as an expression over other, differently-named columns.
+    invalid_fe_names = [fe for fe in fixed_effects if not fe.isidentifier()]
+    if invalid_fe_names:
+        return {"error": f"Invalid fixed_effects column name(s): {invalid_fe_names}"}
+
+    # Naming genotype_col or replicate_col as a fixed effect too produces a
+    # duplicate-column selection and a confusing pandas-internal error deep
+    # inside the per-trait loop (e.g. "Grouper for 'geno' not 1-dimensional")
+    # rather than a clear structural error -- reject it upfront instead.
+    reused_names = [
+        fe for fe in fixed_effects if fe == genotype_col or fe == replicate_col
+    ]
+    if reused_names:
+        return {
+            "error": (
+                f"fixed_effects column(s) {reused_names} duplicate "
+                f"genotype_col/replicate_col; name a different column"
+            )
+        }
 
     for trait in trait_cols:
         if trait not in df.columns:
@@ -299,7 +469,11 @@ def calculate_heritability_estimates(
         # Subset to the only columns the model uses. Replicate is deliberately
         # excluded: its values are never used, so including it (and any NaNs in it)
         # must not drop rows or change H² relative to replicate=None (issue #142).
-        subset = df[[trait, genotype_col]].dropna()
+        # fixed_effects columns ARE included (issue #114): a NaN in a named
+        # fixed-effect column drops that row, applied identically regardless
+        # of force_method (the ANOVA-based path below never uses
+        # fixed_effects in its own formula, only in this shared row filter).
+        subset = df[[trait, genotype_col] + fixed_effects].dropna()
 
         if len(subset) < 4:  # Need minimum data for variance estimation
             heritability_results[trait] = {
@@ -355,17 +529,48 @@ def calculate_heritability_estimates(
 
             if use_mixed_model:
                 # Use mixed model approach (matches R lme4)
-                # Create a clean dataframe for the model
-                model_data = subset.copy()
-                model_data.columns = ["value", "genotype"]
+                # Rename to canonical value/genotype columns; fixed_effects
+                # columns keep their original names since the formula below
+                # references them by name (issue #114).
+                model_data = subset.rename(
+                    columns={trait: "value", genotype_col: "genotype"}
+                )
 
-                # Fit mixed model: value ~ 1 + (1|genotype)
+                # Fit mixed model: value ~ 1 + (1|genotype), or
+                # value ~ C(fe_1) + ... + (1|genotype) when fixed_effects is
+                # set (issue #114). Every fixed effect is wrapped in C(...)
+                # unconditionally -- always treated as categorical.
                 # This matches the R code: lmer(value ~ (1 | ecot_id), data = data_H)
+                if fixed_effects:
+                    formula = "value ~ " + " + ".join(
+                        f"C({fe})" for fe in fixed_effects
+                    )
+                else:
+                    formula = "value ~ 1"
                 try:
                     model = smf.mixedlm(
-                        "value ~ 1", model_data, groups=model_data["genotype"]
+                        formula, model_data, groups=model_data["genotype"]
                     )
-                    result = model.fit(reml=True)  # Use REML like lme4 default
+                    # statsmodels does not reliably *raise* on a fixed effect
+                    # confounded with genotype -- it can instead emit a
+                    # ConvergenceWarning and still return a plausible-looking
+                    # result. Only when fixed_effects is set, capture
+                    # warnings (forcing "always" so a repeat identical
+                    # warning for a later trait isn't silently dropped by
+                    # Python's default once-per-location filter) and treat a
+                    # ConvergenceWarning as a fit failure via the same
+                    # except block below -- gated on fixed_effects so
+                    # fixed_effects=None callers see byte-for-byte identical
+                    # behavior to before this parameter existed (issue #114).
+                    if fixed_effects:
+                        with warnings.catch_warnings(record=True) as caught:
+                            warnings.simplefilter("always")
+                            result = model.fit(reml=True)
+                        for w in caught:
+                            if issubclass(w.category, ConvergenceWarning):
+                                raise RuntimeError(f"Convergence warning: {w.message}")
+                    else:
+                        result = model.fit(reml=True)  # Use REML like lme4 default
 
                     # Extract variance components
                     var_genetic = float(
@@ -387,7 +592,12 @@ def calculate_heritability_estimates(
                         str(geno): float(effect.iloc[0])
                         for geno, effect in result.random_effects.items()
                     }
-                    intercept = float(result.fe_params["Intercept"])
+                    if fixed_effects:
+                        intercept = _marginal_intercept(
+                            result, model_data, fixed_effects
+                        )
+                    else:
+                        intercept = float(result.fe_params["Intercept"])
 
                 except Exception as e:
                     # If mixed model fails for this trait, record the error but keep going
@@ -465,6 +675,17 @@ def calculate_heritability_estimates(
 
     # Optionally filter low heritability traits
     if remove_low_h2:
+        # fixed_effects columns are metadata covariates, not candidate traits
+        # (issue #114) -- without excluding them here, get_trait_columns()
+        # (called internally by remove_low_heritability_traits) has no way to
+        # know they aren't traits, since it was never told they were fit as
+        # fixed effects rather than trait_cols. Left unexcluded, a
+        # fixed_effects column with no entry in heritability_results (it was
+        # never fit as a trait) gets silently removed from df_filtered with
+        # reason "No heritability estimate available".
+        combined_exclude = list(
+            dict.fromkeys((additional_exclude or []) + fixed_effects)
+        )
         df_filtered, removed_traits, removal_details = remove_low_heritability_traits(
             df=df,
             heritability_results=heritability_results,
@@ -472,7 +693,7 @@ def calculate_heritability_estimates(
             barcode_col=barcode_col,
             genotype_col=genotype_col,
             replicate_col=replicate_col,
-            additional_exclude=additional_exclude,
+            additional_exclude=combined_exclude or None,
         )
         return heritability_results, df_filtered, removed_traits, removal_details
 

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -351,6 +351,171 @@ def heritability_data_unbalanced_reps():
     return df, meta
 
 
+@pytest.fixture
+def heritability_data_batch_confounded():
+    """Generate batch-confounded data for the fixed_effects H2 oracle.
+
+    Mirrors issue #114's Bloom-experiment scenario: 20 genotypes, n=10
+    reps each, evenly split into two groups whose reps are mostly (but not
+    entirely) in one of two synthetic batches — genuinely partial
+    per-genotype mixing, not full determinism. Combined with a large
+    per-batch shift, the resulting between-genotype variance from the
+    confound exceeds the within-genotype variance from the partial mixing,
+    so uncorrected H2 (fixed_effects=None) comes out above corrected H2
+    (fixed_effects=["experiment"]).
+
+    Verified empirically (this exact construction, legacy np.random.seed
+    API): seed=42 gives H2_uncorrected~=0.9405, H2_corrected~=0.7194,
+    gap~=0.2211. Across 10 tested seeds (1,2,3,7,13,21,42,99,123,777) the
+    minimum gap is 0.2138 -- comfortably above the 0.05 threshold tests
+    assert. Do not change sigma_g/shift/rep counts without re-verifying;
+    an earlier draft (sigma_g=3.0, shift=8.0, n=4 reps, a 16/4-genotype
+    3:1/1:3 partial mix) was confirmed by simulation to produce the
+    opposite sign, because with too few reps any genuinely partial mix
+    injects more within-genotype variance than between-genotype variance,
+    regardless of shift magnitude.
+
+    Returns:
+        tuple: (pd.DataFrame, dict) where the dict is
+            {"trait": "trait_batch_confounded", "batch_col": "experiment"}.
+    """
+    np.random.seed(42)
+
+    mostly_a = [f"G{g:02d}" for g in range(1, 11)]
+    mostly_b = [f"G{g:02d}" for g in range(11, 21)]
+    n_reps = 10
+
+    data = []
+    barcode = 0
+    for geno in mostly_a:
+        genotype_effect = np.random.normal(0, 0.4)
+        batches = ["Bloom_A"] * 9 + ["Bloom_B"] * 1
+        for r, batch in enumerate(batches):
+            shift = 10.0 if batch == "Bloom_B" else 0.0
+            value = 50 + genotype_effect + shift + np.random.normal(0, 1.0)
+            data.append(
+                {
+                    "geno": geno,
+                    "rep": r + 1,
+                    "Barcode": f"BC{barcode:04d}",
+                    "trait_batch_confounded": value,
+                    "experiment": batch,
+                }
+            )
+            barcode += 1
+    for geno in mostly_b:
+        genotype_effect = np.random.normal(0, 0.4)
+        batches = ["Bloom_A"] * 1 + ["Bloom_B"] * 9
+        for r, batch in enumerate(batches):
+            shift = 10.0 if batch == "Bloom_B" else 0.0
+            value = 50 + genotype_effect + shift + np.random.normal(0, 1.0)
+            data.append(
+                {
+                    "geno": geno,
+                    "rep": r + 1,
+                    "Barcode": f"BC{barcode:04d}",
+                    "trait_batch_confounded": value,
+                    "experiment": batch,
+                }
+            )
+            barcode += 1
+
+    df = pd.DataFrame(data)
+    meta = {"trait": "trait_batch_confounded", "batch_col": "experiment"}
+    return df, meta
+
+
+@pytest.fixture
+def heritability_data_field_block():
+    """Generate field-block data for the fixed_effects BLUP/shrinkage oracles.
+
+    15 genotypes split into two replicate-count groups: 7 "low-rep"
+    genotypes (G01-G07) with n=2 reps each, 8 "high-rep" genotypes
+    (G08-G15) with n=10 reps each. A per-"block" shift is added, with
+    block-composition skew applied as the same ~71% block_1-heavy ratio
+    within *both* replicate-count groups -- orthogonal to which
+    replicate-count group a genotype is in. This orthogonality is
+    required: an earlier draft skewed block assignment by genotype ID in
+    a way that correlated with the replicate-count grouping, and was
+    confirmed by simulation to produce an unreliable shrinkage oracle
+    (~40% failure rate on the naive comparison, even though the simpler
+    BLUP-difference oracle was unaffected).
+
+    Verified empirically (this exact construction, legacy np.random.seed
+    API, 10 tested seeds): the BLUP-adjusted-means oracle (fixed_effects
+    vs. none) never failed to show a difference, and the
+    shrinkage-scales-with-replication oracle never failed *when compared
+    against a block-detrended raw mean* (subtracting the fitted C(block)
+    coefficient per observation before averaging within genotype) --
+    comparing against the naive, non-detrended raw mean is NOT a valid
+    shrinkage test here, since that naive mean is itself contaminated by
+    each genotype's own block composition, the exact thing the fixed
+    effect corrects for.
+
+    Returns:
+        tuple: (pd.DataFrame, dict) where the dict is
+            {"trait": "trait_field_block", "low_rep_genotypes": [...],
+            "high_rep_genotypes": [...]}.
+    """
+    np.random.seed(42)
+
+    low_rep_genotypes = [f"G{g:02d}" for g in range(1, 8)]
+    high_rep_genotypes = [f"G{g:02d}" for g in range(8, 16)]
+    low_block1_heavy = {"G01", "G02", "G03", "G04", "G05"}
+    high_block1_heavy = {"G08", "G09", "G10", "G11", "G12", "G13"}
+
+    data = []
+    barcode = 0
+    for geno in low_rep_genotypes:
+        n_reps = 2
+        block1_frac = 0.8 if geno in low_block1_heavy else 0.2
+        genotype_effect = np.random.normal(0, 2.0)
+        n_b1 = round(block1_frac * n_reps)
+        n_b2 = n_reps - n_b1
+        blocks = ["block_1"] * n_b1 + ["block_2"] * n_b2
+        for r, block in enumerate(blocks):
+            shift = 5.0 if block == "block_2" else 0.0
+            value = 50 + genotype_effect + shift + np.random.normal(0, 1.0)
+            data.append(
+                {
+                    "geno": geno,
+                    "rep": r + 1,
+                    "Barcode": f"BC{barcode:04d}",
+                    "trait_field_block": value,
+                    "block": block,
+                }
+            )
+            barcode += 1
+    for geno in high_rep_genotypes:
+        n_reps = 10
+        block1_frac = 0.8 if geno in high_block1_heavy else 0.2
+        genotype_effect = np.random.normal(0, 2.0)
+        n_b1 = round(block1_frac * n_reps)
+        n_b2 = n_reps - n_b1
+        blocks = ["block_1"] * n_b1 + ["block_2"] * n_b2
+        for r, block in enumerate(blocks):
+            shift = 5.0 if block == "block_2" else 0.0
+            value = 50 + genotype_effect + shift + np.random.normal(0, 1.0)
+            data.append(
+                {
+                    "geno": geno,
+                    "rep": r + 1,
+                    "Barcode": f"BC{barcode:04d}",
+                    "trait_field_block": value,
+                    "block": block,
+                }
+            )
+            barcode += 1
+
+    df = pd.DataFrame(data)
+    meta = {
+        "trait": "trait_field_block",
+        "low_rep_genotypes": low_rep_genotypes,
+        "high_rep_genotypes": high_rep_genotypes,
+    }
+    return df, meta
+
+
 # ============================================================================
 # HERITABILITY DIAGNOSTIC FIXTURES - Data for testing diagnostic functions
 # ============================================================================

--- a/tests/test_blup_result.py
+++ b/tests/test_blup_result.py
@@ -19,6 +19,7 @@ import pandas as pd
 import pytest
 
 from sleap_roots_analyze.result_types import BLUPResult
+from sleap_roots_analyze.statistics import extract_blup_table
 
 
 def _blup_df():
@@ -190,6 +191,31 @@ class TestBLUPResultAdapter:
         BLUPResult.from_blup_table(df, intercepts={"trait_a": 10.0, "trait_b": 20.0})
 
         pd.testing.assert_frame_equal(df, before)
+
+    def test_intercepts_passthrough_fixed_effects(self):
+        """A fixed-effects-derived intercept passes through unchanged (#114).
+
+        Through both extract_blup_table() and BLUPResult.from_blup_table().
+        BLUPResult and its adapter are unaware of fixed_effects -- they only
+        ever see whatever `intercept` float a trait's source dict carries,
+        whether that came from a plain fixed_effects=None fit or an
+        empirical frequency-weighted fixed_effects fit.
+        """
+        # An arbitrary, non-trivial value standing in for an empirical
+        # frequency-weighted intercept produced by fixed_effects.
+        fixed_effects_intercept = 47.638291
+        heritability_results = {
+            "trait_a": {
+                "model_type": "mixed_model",
+                "blup": {"G01": 0.5, "G02": -0.5},
+                "intercept": fixed_effects_intercept,
+            },
+        }
+        blup_df = extract_blup_table(heritability_results)
+        result = BLUPResult.from_blup_table(
+            blup_df, intercepts={"trait_a": fixed_effects_intercept}
+        )
+        assert result.intercepts["trait_a"] == fixed_effects_intercept
 
 
 class TestBLUPResultExport:

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -805,6 +805,30 @@ class TestFixedEffects:
         assert "Invalid fixed_effects" in result["error"]
         assert "trait_high_h2" not in result
 
+    def test_fixed_effect_non_string_name_rejected_not_crashed(self):
+        """A non-str fixed_effects element is rejected, not crashed.
+
+        Regression test (PR #193 review): a CSV-derived batch/wave/scanner
+        column can plausibly be int-labeled; `fe.isidentifier()` assumed
+        every element was already a str, crashing with `AttributeError:
+        'int' object has no attribute 'isidentifier'` before the per-trait
+        try/except that this function's own docstring promises shields
+        every caller from an uncaught exception.
+        """
+        df = pd.DataFrame(
+            {
+                "trait": [1.0, 2.0, 3.0, 4.0],
+                "geno": ["a", "a", "b", "b"],
+                5: [1, 1, 2, 2],
+            }
+        )
+        result = calculate_heritability_estimates(
+            df, ["trait"], genotype_col="geno", replicate_col=None, fixed_effects=[5]
+        )
+        assert "error" in result
+        assert "Invalid fixed_effects" in result["error"]
+        assert "trait" not in result
+
     def test_fixed_effect_reusing_genotype_col_rejected(
         self, heritability_data_known_h2
     ):

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -1238,6 +1238,127 @@ class TestFixedEffects:
                 entry["model_type"] == "mixed_model_failed"
             ), f"{trait} should have failed due to the repeated warning"
 
+    def test_duplicate_fixed_effects_names_rejected(self, heritability_data_known_h2):
+        """A repeated name within fixed_effects is rejected with a clear error.
+
+        Regression test (PR #193 review, 7.6): without this check,
+        fixed_effects=["experiment", "experiment"] degrades to an obscure
+        patsy failure from a duplicate C(...) term in the formula, deep
+        inside the per-trait try/except, rather than a clear structural
+        error matching the existing missing-column/reused-name error shape.
+        """
+        df, _ = heritability_data_known_h2
+        df = df.copy()
+        df["experiment"] = "A"
+        result = calculate_heritability_estimates(
+            df,
+            ["trait_high_h2"],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=["experiment", "experiment"],
+        )
+        assert "error" in result
+        assert "Duplicate fixed_effects" in result["error"]
+        assert "trait_high_h2" not in result
+
+    def test_single_level_fixed_effect_succeeds(self, heritability_data_known_h2):
+        """A single-level (zero variance) fixed_effects column fits successfully.
+
+        Regression test for 7.6: verified correct by hand-tracing in
+        pre-merge review (patsy's C(fe) term contributes zero non-reference
+        coefficients when there is only one level, so
+        _marginal_intercept's "exactly one unmatched level" identity check
+        still holds), but was previously untested.
+        """
+        df, _ = heritability_data_known_h2
+        df = df.copy()
+        df["single_level"] = "only_value"
+
+        result = calculate_heritability_estimates(
+            df,
+            ["trait_high_h2"],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=["single_level"],
+        )
+        entry = result["trait_high_h2"]
+        assert "error" not in entry
+        assert entry["model_type"] == "mixed_model"
+        assert "blup" in entry
+        assert isinstance(entry["intercept"], float)
+
+
+class TestConfoundWarning:
+    """Tests for the confound UserWarning heuristic (7.5).
+
+    The ConvergenceWarning-as-failure heuristic (task 1.9/1.11) has a
+    confirmed false-negative: a fixed effect near-deterministically
+    confounded with genotype can fit cleanly with zero warnings from
+    statsmodels itself (see task 1.10). This surfaces an independent,
+    cheap diagnostic instead of leaving that case silent: if any genotype's
+    observations are confined to a single level of a fixed effect that has
+    more than one level overall, that genotype contributes no
+    within-genotype information for separating the two effects.
+    """
+
+    def test_confounded_fixed_effect_emits_user_warning(self):
+        """A fixed effect fully confounded with genotype triggers the warning.
+
+        Every genotype sits in exactly one level of the fixed effect; the
+        trait must still succeed (this is diagnostic only, not a failure).
+        """
+        rng = np.random.default_rng(3)
+        rows = []
+        for g in range(10):
+            level = "A" if g < 5 else "B"
+            effect = rng.normal(0, 2.0)
+            shift = 3.0 if level == "B" else 0.0
+            for r in range(5):
+                rows.append(
+                    {
+                        "geno": f"G{g:02d}",
+                        "trait": 50 + effect + shift + rng.normal(0, 1.0),
+                        "experiment": level,
+                    }
+                )
+        df = pd.DataFrame(rows)
+
+        with pytest.warns(UserWarning, match="confound"):
+            result = calculate_heritability_estimates(
+                df,
+                ["trait"],
+                genotype_col="geno",
+                replicate_col=None,
+                fixed_effects=["experiment"],
+            )
+        entry = result["trait"]
+        assert "error" not in entry
+        assert entry["model_type"] == "mixed_model"
+
+    def test_unconfounded_fixed_effect_emits_no_user_warning(
+        self, heritability_data_known_h2
+    ):
+        """An unconfounded fixed effect does not trigger the warning.
+
+        False-positive guard: genotypes here span multiple levels.
+        """
+        df, _ = heritability_data_known_h2
+        df = df.copy()
+        df["experiment"] = ["A", "B"] * (len(df) // 2) + ["A"] * (len(df) % 2)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = calculate_heritability_estimates(
+                df,
+                ["trait_high_h2"],
+                genotype_col="geno",
+                replicate_col="rep",
+                fixed_effects=["experiment"],
+            )
+        confound_warnings = [w for w in caught if issubclass(w.category, UserWarning)]
+        assert not confound_warnings
+        assert "error" not in result["trait_high_h2"]
+
 
 def _two_level_fixed_effect_fixture(seed=1, n_geno=10, n_reps=5, n_b=2):
     """20/5-rep-style fixture with one fixed effect at a known, unequal split.

--- a/tests/test_statistics.py
+++ b/tests/test_statistics.py
@@ -6,6 +6,9 @@ import numpy as np
 import warnings
 from unittest.mock import patch
 
+import statsmodels.formula.api as smf
+from statsmodels.tools.sm_exceptions import ConvergenceWarning
+
 from sleap_roots_analyze.statistics import (
     calculate_trait_statistics,
     perform_anova_by_genotype,
@@ -16,6 +19,7 @@ from sleap_roots_analyze.statistics import (
     diagnose_heritability_issues,
     compare_trait_heritabilities,
     extract_blup_table,
+    _marginal_intercept,
 )
 
 
@@ -720,6 +724,842 @@ class TestExtractBlupTable:
             raw_gap = abs(raw_means[geno] - intercept)
             adjusted_gap = abs(blup_table.loc[geno, trait] - intercept)
             assert adjusted_gap < raw_gap
+            high_rep_ratios.append(adjusted_gap / raw_gap)
+
+        assert np.mean(low_rep_ratios) < np.mean(high_rep_ratios)
+
+
+class TestFixedEffects:
+    """Tests for the fixed_effects parameter on calculate_heritability_estimates (#114)."""
+
+    def test_fixed_effects_none_matches_current_behavior(
+        self, heritability_data_known_h2
+    ):
+        """fixed_effects=None (or omitted, or []) reproduces current behavior."""
+        df, _ = heritability_data_known_h2
+        trait = "trait_high_h2"
+
+        result_omitted = calculate_heritability_estimates(
+            df, [trait], genotype_col="geno", replicate_col="rep"
+        )
+        result_none = calculate_heritability_estimates(
+            df, [trait], genotype_col="geno", replicate_col="rep", fixed_effects=None
+        )
+        result_empty = calculate_heritability_estimates(
+            df, [trait], genotype_col="geno", replicate_col="rep", fixed_effects=[]
+        )
+
+        assert result_omitted[trait] == result_none[trait]
+        assert result_omitted[trait] == result_empty[trait]
+
+        model_data = df[[trait, "geno"]].copy()
+        model_data.columns = ["value", "genotype"]
+        model = smf.mixedlm("value ~ 1", model_data, groups=model_data["genotype"])
+        expected_result = model.fit(reml=True)
+        assert result_omitted[trait]["intercept"] == pytest.approx(
+            float(expected_result.fe_params["Intercept"])
+        )
+
+    def test_missing_fixed_effect_column_returns_structural_error(
+        self, heritability_data_known_h2
+    ):
+        """A missing fixed_effects column short-circuits with a structural error."""
+        df, _ = heritability_data_known_h2
+        result = calculate_heritability_estimates(
+            df,
+            ["trait_high_h2"],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=["nonexistent_col"],
+        )
+        assert "error" in result
+        assert "nonexistent_col" in result["error"]
+        assert "trait_high_h2" not in result
+
+    def test_fixed_effect_column_name_with_patsy_metacharacter_rejected(
+        self, heritability_data_known_h2
+    ):
+        """A fixed_effects name that isn't a valid identifier is rejected loudly.
+
+        The column must actually exist in df (so the earlier missing-column
+        check doesn't intercept it first) while still failing
+        isidentifier(), to genuinely exercise the isidentifier() validation
+        rather than the unrelated missing-column path.
+        """
+        df, _ = heritability_data_known_h2
+        df = df.copy()
+        # A pandas column name is not required to be a valid Python
+        # identifier -- this legitimately exists in df.columns.
+        df["rep*block"] = df["rep"]
+        assert "rep*block" in df.columns
+        assert not "rep*block".isidentifier()
+
+        result = calculate_heritability_estimates(
+            df,
+            ["trait_high_h2"],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=["rep*block"],
+        )
+        assert "error" in result
+        assert "Invalid fixed_effects" in result["error"]
+        assert "trait_high_h2" not in result
+
+    def test_fixed_effect_reusing_genotype_col_rejected(
+        self, heritability_data_known_h2
+    ):
+        """Naming genotype_col as a fixed effect too is rejected with a clear error.
+
+        Regression test (found in pre-merge review): without this check,
+        fixed_effects=[genotype_col] causes a duplicate-column selection
+        that surfaces as a confusing pandas-internal error deep inside the
+        per-trait loop ("Grouper for 'geno' not 1-dimensional") rather than a
+        clear structural error.
+        """
+        df, _ = heritability_data_known_h2
+        result = calculate_heritability_estimates(
+            df,
+            ["trait_high_h2"],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=["geno"],
+        )
+        assert "error" in result
+        assert "duplicate" in result["error"]
+        assert "trait_high_h2" not in result
+
+    def test_fixed_effect_reusing_replicate_col_rejected(
+        self, heritability_data_known_h2
+    ):
+        """Naming replicate_col as a fixed effect too is rejected with a clear error."""
+        df, _ = heritability_data_known_h2
+        result = calculate_heritability_estimates(
+            df,
+            ["trait_high_h2"],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=["rep"],
+        )
+        assert "error" in result
+        assert "duplicate" in result["error"]
+        assert "trait_high_h2" not in result
+
+    def test_fixed_effect_column_always_treated_as_categorical(self):
+        """A numeric-looking fixed effect is C()-wrapped, not treated as continuous."""
+        rng = np.random.default_rng(0)
+        rows = []
+        for wave in (1, 2, 3):
+            shift = {1: 0.0, 2: 5.0, 3: -3.0}[wave]
+            for g in range(10):
+                for r in range(3):
+                    rows.append(
+                        {
+                            "geno": f"G{g:02d}",
+                            "wave_number": wave,
+                            "value": 50
+                            + shift
+                            + rng.normal(0, 1.0)
+                            + (0.1 * g if r == 0 else 0),
+                        }
+                    )
+        model_data = pd.DataFrame(rows)
+        model_data["genotype"] = model_data["geno"]
+
+        categorical_fit = smf.mixedlm(
+            "value ~ C(wave_number)", model_data, groups=model_data["genotype"]
+        ).fit(reml=True)
+        continuous_fit = smf.mixedlm(
+            "value ~ wave_number", model_data, groups=model_data["genotype"]
+        ).fit(reml=True)
+
+        # Categorical: Intercept + one coefficient per non-reference level (3 total).
+        # Continuous: Intercept + a single slope coefficient (2 total).
+        assert len(categorical_fit.fe_params) == 3
+        assert len(continuous_fit.fe_params) == 2
+
+    def test_nan_in_fixed_effect_column_drops_row(self, heritability_data_known_h2):
+        """A NaN in a fixed_effects column drops that row only when included."""
+        df, _ = heritability_data_known_h2
+        df = df.copy()
+        df["experiment"] = "A"
+        df.loc[df.index[0], "experiment"] = np.nan
+        trait = "trait_high_h2"
+
+        with_fe = calculate_heritability_estimates(
+            df,
+            [trait],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=["experiment"],
+        )
+        without_fe = calculate_heritability_estimates(
+            df, [trait], genotype_col="geno", replicate_col="rep", fixed_effects=None
+        )
+        assert (
+            with_fe[trait]["n_observations"] == without_fe[trait]["n_observations"] - 1
+        )
+
+    def test_batch_confounded_uncorrected_h2_exceeds_corrected(
+        self, heritability_data_batch_confounded
+    ):
+        """The core Tier 2 oracle: uncorrected H2 exceeds corrected H2."""
+        df, meta = heritability_data_batch_confounded
+        trait = meta["trait"]
+        result_uncorrected = calculate_heritability_estimates(
+            df, [trait], genotype_col="geno", replicate_col="rep"
+        )
+        result_corrected = calculate_heritability_estimates(
+            df,
+            [trait],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=[meta["batch_col"]],
+        )
+        h2_uncorrected = result_uncorrected[trait]["heritability"]
+        h2_corrected = result_corrected[trait]["heritability"]
+        assert h2_uncorrected - h2_corrected >= 0.05
+
+    def test_mixed_model_failure_with_fixed_effects_recorded_as_error(
+        self, heritability_data_known_h2
+    ):
+        """A raised exception during fit with fixed_effects set is recorded as a failure."""
+        df, _ = heritability_data_known_h2
+        df = df.copy()
+        df["experiment"] = ["A", "B"] * (len(df) // 2) + ["A"] * (len(df) % 2)
+        with patch("statsmodels.formula.api.mixedlm", side_effect=Exception("boom")):
+            result = calculate_heritability_estimates(
+                df,
+                ["trait_high_h2"],
+                genotype_col="geno",
+                replicate_col="rep",
+                fixed_effects=["experiment"],
+            )
+        entry = result["trait_high_h2"]
+        assert entry["model_type"] == "mixed_model_failed"
+        assert "blup" not in entry
+        assert "intercept" not in entry
+
+    def test_convergence_warning_treated_as_failure(self, heritability_data_known_h2):
+        """A ConvergenceWarning without a raised exception is treated as a failure."""
+        df, _ = heritability_data_known_h2
+        df = df.copy()
+        df["experiment"] = ["A", "B"] * (len(df) // 2) + ["A"] * (len(df) % 2)
+
+        real_mixedlm = smf.mixedlm
+
+        def warning_mixedlm(*args, **kwargs):
+            model = real_mixedlm(*args, **kwargs)
+            original_fit = model.fit
+
+            def fit_with_warning(*fit_args, **fit_kwargs):
+                warnings.warn("Test-induced convergence issue", ConvergenceWarning)
+                return original_fit(*fit_args, **fit_kwargs)
+
+            model.fit = fit_with_warning
+            return model
+
+        with patch("statsmodels.formula.api.mixedlm", side_effect=warning_mixedlm):
+            result = calculate_heritability_estimates(
+                df,
+                ["trait_high_h2"],
+                genotype_col="geno",
+                replicate_col="rep",
+                fixed_effects=["experiment"],
+            )
+        entry = result["trait_high_h2"]
+        assert entry["model_type"] == "mixed_model_failed"
+        assert "blup" not in entry
+        assert "intercept" not in entry
+
+    def test_unrelated_warning_during_fit_does_not_fail_trait(
+        self, heritability_data_known_h2
+    ):
+        """A non-ConvergenceWarning warning during fit does not fail the trait."""
+        df, _ = heritability_data_known_h2
+        df = df.copy()
+        df["experiment"] = ["A", "B"] * (len(df) // 2) + ["A"] * (len(df) % 2)
+
+        real_mixedlm = smf.mixedlm
+
+        def warning_mixedlm(*args, **kwargs):
+            model = real_mixedlm(*args, **kwargs)
+            original_fit = model.fit
+
+            def fit_with_warning(*fit_args, **fit_kwargs):
+                warnings.warn("Unrelated warning", UserWarning)
+                return original_fit(*fit_args, **fit_kwargs)
+
+            model.fit = fit_with_warning
+            return model
+
+        with patch("statsmodels.formula.api.mixedlm", side_effect=warning_mixedlm):
+            result = calculate_heritability_estimates(
+                df,
+                ["trait_high_h2"],
+                genotype_col="geno",
+                replicate_col="rep",
+                fixed_effects=["experiment"],
+            )
+        entry = result["trait_high_h2"]
+        assert entry["model_type"] == "mixed_model"
+        assert "error" not in entry
+        assert "blup" in entry
+        assert "intercept" in entry
+
+    def test_convergence_warning_not_caught_without_fixed_effects(
+        self, heritability_data_known_h2
+    ):
+        """The warning-capture gate is conditional on fixed_effects being set."""
+        df, _ = heritability_data_known_h2
+
+        real_mixedlm = smf.mixedlm
+
+        def warning_mixedlm(*args, **kwargs):
+            model = real_mixedlm(*args, **kwargs)
+            original_fit = model.fit
+
+            def fit_with_warning(*fit_args, **fit_kwargs):
+                warnings.warn("Test-induced convergence issue", ConvergenceWarning)
+                return original_fit(*fit_args, **fit_kwargs)
+
+            model.fit = fit_with_warning
+            return model
+
+        with patch("statsmodels.formula.api.mixedlm", side_effect=warning_mixedlm):
+            result = calculate_heritability_estimates(
+                df, ["trait_high_h2"], genotype_col="geno", replicate_col="rep"
+            )
+        entry = result["trait_high_h2"]
+        assert entry["model_type"] == "mixed_model"
+        assert "error" not in entry
+        assert "blup" in entry
+        assert "intercept" in entry
+
+    def test_fixed_effects_columns_excluded_from_low_h2_filtering(self):
+        """fixed_effects columns are never silently dropped by remove_low_h2=True.
+
+        Regression test (found in pre-merge review): without excluding
+        fixed_effects from the trait-column scan, get_trait_columns() (called
+        internally by remove_low_heritability_traits) has no way to know a
+        fixed_effects column isn't a candidate trait. Since it was never fit
+        as a trait_col, it has no entry in heritability_results and gets
+        silently removed from df_filtered with reason "No heritability
+        estimate available".
+        """
+        np.random.seed(0)
+        rows = []
+        for g in range(10):
+            effect = np.random.normal(0, 2.0)
+            for r in range(6):
+                block = "block_1" if r < 3 else "block_2"
+                shift = 3.0 if block == "block_2" else 0.0
+                rows.append(
+                    {
+                        "geno": f"G{g:02d}",
+                        "rep": r + 1,
+                        "trait1": 50 + effect + shift + np.random.normal(0, 1.0),
+                        "block": block,
+                    }
+                )
+        df = pd.DataFrame(rows)
+
+        _, df_filtered, removed_traits, _ = calculate_heritability_estimates(
+            df,
+            ["trait1"],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=["block"],
+            remove_low_h2=True,
+            h2_threshold=0.9,
+        )
+        assert "block" in df_filtered.columns
+        assert "block" not in removed_traits
+
+    def test_near_fully_confounded_fixed_effect_organic_behavior(self):
+        """Pins statsmodels' actual (organic, non-mocked) behavior on a fixed effect.
+
+        The fixed effect is a near-deterministic function of genotype. 18 of
+        20 genotypes appear in only one of two experiment batches; 2
+        genotypes split their reps 3/2 between batches as the only source
+        of within-genotype batch variation. Observed once (seed=0, this
+        platform) and pinned here: statsmodels fits without raising or
+        warning at all — neither 1.9's warn path nor 1.8's raise path
+        applies. If a future statsmodels version (or a different platform's
+        BLAS/LAPACK, for this near-singular fit) changes this qualitative
+        outcome (raises, or warns), this test will fail and should be
+        updated to match the new observed behavior rather than patched to
+        force the old one. The exact heritability value is deliberately NOT
+        pinned tightly (pre-merge review flagged this as CI-fragile, never
+        having run on the Ubuntu/Windows/macOS matrix) — only the
+        qualitative outcome (which of the three paths triggered) is the
+        point of this characterization test.
+        """
+        np.random.seed(0)
+        rows = []
+        for g in range(20):
+            geno = f"G{g:02d}"
+            effect = np.random.normal(0, 2.0)
+            if g < 18:
+                batches = ["A"] * 5 if g < 9 else ["B"] * 5
+            else:
+                batches = ["A", "A", "B", "B", "A"]
+            for r, batch in enumerate(batches):
+                shift = 8.0 if batch == "B" else 0.0
+                value = 50 + effect + shift + np.random.normal(0, 1.0)
+                rows.append(
+                    {
+                        "geno": geno,
+                        "rep": r + 1,
+                        "trait": value,
+                        "experiment": batch,
+                    }
+                )
+        df = pd.DataFrame(rows)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = calculate_heritability_estimates(
+                df,
+                ["trait"],
+                genotype_col="geno",
+                replicate_col="rep",
+                fixed_effects=["experiment"],
+            )
+
+        convergence_warnings = [
+            w for w in caught if issubclass(w.category, ConvergenceWarning)
+        ]
+        assert convergence_warnings == []
+        entry = result["trait"]
+        assert entry["model_type"] == "mixed_model"
+        assert "error" not in entry
+        # The exact value is platform/BLAS-sensitive for a near-singular fit;
+        # only confirm it's a valid, non-degenerate probability, not an exact
+        # decimal (see docstring).
+        assert 0.0 <= entry["heritability"] <= 1.0
+
+    def test_fixed_effects_with_anova_based_force_method(
+        self, heritability_data_batch_confounded
+    ):
+        """fixed_effects still applies row-filtering under force_method='anova_based'.
+
+        It is never used in that path's own variance-component computation.
+        """
+        df, meta = heritability_data_batch_confounded
+        trait = meta["trait"]
+        df = df.copy()
+        df.loc[df.index[0], meta["batch_col"]] = np.nan
+
+        result = calculate_heritability_estimates(
+            df,
+            [trait],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=[meta["batch_col"]],
+            force_method="anova_based",
+        )
+        entry = result[trait]
+        assert entry["model_type"] == "anova_based"
+        assert "blup" not in entry
+        assert "intercept" not in entry
+
+        result_no_nan_drop = calculate_heritability_estimates(
+            df,
+            [trait],
+            genotype_col="geno",
+            replicate_col="rep",
+            force_method="anova_based",
+        )
+        assert entry["n_observations"] == (
+            result_no_nan_drop[trait]["n_observations"] - 1
+        )
+
+    def test_repeat_convergence_warning_across_traits_both_fail(
+        self, heritability_data_known_h2
+    ):
+        """A repeat identical ConvergenceWarning fails every affected trait.
+
+        Not just the first -- exercises the simplefilter("always") requirement.
+        """
+        df, _ = heritability_data_known_h2
+        df = df.copy()
+        df["experiment"] = ["A", "B"] * (len(df) // 2) + ["A"] * (len(df) % 2)
+
+        real_mixedlm = smf.mixedlm
+
+        def warning_mixedlm(*args, **kwargs):
+            model = real_mixedlm(*args, **kwargs)
+            original_fit = model.fit
+
+            def fit_with_warning(*fit_args, **fit_kwargs):
+                warnings.warn(
+                    "Repeated test-induced convergence issue", ConvergenceWarning
+                )
+                return original_fit(*fit_args, **fit_kwargs)
+
+            model.fit = fit_with_warning
+            return model
+
+        with patch("statsmodels.formula.api.mixedlm", side_effect=warning_mixedlm):
+            result = calculate_heritability_estimates(
+                df,
+                ["trait_high_h2", "trait_moderate_h2"],
+                genotype_col="geno",
+                replicate_col="rep",
+                fixed_effects=["experiment"],
+            )
+        for trait in ("trait_high_h2", "trait_moderate_h2"):
+            entry = result[trait]
+            assert (
+                entry["model_type"] == "mixed_model_failed"
+            ), f"{trait} should have failed due to the repeated warning"
+
+
+def _two_level_fixed_effect_fixture(seed=1, n_geno=10, n_reps=5, n_b=2):
+    """20/5-rep-style fixture with one fixed effect at a known, unequal split.
+
+    freq(experiment="B") = n_b / n_reps; freq(experiment="A") = 1 - that.
+    """
+    rng = np.random.default_rng(seed)
+    rows = []
+    for g in range(n_geno):
+        effect = rng.normal(0, 2.0)
+        for r in range(n_reps):
+            level = "B" if r < n_b else "A"
+            shift = 3.0 if level == "B" else 0.0
+            rows.append(
+                {
+                    "geno": f"G{g:02d}",
+                    "trait": 50 + effect + shift + rng.normal(0, 1.0),
+                    "experiment": level,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _two_fixed_effect_fixture(seed=2, n_geno=10, n_reps=10):
+    """Fixture with two fixed effects, each at its own known split."""
+    rng = np.random.default_rng(seed)
+    rows = []
+    for g in range(n_geno):
+        effect = rng.normal(0, 2.0)
+        for r in range(n_reps):
+            experiment = "B" if r < 3 else "A"  # freq(B) = 0.3
+            block = "block2" if r in (2, 3, 6, 7) else "block1"  # freq(block2) = 0.4
+            shift = (3.0 if experiment == "B" else 0.0) + (
+                -1.5 if block == "block2" else 0.0
+            )
+            rows.append(
+                {
+                    "geno": f"G{g:02d}",
+                    "trait": 50 + effect + shift + rng.normal(0, 1.0),
+                    "experiment": experiment,
+                    "block": block,
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def _hand_computed_marginal_intercept(fitted_result, model_data, fixed_effects):
+    """Independent (non-production) hand computation for oracle comparison."""
+    intercept = float(fitted_result.fe_params["Intercept"])
+    for fe in fixed_effects:
+        freqs = model_data[fe].value_counts(normalize=True)
+        for level, freq in freqs.items():
+            key = f"C({fe})[T.{level}]"
+            if key in fitted_result.fe_params.index:
+                intercept += float(freq) * float(fitted_result.fe_params[key])
+    return intercept
+
+
+class TestMarginalIntercept:
+    """Tests for the empirical frequency-weighted intercept (#114)."""
+
+    def test_marginal_intercept_none_equals_plain_intercept(
+        self, heritability_data_known_h2
+    ):
+        """With fixed_effects=None, intercept is exactly fe_params['Intercept']."""
+        df, _ = heritability_data_known_h2
+        trait = "trait_high_h2"
+        result = calculate_heritability_estimates(
+            df, [trait], genotype_col="geno", replicate_col="rep"
+        )
+        model_data = df[[trait, "geno"]].copy()
+        model_data.columns = ["value", "genotype"]
+        expected = smf.mixedlm(
+            "value ~ 1", model_data, groups=model_data["genotype"]
+        ).fit(reml=True)
+        assert result[trait]["intercept"] == pytest.approx(
+            float(expected.fe_params["Intercept"])
+        )
+
+    def test_marginal_intercept_matches_hand_computed_weighted_average(self):
+        """The returned intercept matches an independent hand computation."""
+        df = _two_level_fixed_effect_fixture()
+        model_data = df[["trait", "geno", "experiment"]].copy()
+        model_data.columns = ["value", "genotype", "experiment"]
+        independent_fit = smf.mixedlm(
+            "value ~ C(experiment)", model_data, groups=model_data["genotype"]
+        ).fit(reml=True)
+        expected = _hand_computed_marginal_intercept(
+            independent_fit, model_data, ["experiment"]
+        )
+
+        result = calculate_heritability_estimates(
+            df,
+            ["trait"],
+            genotype_col="geno",
+            replicate_col=None,
+            fixed_effects=["experiment"],
+        )
+        assert result["trait"]["intercept"] == pytest.approx(expected, abs=1e-6)
+
+    def test_marginal_intercept_differs_from_reference_level_when_unbalanced(self):
+        """The empirical intercept differs from the raw reference-level Intercept."""
+        df = _two_level_fixed_effect_fixture()
+        model_data = df[["trait", "geno", "experiment"]].copy()
+        model_data.columns = ["value", "genotype", "experiment"]
+        independent_fit = smf.mixedlm(
+            "value ~ C(experiment)", model_data, groups=model_data["genotype"]
+        ).fit(reml=True)
+        raw_reference_intercept = float(independent_fit.fe_params["Intercept"])
+
+        result = calculate_heritability_estimates(
+            df,
+            ["trait"],
+            genotype_col="geno",
+            replicate_col=None,
+            fixed_effects=["experiment"],
+        )
+        assert abs(result["trait"]["intercept"] - raw_reference_intercept) > 1e-3
+
+    def test_marginal_intercept_multiple_fixed_effects_independent(self):
+        """Two fixed effects contribute independently, without conflation."""
+        df = _two_fixed_effect_fixture()
+        model_data = df[["trait", "geno", "experiment", "block"]].copy()
+        model_data.columns = ["value", "genotype", "experiment", "block"]
+        independent_fit = smf.mixedlm(
+            "value ~ C(experiment) + C(block)",
+            model_data,
+            groups=model_data["genotype"],
+        ).fit(reml=True)
+        expected = _hand_computed_marginal_intercept(
+            independent_fit, model_data, ["experiment", "block"]
+        )
+
+        result = calculate_heritability_estimates(
+            df,
+            ["trait"],
+            genotype_col="geno",
+            replicate_col=None,
+            fixed_effects=["experiment", "block"],
+        )
+        assert result["trait"]["intercept"] == pytest.approx(expected, abs=1e-6)
+
+    def test_marginal_intercept_float_dtype_fixed_effect_column(self):
+        """A float64-typed fixed-effect column doesn't corrupt the coefficient lookup."""
+        rng = np.random.default_rng(3)
+        rows = []
+        for g in range(10):
+            effect = rng.normal(0, 2.0)
+            for wave in (1.0, 2.0, 3.0):
+                shift = {1.0: 0.0, 2.0: 4.0, 3.0: -2.0}[wave]
+                rows.append(
+                    {
+                        "geno": f"G{g:02d}",
+                        "trait": 50 + effect + shift + rng.normal(0, 1.0),
+                        "wave_number": wave,
+                    }
+                )
+        df = pd.DataFrame(rows)
+        assert df["wave_number"].dtype == np.float64
+
+        model_data = df[["trait", "geno", "wave_number"]].copy()
+        model_data.columns = ["value", "genotype", "wave_number"]
+        independent_fit = smf.mixedlm(
+            "value ~ C(wave_number)", model_data, groups=model_data["genotype"]
+        ).fit(reml=True)
+        expected = _hand_computed_marginal_intercept(
+            independent_fit, model_data, ["wave_number"]
+        )
+
+        result = calculate_heritability_estimates(
+            df,
+            ["trait"],
+            genotype_col="geno",
+            replicate_col=None,
+            fixed_effects=["wave_number"],
+        )
+        assert result["trait"]["intercept"] == pytest.approx(expected, abs=1e-6)
+
+    def test_marginal_intercept_non_sorted_categorical_order(self):
+        """A non-default pd.Categorical order doesn't mispair frequencies."""
+        rng = np.random.default_rng(4)
+        rows = []
+        # Non-alphabetical, non-numeric declared order: reference = "high".
+        levels = ["high", "low", "mid"]
+        shifts = {"high": 0.0, "low": 5.0, "mid": -3.0}
+        for g in range(10):
+            effect = rng.normal(0, 2.0)
+            for level in levels:
+                rows.append(
+                    {
+                        "geno": f"G{g:02d}",
+                        "trait": 50 + effect + shifts[level] + rng.normal(0, 1.0),
+                        "tier": level,
+                    }
+                )
+        df = pd.DataFrame(rows)
+        df["tier"] = pd.Categorical(df["tier"], categories=levels)
+
+        model_data = df[["trait", "geno", "tier"]].copy()
+        model_data.columns = ["value", "genotype", "tier"]
+        independent_fit = smf.mixedlm(
+            "value ~ C(tier)", model_data, groups=model_data["genotype"]
+        ).fit(reml=True)
+        # Confirm the reference level is really "high" (first declared category).
+        assert "C(tier)[T.high]" not in independent_fit.fe_params.index
+        assert "C(tier)[T.low]" in independent_fit.fe_params.index
+        assert "C(tier)[T.mid]" in independent_fit.fe_params.index
+        expected = _hand_computed_marginal_intercept(
+            independent_fit, model_data, ["tier"]
+        )
+
+        result = calculate_heritability_estimates(
+            df,
+            ["trait"],
+            genotype_col="geno",
+            replicate_col=None,
+            fixed_effects=["tier"],
+        )
+        assert result["trait"]["intercept"] == pytest.approx(expected, abs=1e-6)
+
+    def test_marginal_intercept_rejects_coefficient_key_not_in_observed_levels(self):
+        """_marginal_intercept's identity check catches an orphaned coefficient key.
+
+        Regression test (found in pre-merge review): the original guard only
+        checked that the *count* of recovered coefficients equaled
+        n_levels - 1, which can pass even when a real level's string failed
+        to match its own coefficient (silently defaulting to 0.0) while an
+        unrelated key happened to keep the count the same. This directly
+        unit-tests _marginal_intercept with a fabricated mismatch a real fit
+        would not organically produce, to exercise the identity check itself.
+        """
+
+        class _FakeResult:
+            fe_params = pd.Series(
+                {"Intercept": 10.0, "C(fe)[T.99]": 5.0},
+            )
+
+        model_data = pd.DataFrame({"fe": [1, 2, 3]})
+        with pytest.raises(ValueError, match="not found in the fitted data"):
+            _marginal_intercept(_FakeResult(), model_data, ["fe"])
+
+    def test_marginal_intercept_rejects_multiple_unmatched_levels(self):
+        """_marginal_intercept's identity check catches more than one apparent reference."""
+
+        class _FakeResult:
+            fe_params = pd.Series({"Intercept": 10.0})
+
+        model_data = pd.DataFrame({"fe": [1, 2, 3]})
+        with pytest.raises(ValueError, match="found 3"):
+            _marginal_intercept(_FakeResult(), model_data, ["fe"])
+
+
+class TestFieldBlockOracle:
+    """Field-block BLUP/shrinkage oracles for fixed_effects (#114)."""
+
+    def test_field_block_fixed_effect_changes_blup_adjusted_means(
+        self, heritability_data_field_block
+    ):
+        """BLUP-adjusted means differ between fixed_effects=None and ["block"]."""
+        df, meta = heritability_data_field_block
+        trait = meta["trait"]
+
+        result_none = calculate_heritability_estimates(
+            df, [trait], genotype_col="geno", replicate_col="rep"
+        )
+        result_block = calculate_heritability_estimates(
+            df,
+            [trait],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=["block"],
+        )
+        table_none = extract_blup_table(result_none)
+        table_block = extract_blup_table(result_block)
+
+        max_diff = (table_none[trait] - table_block[trait]).abs().max()
+        assert max_diff > 1e-6
+
+    def test_shrinkage_scales_with_replication_under_fixed_effects(
+        self, heritability_data_field_block
+    ):
+        """Shrinkage still scales inversely with replication when fixed_effects is set.
+
+        The raw-mean reference point must be block-detrended, not naive --
+        the naive df.groupby(genotype)[trait].mean() is itself contaminated
+        by each genotype's own block composition, the exact thing the fixed
+        effect corrects for.
+        """
+        df, meta = heritability_data_field_block
+        trait = meta["trait"]
+
+        result = calculate_heritability_estimates(
+            df,
+            [trait],
+            genotype_col="geno",
+            replicate_col="rep",
+            fixed_effects=["block"],
+        )
+        blup = result[trait]["blup"]
+
+        # Independently re-fit to obtain the fitted C(block) coefficient for
+        # detrending, and the reference-level Intercept for centering.
+        #
+        # NOTE: this deliberately compares raw shrinkage against `blup[g]`
+        # directly (not `extract_blup_table()`'s already-summed
+        # adjusted_mean), centered on the *reference-level* Intercept from
+        # this independent re-fit -- not production's returned (marginal,
+        # frequency-weighted) `intercept`. `blup[g]` is a raw model output,
+        # entirely unaffected by which intercept convention is used to
+        # report the adjusted mean afterward. `raw_mean_detrended[g]` has no
+        # such dependency either -- it's derived purely from the data
+        # relative to the reference level. Mixing a reference-level quantity
+        # (blup) with a marginal-intercept-centered raw mean introduces a
+        # constant offset that does NOT cancel under the absolute-value
+        # shrinkage comparison (confirmed empirically: doing so broke this
+        # test for a subset of genotypes). Both sides of the comparison must
+        # share the same reference-level center.
+        model_data = df[[trait, "geno", "block"]].copy()
+        model_data.columns = ["value", "genotype", "block"]
+        independent_fit = smf.mixedlm(
+            "value ~ C(block)", model_data, groups=model_data["genotype"]
+        ).fit(reml=True)
+        reference_intercept = float(independent_fit.fe_params["Intercept"])
+        block_coef = {}
+        for key in independent_fit.fe_params.index:
+            if key != "Intercept":
+                match = key.split("[T.")[-1].rstrip("]")
+                block_coef[match] = float(independent_fit.fe_params[key])
+
+        df_detrended = df.copy()
+        df_detrended["detrended"] = df_detrended.apply(
+            lambda row: row[trait] - block_coef.get(row["block"], 0.0), axis=1
+        )
+        raw_mean_detrended = df_detrended.groupby("geno")["detrended"].mean()
+
+        low_rep_ratios = []
+        high_rep_ratios = []
+        for geno in meta["low_rep_genotypes"]:
+            raw_gap = abs(raw_mean_detrended[geno] - reference_intercept)
+            adjusted_gap = abs(blup[geno])
+            assert adjusted_gap <= raw_gap + 1e-6
+            low_rep_ratios.append(adjusted_gap / raw_gap)
+        for geno in meta["high_rep_genotypes"]:
+            raw_gap = abs(raw_mean_detrended[geno] - reference_intercept)
+            adjusted_gap = abs(blup[geno])
+            assert adjusted_gap <= raw_gap + 1e-6
             high_rep_ratios.append(adjusted_gap / raw_gap)
 
         assert np.mean(low_rep_ratios) < np.mean(high_rep_ratios)

--- a/tests/test_step_statistical_analysis.py
+++ b/tests/test_step_statistical_analysis.py
@@ -588,6 +588,82 @@ class TestBLUPTableOutput:
         assert (tmp_path / "data" / "08_blup_adjusted_means.csv").exists()
 
 
+class TestFixedEffectsConfig:
+    """Tests for StatisticsConfig.fixed_effects threading (#114)."""
+
+    def test_statistics_config_fixed_effects_default_none(self):
+        """StatisticsConfig.fixed_effects defaults to None."""
+        assert StatisticsConfig().fixed_effects is None
+
+    def test_fixed_effects_threaded_into_heritability_call(self, prev_result, tmp_path):
+        """statistics.fixed_effects changes the heritability/BLUP output."""
+        np.random.seed(0)
+        n = 40
+        data = pd.DataFrame(
+            {
+                "Barcode": [f"plant{i}" for i in range(n)],
+                "Genotype": (["A"] * 10 + ["B"] * 10) * 2,
+                "Replicate": list(range(1, 11)) * 4,
+                "experiment": ["exp1"] * 20 + ["exp2"] * 20,
+                "trait1": np.concatenate(
+                    [
+                        np.random.randn(20) * 2 + 50,
+                        np.random.randn(20) * 2 + 65,
+                    ]
+                ),
+            }
+        )
+        local_prev_result = StepResult(
+            data=data,
+            metadata={"valid_trait_names": ["trait1"], "samples": n},
+            files_generated=[],
+        )
+
+        config_none = VizPipelineConfig(
+            pipeline_name="test_viz",
+            columns=ColumnConfig(
+                barcode="Barcode", genotype="Genotype", replicate="Replicate"
+            ),
+            data=DataConfig(csv_path="dummy.csv"),
+            statistics=StatisticsConfig(fixed_effects=None),
+        )
+        config_fe = VizPipelineConfig(
+            pipeline_name="test_viz",
+            columns=ColumnConfig(
+                barcode="Barcode", genotype="Genotype", replicate="Replicate"
+            ),
+            data=DataConfig(csv_path="dummy.csv"),
+            statistics=StatisticsConfig(fixed_effects=["experiment"]),
+        )
+
+        step = StatisticalAnalysisStep()
+        tmp_none = tmp_path / "none"
+        tmp_fe = tmp_path / "fe"
+        step.execute(data, config_none, tmp_none, local_prev_result)
+        step.execute(data, config_fe, tmp_fe, local_prev_result)
+
+        herit_none = pd.read_csv(tmp_none / "data" / "08_heritability_results.csv")
+        herit_fe = pd.read_csv(tmp_fe / "data" / "08_heritability_results.csv")
+        h2_none = herit_none.loc[herit_none["trait"] == "trait1", "heritability"].iloc[
+            0
+        ]
+        h2_fe = herit_fe.loc[herit_fe["trait"] == "trait1", "heritability"].iloc[0]
+        assert h2_none != pytest.approx(h2_fe)
+
+        blup_none = pd.read_csv(tmp_none / "data" / "08_blup_adjusted_means.csv")
+        blup_fe = pd.read_csv(tmp_fe / "data" / "08_blup_adjusted_means.csv")
+        assert not blup_none["trait1"].equals(blup_fe["trait1"])
+
+    def test_fixed_effects_qc_config_no_statistics_resolves_none(
+        self, sample_data, config, prev_result, tmp_path
+    ):
+        """A bare QCPipelineConfig (no statistics field) resolves fixed_effects to None."""
+        step = StatisticalAnalysisStep()
+        result = step.execute(sample_data, config, tmp_path, prev_result)
+
+        assert result.metadata["heritability_results"] != {}
+
+
 # --- Task 2: Tests for metadata and summary ---
 
 

--- a/tests/test_step_statistical_analysis.py
+++ b/tests/test_step_statistical_analysis.py
@@ -18,7 +18,10 @@ from sleap_roots_analyze.pipeline import (
 from sleap_roots_analyze.pipeline.config.components import StatisticsConfig
 from sleap_roots_analyze.pipeline.config.viz_config import VizPipelineConfig
 from sleap_roots_analyze.pipeline.core import StepResult
-from sleap_roots_analyze.pipeline.steps import StatisticalAnalysisStep
+from sleap_roots_analyze.pipeline.steps import (
+    LoadDataAndImagesStep,
+    StatisticalAnalysisStep,
+)
 
 
 @pytest.fixture
@@ -662,6 +665,108 @@ class TestFixedEffectsConfig:
         result = step.execute(sample_data, config, tmp_path, prev_result)
 
         assert result.metadata["heritability_results"] != {}
+
+    def test_statistics_config_fixed_effects_rejects_non_list(self):
+        """A bare string is rejected at config-construction time (PR #193, 7.4).
+
+        A str is iterable, so passing it straight through would silently
+        produce a per-character fixed_effects list deep inside
+        calculate_heritability_estimates instead of a clear error.
+        """
+        with pytest.raises(ValueError, match="fixed_effects"):
+            StatisticsConfig(fixed_effects="experiment")
+
+    def test_statistics_config_fixed_effects_rejects_non_str_elements(self):
+        """A non-str element is rejected at config-construction time.
+
+        Before it ever reaches calculate_heritability_estimates.
+        """
+        with pytest.raises(ValueError, match="fixed_effects"):
+            StatisticsConfig(fixed_effects=["experiment", 5])
+
+    def test_viz_pipeline_config_auto_excludes_fixed_effects(self):
+        """VizPipelineConfig auto-derives additional_exclude_cols (7.3).
+
+        Unions statistics.fixed_effects into data.additional_exclude_cols
+        automatically. Without this, the pipeline's upstream trait_cols scan
+        (LoadDataAndImagesStep -> get_trait_columns) has no knowledge of
+        config.statistics.fixed_effects on its own, so a fixed_effects name
+        outside the hardcoded metadata-substring list (e.g. "block") would
+        silently be treated as a phenotypic trait everywhere upstream of the
+        statistics step.
+        """
+        config = VizPipelineConfig(
+            pipeline_name="test_viz",
+            data=DataConfig(csv_path="dummy.csv", additional_exclude_cols=["existing"]),
+            statistics=StatisticsConfig(fixed_effects=["block", "experiment"]),
+        )
+        assert config.data.additional_exclude_cols == [
+            "existing",
+            "block",
+            "experiment",
+        ]
+
+    def test_viz_pipeline_config_auto_exclude_dedups_overlapping_names(self):
+        """A fixed_effects name already present in additional_exclude_cols is deduped.
+
+        E.g. because it also matches the hardcoded metadata-substring list.
+        """
+        config = VizPipelineConfig(
+            pipeline_name="test_viz",
+            data=DataConfig(
+                csv_path="dummy.csv", additional_exclude_cols=["experiment"]
+            ),
+            statistics=StatisticsConfig(fixed_effects=["experiment", "block"]),
+        )
+        assert config.data.additional_exclude_cols == ["experiment", "block"]
+
+    def test_viz_pipeline_config_no_fixed_effects_leaves_additional_exclude_unchanged(
+        self,
+    ):
+        """fixed_effects=None (the default) leaves additional_exclude_cols alone.
+
+        No behavior change for existing callers.
+        """
+        config = VizPipelineConfig(
+            pipeline_name="test_viz",
+            data=DataConfig(csv_path="dummy.csv", additional_exclude_cols=["existing"]),
+        )
+        assert config.data.additional_exclude_cols == ["existing"]
+
+    def test_fixed_effect_column_excluded_from_pipeline_trait_cols(self, tmp_path):
+        """A fixed_effects column outside the hardcoded substring list is excluded.
+
+        Integration test for 7.3: e.g. "block" is excluded from trait_cols by
+        LoadDataAndImagesStep once VizPipelineConfig auto-derives the
+        exclusion, not silently treated as a trait.
+        """
+        csv_path = tmp_path / "data.csv"
+        pd.DataFrame(
+            {
+                "Barcode": [f"p{i}" for i in range(8)],
+                "Genotype": ["A"] * 4 + ["B"] * 4,
+                "Replicate": [1, 2, 3, 4] * 2,
+                "block": [1, 2, 1, 2, 1, 2, 1, 2],
+                "trait1": np.random.default_rng(0).normal(size=8),
+            }
+        ).to_csv(csv_path, index=False)
+
+        config = VizPipelineConfig(
+            pipeline_name="test_viz",
+            columns=ColumnConfig(
+                barcode="Barcode", genotype="Genotype", replicate="Replicate"
+            ),
+            data=DataConfig(csv_path=str(csv_path)),
+            statistics=StatisticsConfig(fixed_effects=["block"]),
+        )
+
+        step = LoadDataAndImagesStep()
+        result = step.execute(
+            data=None, config=config, run_dir=tmp_path, prev_result=None
+        )
+
+        assert "block" not in result.metadata["trait_cols"]
+        assert "trait1" in result.metadata["trait_cols"]
 
 
 # --- Task 2: Tests for metadata and summary ---


### PR DESCRIPTION
## Summary

Tier 2 of the wheat EDPIE cross-platform genotype-prediction program (Tier 1: BLUP extraction, #189/#190). Adds a `fixed_effects` parameter to `calculate_heritability_estimates()` so the mixed model becomes `value ~ <fixed_effects> + (1|genotype)` instead of genotype-only, fixing a heritability-inflation bug where a batch/experiment confound gets absorbed into the genotype term when genotypes aren't balanced across batches (concrete case in #114: alfalfa GWAS trait reporting H² ≈ 0.83 despite naive within-genotype ICC of 0.087–0.318).

- `calculate_heritability_estimates(fixed_effects: Optional[List[str]] = None)` — every name is `C(...)`-wrapped unconditionally (always categorical). `fixed_effects=None` (default) is byte-for-byte identical to prior behavior.
- New `_marginal_intercept()` helper: when `fixed_effects` is set, `intercept` becomes an empirical, sample frequency-weighted value rather than the raw reference-level `fe_params["Intercept"]`, so BLUP-adjusted means aren't pinned to patsy's arbitrary baseline category.
- A captured `ConvergenceWarning` (checked by category, not message text) is treated as a fit failure — only when `fixed_effects` is set — since `statsmodels` does not always raise on a fixed effect confounded with genotype.
- `StatisticsConfig.fixed_effects` (default `None`) threads through `StatisticalAnalysisStep`.
- `fixed_effects` is independent of `replicate_col` — a block/replicate fixed effect (R_j) is expressed by naming that column directly, confirming Tier 1's tentative design note.

## Process notes

This proposal went through 4 rounds of adversarial review (`openspec/changes/add-heritability-fixed-effects/design.md`) before implementation, including empirical `statsmodels` simulation that caught and fixed a synthetic oracle fixture that was silently wrong-signed. A 5-agent pre-merge review then caught and fixed:
- A real bug: `remove_low_h2=True` + `fixed_effects` could silently drop the fixed-effect column from the filtered output.
- A latent robustness gap: the marginal-intercept coefficient-matching guard was a count check, not an identity check.
- A confusing error path when a `fixed_effects` name duplicates `genotype_col`/`replicate_col`.
- A CI-fragile test tolerance on a platform-sensitive characterization test.

Full rationale for every design decision and review finding is in `design.md`.

## Test plan

- [x] Full test suite: 2644 passed, 31 skipped (`uv run pytest tests/ -m "not integration"`)
- [x] `black --check` / `ruff check` clean on all changed files
- [x] `openspec validate add-heritability-fixed-effects --strict` passes
- [x] Core oracle verified empirically against real `statsmodels` across 10+ seeds (not eyeballed) — batch-confounded fixture shows uncorrected H² > corrected H² with 4x+ margin at the worst seed
- [x] Backward compatibility: `fixed_effects=None` traced and tested as byte-for-byte identical to pre-change behavior
- [x] New regression tests for all pre-merge-review findings

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)