### PR TITLE
feat(#200): permutation-null significance test + prediction figure — Tier 4

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -1583,8 +1583,9 @@ methods present in `all_outlier_results`.
 
 Cross-platform genotype-effect prediction: leave-one-genotype-out (LOGO) cross-validated
 ridge/PLS machinery (Tier 3 of the wheat EDPIE cross-platform genotype-prediction program,
-#194). Given genotype BLUPs (or raw genotype means) estimated within one platform, tests
-whether they predict genotype effects in another platform.
+#194), plus a permutation-null significance test (Tier 4, #200). Given genotype BLUPs (or
+raw genotype means) estimated within one platform, tests whether they predict genotype
+effects in another platform, and whether that prediction is distinguishable from chance.
 
 ### Functions
 
@@ -1633,6 +1634,73 @@ result = logo_cv_predict(
     reduction_method="pls_latent",
 )
 print(result.r2, result.rmse, result.spearman_rho)
+```
+
+#### `top_quartile_recovery`
+
+```python
+top_quartile_recovery(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    q: Optional[int] = None
+) -> float
+```
+
+Fraction of the true top-`q` genotypes (ranked by `y_true`) that appear in the predicted
+top-`2q` (ranked by `y_pred`). `q` defaults to `max(1, round(len(y_true) / 4))`. Chance-level
+(random `y_pred`) expected recovery is `2*q/n` by linearity of expectation — not a fixed
+25% — varying ≈44-55% across this program's real n=15-24 scale (e.g. ≈52.6% at n=19, q=5).
+Raises `ValueError` for an explicitly-supplied `q` that is non-positive or has
+`2*q > len(y_true)`.
+
+#### `permutation_test`
+
+```python
+permutation_test(
+    X: pd.DataFrame,
+    y: np.ndarray,
+    genotypes: Sequence[str],
+    reduction_method: str = "pls_latent",
+    representative_names: Optional[Sequence[str]] = None,
+    n_permutations: int = 1000,
+    random_state: Union[int, np.random.SeedSequence, np.random.Generator] = 42
+) -> PermutationTestResult
+```
+
+Permutation-null significance test for a cross-platform LOGO-CV prediction. Self-contained:
+first calls `logo_cv_predict()` once on the real (unshuffled) `y` to populate the observed
+R²/RMSE/Spearman ρ/top-quartile-recovery, then draws `n_permutations` independent shuffles of
+`y` relative to `genotypes` (`X` and `genotypes` are never shuffled) and calls
+`logo_cv_predict()` once per shuffle to build the null distributions and one-sided p-values.
+
+**Two caveats, easy to get wrong:**
+- `p_value_r2` and `p_value_spearman_rho` are right-tailed (`count(null >= observed)` —
+  higher is better). `p_value_rmse` is **left-tailed**
+  (`count(null <= observed)` — lower is better, the opposite convention). Do not read a low
+  `p_value_rmse` as indicating a bad fit.
+- `random_state` accepts `int`/`numpy.random.SeedSequence` reproducibly (the same input
+  always reproduces the same null draws), but a passed-in `numpy.random.Generator` instance
+  is **stateful** — reusing the *same* `Generator` instance across two calls will **not**
+  reproduce identical results, since its internal state has advanced between calls.
+
+Raises `ValueError` if `n_permutations` is not positive (before any `logo_cv_predict` call);
+if the observed-value call itself raises (e.g. invalid `reduction_method`); if a constant
+(zero-variance) `y` produces a non-finite observed `spearman_rho`/`top_quartile_recovery`
+(raised before any permutation is drawn); or if any permutation produces a non-finite null
+value (raised only after all `n_permutations` complete, naming the metric and permutation
+index).
+
+**Example:**
+```python
+result = permutation_test(
+    X=source_blup_table,
+    y=target_blup_table["target_trait"].values,
+    genotypes=source_blup_table.index.tolist(),
+    reduction_method="pls_latent",
+    n_permutations=1000,
+    random_state=42,
+)
+print(result.observed_r2, result.p_value_r2, result.p_value_rmse)
 ```
 
 ---

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -8,6 +8,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `permutation_test(X, y, genotypes, reduction_method="pls_latent",
+  representative_names=None, n_permutations=1000, random_state=42)` and
+  `top_quartile_recovery(y_true, y_pred, q=None)` (#200): a permutation-null
+  significance test for cross-platform LOGO-CV prediction, closing the gap
+  Tier 3 Decision 9 flagged (`spearman_p`'s asymptotic p-value is unreliable
+  below n≈20-30). Self-contained: computes the observed R²/RMSE/Spearman ρ/
+  top-quartile-recovery via one `logo_cv_predict()` call, then null
+  distributions via `n_permutations` shuffled-`y` calls. One-sided p-values
+  are right-tailed for R²/ρ (higher is better) and **left-tailed** for RMSE
+  (lower is better — the opposite convention). `top_quartile_recovery`'s
+  chance-level baseline is `2*q/n`, not a fixed 25%. Serializable
+  `PermutationResult` / `CrossPlatformPermutationResult` dataclasses and
+  `CrossPlatformPermutationResult.from_permutation_test_results(...)` adapter,
+  mirroring `TargetPrediction`/`CrossPlatformPredictionResult`'s pattern.
+- `VisualizePredictionStep`, an optional 7th task on `CrossPlatformPipeline`
+  (#200), gated on `PredictionConfig.visualize` (requires `enabled=True`
+  too): runs `permutation_test()` for every `(target, method)` combination
+  via `joblib.Parallel` across independent targets (parallelizing individual
+  permutation calls measured *slower* than serial — empirically verified,
+  not assumed), saves one `07_permutation_<method>.json` per method, and a
+  composite 3-panel `07_prediction_figure.png` per pair (PC1 obs-vs-pred
+  scatter, all-targets R²-vs-pooled-null violin, top-quartile-recovery bar
+  chart) from the primary `reduction_method`'s results. Additive extension to
+  `PredictCrossPlatformStep`'s `StepResult.data` (`predictor_matrices` key)
+  lets this step reuse task 6's already-computed matrices instead of
+  rebuilding BLUP-loading/alignment logic. Tier 4 of the cross-platform
+  genotype-prediction program (Tier 3: #194, Tier 3.5: #196).
 - `PredictionConfig` (nested on `CrossPlatformConfig` as `prediction`, default
   disabled) and `PredictCrossPlatformStep`, an optional 6th task on
   `CrossPlatformPipeline` (#196): wires Tier 3's `logo_cv_predict`/

--- a/docs/CROSS_PLATFORM_ANALYSIS.md
+++ b/docs/CROSS_PLATFORM_ANALYSIS.md
@@ -974,8 +974,10 @@ hardcoded lookup — see `tests/test_cross_platform_prediction.py`'s
 
 Tier 3.5 (issue #196) wires this machinery into `CrossPlatformPipeline` itself, as
 an optional 6th step — `PredictCrossPlatformStep` — on the same per-pair
-`cross-platform` command already used for correlation. The permutation null and
-its figures (Tier 4) remain a separate, later change.
+`cross-platform` command already used for correlation. Tier 4 (issue #200) adds
+a permutation-null significance test and a summary figure — see
+[Permutation-Null Significance Test & Figure](#permutation-null-significance-test--figure)
+below.
 
 ### Configuration
 
@@ -1021,6 +1023,88 @@ plus each of `comparison_methods`), holding a `CrossPlatformPredictionResult`
 with one entry per prediction target — the target platform's cluster-
 representative traits, plus a `PC1` entry.
 
+### Permutation-Null Significance Test & Figure
+
+Tier 4 of the cross-platform genotype-prediction program (issue #200) answers
+the question the observed R²/RMSE/ρ above cannot: is a given prediction
+distinguishable from chance at n≈19 genotypes? `spearman_p`'s asymptotic
+p-value (`scipy.stats.spearmanr`'s default) is documented as unreliable below
+n≈20-30 — `permutation_test()` closes that gap empirically, by refitting the
+same LOGO-CV procedure on many random relabelings of the target and comparing
+the observed value's rank against that empirical null distribution.
+
+```python
+from sleap_roots_analyze import permutation_test, top_quartile_recovery
+
+result = permutation_test(
+    X=source_platform_blup_table,
+    y=target_platform_blup_table["target_trait"].values,
+    genotypes=source_platform_blup_table.index.tolist(),
+    reduction_method="pls_latent",
+    n_permutations=1000,
+    random_state=42,
+)
+print(result.observed_r2, result.p_value_r2, result.p_value_rmse)
+
+recovery = top_quartile_recovery(y_true, y_pred)  # q defaults to round(n/4)
+```
+
+`permutation_test()` is self-contained: it computes the observed value itself
+(one `logo_cv_predict()` call) before drawing `n_permutations` shuffled-`y`
+calls for the null distributions — a caller does not need a separate
+`logo_cv_predict()` call first. Two caveats worth knowing before using it
+directly:
+
+- **`p_value_r2`/`p_value_spearman_rho` are right-tailed (higher is better);
+  `p_value_rmse` is left-tailed (lower is better) — the opposite convention.**
+  Do not read a low `p_value_rmse` as indicating a bad fit.
+- **`random_state` accepts `int`/`numpy.random.SeedSequence` reproducibly**
+  (the same input always reproduces the same null draws), but a passed-in
+  `numpy.random.Generator` instance is stateful — reusing the *same* instance
+  across two calls will **not** reproduce identical results.
+
+`top_quartile_recovery`'s chance-level (random `y_pred`) baseline is `2*q/n`,
+not a fixed 25% — it varies ≈44-55% across this program's real per-pair
+genotype counts (n≈15-24), e.g. ≈52.6% at n=19, q=5. The *empirically measured*
+null (a real LOGO-CV null, not a uniformly-random `y_pred`) can differ
+measurably from that theoretical figure — e.g. ≈44.3% on this program's own
+synthetic pure-noise oracle fixture at n=19 — so always verify the empirical
+null for your actual data rather than asserting against the theoretical
+baseline alone.
+
+`VisualizePredictionStep`, an optional 7th step on `CrossPlatformPipeline`,
+runs `permutation_test()` for every `(target, method)` combination and builds
+a 3-panel summary figure. Enable it by adding `visualize: true` (plus the 3
+permutation-specific fields below) to an existing `prediction:` block —
+`visualize=True` requires `enabled=True` too:
+
+```yaml
+prediction:
+  enabled: true
+  # ... existing fields (predictor_source, reduction_method, etc.) ...
+  visualize: true                    # false by default
+  n_permutations: 1000               # default; 1000 shuffled-y calls per target/method
+  permutation_random_state: 42       # default; seeds an independent draw per (target, method)
+  permutation_n_jobs: 8              # default; joblib.Parallel workers, across targets
+```
+
+**Parallelization**: individual permutation calls are too fast (tens of
+milliseconds) for process-based parallelism to pay off — empirically measured
+*slower* than serial. `joblib.Parallel` instead parallelizes across
+independent `(target, method)` units, each running its own full,
+`n_permutations`-length loop. Verified against real EDPIE data (issue #200
+Section 11): the worst-case pair (Turface19→Cylinder, ~129 representative
+targets) completed this step in **~13 minutes** at `n_jobs=8` on a 16-core
+machine, well under the program's 30-minute feasibility gate.
+
+Output: one `07_permutation_<method>.json` file per method (same
+`reduction_method`/`comparison_methods` set as task 6's
+`06_prediction_<method>.json`), holding a `CrossPlatformPermutationResult`;
+and one `07_prediction_figure.png` per pair, built from only the primary
+`reduction_method`'s results — a PC1 observed-vs-predicted scatter, an
+all-targets observed-R²-vs-pooled-null-R² violin, and a top-quartile-recovery
+bar chart (mean observed vs. mean null).
+
 ### Current Limitations
 
 - The `PC1` target's computation (`sklearn.decomposition.PCA` via
@@ -1040,5 +1124,6 @@ representative traits, plus a `PC1` entry.
   `06_prediction_<method>.json`'s genotype count against each platform's own
   genotype count if this matters for your analysis.
 - `CrossPlatformSummaryGenerator`/`/cross-platform-summary` does not yet
-  surface prediction results — tracked as follow-up
+  surface prediction results — nor permutation-test/figure results (Tier 4) —
+  tracked as follow-up
   [#197](https://github.com/talmolab/sleap-roots-analyze/issues/197).

--- a/docs/superpowers/specs/2026-07-16-prediction-permutation-and-figure-design.md
+++ b/docs/superpowers/specs/2026-07-16-prediction-permutation-and-figure-design.md
@@ -1,0 +1,216 @@
+# Design: Prediction Permutation Null & Figure Delivery (Tier 4)
+
+**Status:** Approved for OpenSpec proposal drafting.
+**Program:** Wheat EDPIE cross-platform genotype-prediction program (Tier 4 of 0-4).
+**External context:** `c:\vaults\sleap-roots\wheat-edpie-paper\cross-platform-prediction\{roadmap,theory}.md`.
+**Tracking issue:** not yet filed — draft during this tier's OpenSpec proposal, get Elizabeth's
+go-ahead, then file cross-referencing epic #49 (no new epic), matching Tier 3/3.5's precedent.
+
+## Why
+
+Tier 3 (`add-cross-platform-prediction`, merged #195) shipped `logo_cv_predict()`,
+`fit_pca_on_fold()`, and `CrossPlatformPredictionResult` as stateless Python-API functions,
+deliberately written to support a future permutation loop without refactoring (Tier 3's own
+Decision 3). Tier 3.5 (`add-prediction-pipeline-step`, merged #199) wired the observed
+(non-permuted) prediction into `CrossPlatformPipeline` as an optional `PredictCrossPlatformStep`.
+
+Neither tier delivers statistical significance (is a given R² distinguishable from chance at
+n≈19?) or a paper-ready figure. This tier closes both gaps: a permutation-null significance test
+(Python API, hard-depends on Tier 3 only) and `VisualizePredictionStep` (a new optional pipeline
+step, soft-depends on Tier 3.5) that renders a 3-panel figure per directed pair.
+
+## Goals / Non-Goals
+
+- **Goals:** `permutation_test()` and `top_quartile_recovery()` (Python API, `cross_platform_
+  prediction.py`); `PermutationResult`/`CrossPlatformPermutationResult` (`result_types.py`);
+  a `joblib.Parallel`-based runtime strategy verified to fit the roadmap's 30-minute feasibility
+  gate at real EDPIE scale; `VisualizePredictionStep` as an optional 7th pipeline task; a
+  3-panel `prediction_figure.png` per pair; `theory.md`'s permutation-null pseudo-code addendum
+  (Tier 0 erratum, this tier's contribution).
+- **Non-Goals:** any change to `logo_cv_predict`, `fit_pca_on_fold`, `CrossPlatformPredictionResult`,
+  or `PredictCrossPlatformStep`'s existing (Tier 3.5) behavior/outputs — only additive extensions;
+  any change to `CrossPlatformSummaryGenerator` (still #197's territory); any change to
+  `/configure-run-all`/`/dry-run`/`/validate-config` (still #198's territory, pre-existing).
+
+## Section 1: Python-API additions (Tier 3 module, no pipeline dependency)
+
+`cross_platform_prediction.py` (Tier 3's existing, stateless module) gains:
+
+- **`permutation_test(X, y, genotypes, reduction_method="pls_latent", representative_names=None,
+  n_permutations=1000, random_state=42) -> PermutationResult`.** Shuffles `y` relative to
+  `genotypes` `n_permutations` times (a fixed, seeded `numpy.random.Generator`, one independent
+  shuffle per iteration), calling `logo_cv_predict()` once per shuffle (each call already runs the
+  internal 19-fold LOGO-CV loop — "N=1000 permutations" means 1000 `logo_cv_predict` calls, not
+  1000×19). Returns the full null distributions for R², RMSE, and Spearman ρ, plus one-sided
+  p-values for each (`p = (#null ≥ observed + 1) / (n_permutations + 1)`).
+- **`top_quartile_recovery(y_true, y_pred, q=None) -> float`.** The roadmap's settled metric:
+  fraction of the true top-`q` genotypes (by `y_true`) that appear in the predicted top-`2q` (by
+  `y_pred`). `q` defaults to `round(n / 4)`. Used for both the observed value (on real LOGO-CV
+  predictions) and, per-permutation, the null distribution.
+
+`result_types.py` gains:
+
+- **`PermutationResult`** (frozen dataclass, same finite-floats/`to_json` convention as
+  `LOGOCVResult`/`TargetPrediction`): `target_name`, `observed_r2`/`rmse`/`spearman_rho`/
+  `top_quartile_recovery`, `null_r2`/`null_rmse`/`null_spearman_rho`/`null_top_quartile_recovery`
+  (each length `n_permutations`), `p_value_r2`/`p_value_rmse`/`p_value_spearman_rho`,
+  `n_permutations`.
+- **`CrossPlatformPermutationResult`** (mirrors `CrossPlatformPredictionResult`):
+  `source_platform`, `target_platform`, `reduction_method`, `predictions: list[PermutationResult]`.
+  Kept **separate** from (not nested inside) `CrossPlatformPredictionResult` — permutation is
+  optional and heavier than the observed-result concern; a caller who only wants observed values
+  should not need to know permutation exists.
+
+## Section 2: Parallelization strategy & runtime
+
+Empirically measured this session, using the real `logo_cv_predict` on a `(19, 15)` synthetic
+matrix:
+
+- Individual `logo_cv_predict` calls cost ~16ms (`pls_latent`/`representatives`) to ~27ms (`pc1`).
+- Parallelizing **individual permutation calls** via `joblib.Parallel` (`loky` backend, batched or
+  unbatched) is **slower than serial** at every tested `n_jobs` (4/8/16) — worker spawn/pickling
+  overhead dwarfs a ~16-20ms task.
+- Parallelizing **across independent targets** (each worker runs one target's own full,
+  serial 1000-permutation loop — a ~16s unit of work per target) measured **3.85× speedup at
+  `n_jobs=8`** on this 16-core machine; more workers (`n_jobs=16`) get worse, not better
+  (oversubscription).
+
+Applying the `n_jobs=8`/per-target strategy to the worst real case (Cylinder-as-target pair has
+~129 representative traits per Tier 3.5's Section 8 manual validation; both the primary
+`reduction_method` and one `comparison_methods` entry; N=1000; all 4 directed pairs):
+
+| | Serial | Parallel (n_jobs=8, per-target) |
+|---|---|---|
+| Total estimated wall time | ~105.5 min | **~27.4 min** |
+
+This is under the roadmap's 30-minute feasibility gate, but not by a wide margin — flagged as a
+risk (see Risks) to re-verify against real Cylinder-scale data (hundreds of raw traits before
+clustering, not this session's 15-trait synthetic benchmark) during this tier's manual validation.
+
+**Design:** `PredictionConfig.permutation_n_jobs: int = 8` (not `-1`/all-cores — matches the
+measured optimum for this workload shape, not a generic "use all cores" default).
+`VisualizePredictionStep` calls `joblib.Parallel(n_jobs=config.prediction.permutation_n_jobs)`
+over the full list of `(target_name, method)` units, each invoking `permutation_test()` once (that
+function's own internal loop stays serial). `joblib` becomes a direct import (previously only a
+transitive `scikit-learn` dependency) — add it explicitly to `pyproject.toml`'s dependency list
+rather than relying on the transitive pin.
+
+`theory.md` (Tier 0) gets a new section: permutation-null pseudo-code (matching its existing
+LOGO-CV/per-fold-PCA pseudo-code style), documenting the shuffle-and-refit procedure and the
+per-target (not per-permutation) parallelization strategy above, since this session's benchmark
+result is a genuinely counter-intuitive lesson (the "obvious" parallelization axis is the wrong
+one) worth carrying forward for any future tier that loops `logo_cv_predict`.
+
+## Section 3: Pipeline wiring
+
+**Extend `PredictCrossPlatformStep`** (Tier 3.5, already merged) additively: `StepResult.data`
+gains a new key, `predictor_matrices`, holding the already-computed `source_clean`/`target_clean`
+DataFrames and `source_representative_names`/`target_representatives` (all computed during task
+6's own execution, previously discarded after use). No existing `data`/`metadata`/
+`files_generated` key changes shape — fully backward-compatible with every Tier 3.5 test.
+
+**New `VisualizePredictionStep`** (`pipeline/steps/visualize_prediction.py`), optional 7th task on
+`CrossPlatformPipeline`. `depends_on=["06_predict_cross_platform"]` — for both data *and*
+ordering this time (unlike Tier 3.5 Decision 15's ordering-only second dependency; this step
+genuinely reads task 6's `predictor_matrices` and observed results). Entirely absent from
+`create_tasks()` unless `config.prediction.visualize` is `True` (not merely skipped — matching
+Tier 3.5's `enabled`-gating precedent).
+
+Step behavior:
+1. Read `predictor_matrices` and the observed `CrossPlatformPredictionResult`(s) from task 6.
+2. For every `(target_name, method)` combination (both `reduction_method` and every
+   `comparison_methods` entry), run `permutation_test()` via the `joblib.Parallel`-over-targets
+   strategy from Section 2.
+3. Save one `CrossPlatformPermutationResult` JSON per method: `07_permutation_<method>.json`.
+4. Build the composite 3-panel figure (Section 4) using only the **primary** `reduction_method`'s
+   results (not every `comparison_methods` entry), save `07_prediction_figure.png`.
+
+**Config** — new fields nested on `PredictionConfig` (not a new sibling config — `visualize` only
+ever makes sense when `enabled=True`, so a separate config would just recreate the same gate):
+`visualize: bool = False`, `n_permutations: int = 1000`, `permutation_random_state: int = 42`,
+`permutation_n_jobs: int = 8`. `CrossPlatformConfig.__post_init__` gains one more cross-check:
+`visualize=True` with `enabled=False` raises `ValueError` at construction time — same plain-
+`ValueError` convention as every other Tier 3.5 validation (no new exception type).
+
+## Section 4: Figure content & oracle strategy
+
+**Figure content.** New module `sleap_roots_analyze/visualize_prediction.py` (parallel to
+`cross_experiment_analysis.py`'s home for `create_correlation_summary_plot` etc. — plotting logic
+as plain, independently-testable functions; the Step only orchestrates + saves), with
+`create_prediction_figure(...) -> matplotlib.Figure`, 3 subplot panels:
+
+1. **Obs-vs-pred scatter** — PC1 target only (single scalar per genotype, comparable across all 4
+   pairs), one point per genotype, from the primary method's observed `CrossPlatformPredictionResult`.
+2. **CV-R²-vs-null strip/violin** — every representative-trait target's observed R² plotted as
+   points/strip, overlaid on a violin of the *pooled* null R² distribution (every target's
+   permutation null combined into one set) for the primary method — gives the reader the whole
+   real-vs-null picture in one glance, motivated by the "for the paper" full per-trait scope.
+3. **Top-quartile recovery bar chart** — 2 bars: mean observed recovery rate across all targets vs.
+   the corresponding mean null expectation.
+
+Saved as `run_dir / "07_prediction_figure.png"` (`dpi=300, bbox_inches="tight"`, matching
+`visualize_cross_platform.py`'s existing convention exactly). One figure per pair (not one per
+method) — `comparison_methods` still get full permutation JSON data (Section 3, step 3) for the
+paper's numeric tables/appendix, just not their own PNG.
+
+**Oracles** (concretizing the roadmap's Tier 4 row):
+
+- **Permutation p-value uniformity.** A K-S calibration test: run `permutation_test()` on ~30-50
+  independent pure-noise fixtures (real `X`, unrelated `y`), collect the resulting p-values,
+  K-S-test them against `Uniform(0,1)`, assert `p > 0.05`. Uses a reduced `n_permutations` (e.g.
+  200) to stay CI-fast — distinct from the `n_permutations=1000` production default, mirroring
+  Tier 3.5's CI-fast-synthetic-fixture-vs.-manual-validation split.
+- **Signal separation.** Reuses Tier 3's N=20-seed-averaged planted-signal/noise fixtures (Tier 3
+  Decision 6's precedent — a single realization's LOGO-CV R² is too noisy at n≈19 to pin a
+  threshold against). Assert mean signal R² is comfortably above that signal fixture's own
+  permutation-null median; assert mean noise-fixture R² falls within its own null's
+  median ± 1σ.
+- **Top-quartile recovery.** Same planted-signal/noise fixtures: assert ≥80% (signal) vs. an
+  **empirically-verified** null expectation — the roadmap's "≈25%" is a starting estimate, not a
+  value to pin blind; verify the real number via actual computation during implementation, per
+  this program's established "don't assume, verify" convention (Tier 3 Decision 6's own precedent
+  of catching a wrong assumed R² this same way).
+- **Figure provenance.** PNG exists, non-empty, and a hash/timestamp check confirms it was
+  regenerated from the current run's input CSVs (not stale from a prior run) — a CI-fast
+  synthetic-fixture check, following Tier 3.5's golden-fixture-snapshot pattern.
+
+## Risks / Trade-offs
+
+- **27.4-minute estimate is close to the 30-minute gate and extrapolated from a small synthetic
+  fixture (`n_traits=15`), not real Cylinder-scale data (hundreds of raw traits pre-clustering).**
+  Must be re-measured against real EDPIE data during this tier's manual validation (Section-8-
+  equivalent) before merge; if real timing exceeds 30 minutes, the fallback is documented here:
+  reduce `n_jobs` search further, or scope the pipeline-computed permutation (not the Python-API
+  function itself) to primary-method-only (drop the `comparison_methods` sweep from the
+  per-pipeline-run permutation JSON, keeping it available via direct Python-API calls for anyone
+  who wants it), roughly halving the estimate.
+- **`joblib` becomes a direct dependency**, not merely transitive via `scikit-learn`. Low risk
+  (already vendored, already imported transitively everywhere `scikit-learn` is used) but is a
+  `pyproject.toml` change worth calling out explicitly, since the roadmap's Goal section states
+  "no new dependencies" for the overall program.
+- **Full per-trait permutation scope (chosen for the paper) produces large JSON files** for
+  Cylinder-target pairs (~129 targets × 1000 null values × 3 metrics ≈ 387,000 floats per
+  method-pair). Acceptable for a research artifact, but worth noting these JSONs will be
+  meaningfully larger than Tier 3.5's `06_prediction_<method>.json` files.
+- **Pooling all targets' null R² into one violin (figure panel 2) discards per-target null
+  identity** — a reader cannot tell from the figure alone which specific traits' nulls contribute
+  to which part of the pooled distribution. Acceptable since the full per-target breakdown remains
+  available in the `07_permutation_<method>.json` files for anyone who needs it; the figure is a
+  summary view, not the complete record.
+
+## Testing Plan (outline — full breakdown belongs in tasks.md)
+
+1. `permutation_test()`/`top_quartile_recovery()` unit tests (input validation, determinism given
+   a fixed seed, shape/length contracts) — Python API, no pipeline dependency.
+2. `PermutationResult`/`CrossPlatformPermutationResult` serialization round-trip tests, matching
+   the `to_json`/finite-floats-contract pattern of every sibling result type.
+3. The four oracle tests from Section 4 above (K-S calibration, signal separation, top-quartile
+   recovery, figure provenance).
+4. `PredictCrossPlatformStep`'s additive `predictor_matrices` extension — a backward-compat
+   regression test confirming existing `data`/`metadata`/`files_generated` keys are unchanged.
+5. `VisualizePredictionStep` wiring tests (task presence/absence gated by `visualize`,
+   `visualize=True` + `enabled=False` rejected, joblib parallelization produces identical results
+   to a serial reference run for a small fixture, JSON + PNG both produced).
+6. `CrossPlatformPipeline` task-list tests (7th task present/absent).
+7. Manual, non-CI, real-EDPIE-data validation (Section-8-equivalent) — including the real-scale
+   runtime re-measurement flagged in Risks, before merge.

--- a/docs/superpowers/specs/2026-07-16-prediction-permutation-and-figure-design.md
+++ b/docs/superpowers/specs/2026-07-16-prediction-permutation-and-figure-design.md
@@ -212,6 +212,47 @@ paper's numeric tables/appendix, just not their own PNG.
   available in the `07_permutation_<method>.json` files for anyone who needs it; the figure is a
   summary view, not the complete record.
 
+## Section 5: Manual real-data validation gate (non-CI, pre-merge, sign-off required)
+
+Following Tier 3's Section 8 and Tier 3.5's Section 8 precedent exactly: a non-CI validation task
+against real EDPIE data, required before merge, with Elizabeth's explicit sign-off — not merely a
+CI-green signal. This is also where this design's biggest open risk (the 27.4-minute estimate,
+Section 2/Risks) gets resolved with real numbers instead of a synthetic-fixture extrapolation.
+
+1. **Build/reuse real inputs.** Reuse Tier 3.5's Section 8 real BLUP tables and 4 directed-pair
+   `CrossPlatformConfig` YAMLs (`pipeline_runs/section8_manual_validation_20260716/`) if still
+   valid; rebuild via the same non-committed script pattern if the underlying QC vintage has moved.
+   Extend each YAML's `prediction:` block with `visualize: true`, `n_permutations: 1000`,
+   `permutation_n_jobs: 8` (the design defaults — no per-run override needed unless the timing
+   check below says otherwise).
+2. **Run all 4 directed pairs** through the full 7-task pipeline (`sleap-roots-analyze
+   cross-platform <config>.yaml`), including `Turface19→Cylinder` — the worst-case pair (Cylinder
+   as target, ~129 representative traits per Tier 3.5's own Section 8 finding).
+3. **Re-measure real wall time**, per pair and total, and record it here (superseding the
+   synthetic-fixture-derived 27.4-minute estimate). If any pair — or the total — exceeds the
+   roadmap's 30-minute gate, apply one of the documented fallbacks (Risks section) *before*
+   proceeding to sign-off, not after.
+4. **Sanity-check permutation-based p-values against Tier 3.5's Section 8.2/8.3 findings**, which
+   used `scipy.stats.spearmanr`'s asymptotic p-value (documented, per Tier 3 Decision 9, as
+   imprecise below n≈20-30 — exactly the gap Tier 4's permutation null exists to close). In
+   particular: do the handful of nominally-significant real hits Tier 3.5 found (e.g.
+   Cylinder→Field `Root Count 20cm`, asymptotic R²=0.25/ρ=+0.49/p=0.033; Turface19→Cylinder
+   `Seminal Angles Proximal Max Max`, asymptotic R²=0.38/ρ=+0.62/p=0.004) still look significant
+   under the permutation-based p-value? A large divergence between asymptotic and permutation
+   p-values on these specific, already-flagged targets would be a meaningful finding for the paper,
+   not just a sanity check.
+5. **Cross-check against Tier 3.5's Section 8.5 multiple-testing/power caveat** (raw p<0.05 count
+   63/354, FDR-corrected count 9/354, all 9 negative ρ). Does permutation-based inference reinforce
+   or change that caveat's conclusion? Record the answer — this is the kind of finding this
+   program's own Section 8 process has surfaced before (Tier 3.5's own vintage-correction and
+   `Computation.Time.s`-exclusion fixes both came from exactly this kind of close manual look).
+6. **Visually inspect all 4 `07_prediction_figure.png` outputs** for legibility and correctness
+   (readable axis labels/titles, PC1 scatter shows genotype-level points, violin/strip panel shows
+   a visible real-vs-null gap or lack thereof, bar chart's two bars are distinguishable).
+7. **Sign-off requirement:** findings presented to Elizabeth; this task is not complete until she
+   has reviewed and explicitly signed off, mirroring Tier 3/3.5's `/pre-merge-check` gate — a green
+   CI run is necessary but not sufficient.
+
 ## Testing Plan (outline — full breakdown belongs in tasks.md)
 
 1. `permutation_test()`/`top_quartile_recovery()` unit tests (input validation, determinism given
@@ -228,5 +269,4 @@ paper's numeric tables/appendix, just not their own PNG.
    `PermutationResult`'s `observed_*` fields exactly reproduce task 6's already-reported
    `TargetPrediction` values for the same target/method).
 6. `CrossPlatformPipeline` task-list tests (7th task present/absent).
-7. Manual, non-CI, real-EDPIE-data validation (Section-8-equivalent) — including the real-scale
-   runtime re-measurement flagged in Risks, before merge.
+7. Section 5's manual real-data validation gate, non-CI, before merge — see above.

--- a/docs/superpowers/specs/2026-07-16-prediction-permutation-and-figure-design.md
+++ b/docs/superpowers/specs/2026-07-16-prediction-permutation-and-figure-design.md
@@ -42,11 +42,25 @@ step, soft-depends on Tier 3.5) that renders a 3-panel figure per directed pair.
   shuffle per iteration), calling `logo_cv_predict()` once per shuffle (each call already runs the
   internal 19-fold LOGO-CV loop — "N=1000 permutations" means 1000 `logo_cv_predict` calls, not
   1000×19). Returns the full null distributions for R², RMSE, and Spearman ρ, plus one-sided
-  p-values for each (`p = (#null ≥ observed + 1) / (n_permutations + 1)`).
+  p-values for each (`p = (#null ≥ observed + 1) / (n_permutations + 1)`). Each permutation's
+  `top_quartile_recovery` null value (see below) is computed with that permutation's *shuffled* `y`
+  as ground truth against that same call's LOGO-CV predictions — not the original, unshuffled `y`
+  — so the null reflects chance-level recovery under the shuffled labeling, not recovery of the
+  real ranking.
 - **`top_quartile_recovery(y_true, y_pred, q=None) -> float`.** The roadmap's settled metric:
   fraction of the true top-`q` genotypes (by `y_true`) that appear in the predicted top-`2q` (by
   `y_pred`). `q` defaults to `round(n / 4)`. Used for both the observed value (on real LOGO-CV
   predictions) and, per-permutation, the null distribution.
+
+`permutation_test()` is self-contained: given the *real* (unshuffled) `y`, it first calls
+`logo_cv_predict(X, y, genotypes, reduction_method, representative_names)` once to populate
+`observed_r2`/`rmse`/`spearman_rho`/`top_quartile_recovery`, then runs the `n_permutations` shuffled
+calls for the null distributions — a caller gets a complete result from one call, without needing
+a separate `logo_cv_predict()` call first for convenience. In `VisualizePredictionStep`, this
+observed value is expected to exactly reproduce task 6's already-reported `TargetPrediction`
+(both call `logo_cv_predict` with identical inputs) — the wiring test in the Testing Plan below
+cross-checks this, the same "wiring correctness, not just existence" pattern as Tier 3.5's own
+Section 6 oracle.
 
 `result_types.py` gains:
 
@@ -210,7 +224,9 @@ paper's numeric tables/appendix, just not their own PNG.
    regression test confirming existing `data`/`metadata`/`files_generated` keys are unchanged.
 5. `VisualizePredictionStep` wiring tests (task presence/absence gated by `visualize`,
    `visualize=True` + `enabled=False` rejected, joblib parallelization produces identical results
-   to a serial reference run for a small fixture, JSON + PNG both produced).
+   to a serial reference run for a small fixture, JSON + PNG both produced, and each
+   `PermutationResult`'s `observed_*` fields exactly reproduce task 6's already-reported
+   `TargetPrediction` values for the same target/method).
 6. `CrossPlatformPipeline` task-list tests (7th task present/absent).
 7. Manual, non-CI, real-EDPIE-data validation (Section-8-equivalent) — including the real-scale
    runtime re-measurement flagged in Risks, before merge.

--- a/openspec/changes/add-prediction-permutation-and-figure/design.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/design.md
@@ -446,10 +446,12 @@ implementation began. 5 BLOCKING and 11 IMPORTANT findings, reconciled as follow
 - **IMPORTANT — `CrossPlatformPermutationResult`'s requirement was missing the "no sklearn/numpy
   object" parity scenario** its sibling `CrossPlatformPredictionResult` requirement has. Fixed:
   added to the `serializable-result-types` spec delta, with a corresponding test (tasks.md 3.3a).
-- **SUGGESTION — Section 2 (14 tasks) and Section 6 (8 tasks) were too coarse for this program's
-  established per-commit granularity.** Fixed: both split, with explicit commit-boundary notes
-  (Section 2: `top_quartile_recovery` vs. `permutation_test`; Section 6: wiring/reuse →
-  parallelization → JSON/figure I/O).
+- **SUGGESTION — Section 2 (14 tasks) and the step section (8 tasks; numbered 6 at the time of
+  this fix, renumbered to 7 — specifically 7a/7b/7c — by round 2's Section 6/7 restructuring; this
+  cross-reference itself went stale and was corrected during round 4's own staleness sweep) were
+  too coarse for this program's established per-commit granularity.** Fixed: both split, with
+  explicit commit-boundary notes (Section 2: `top_quartile_recovery` vs. `permutation_test`; the
+  step section: wiring/reuse → parallelization → JSON/figure I/O).
 - **SUGGESTION — no boundary scenario for `top_quartile_recovery` when `q` rounds to 0 or exceeds
   `n/2`.** Fixed: added to the `cross-platform-prediction` spec, with a corresponding test
   (tasks.md 2.3a).
@@ -674,3 +676,93 @@ statistical bug) + 1 new BLOCKING-adjacent implementation risk — severity has 
 diminished round-over-round the way Tiers 3/3.5's own review history did. Each round has still
 found at least one substantive, non-cosmetic defect. A fourth round is recommended before treating
 this as settled, rather than stopping here on volume alone.
+
+## Adversarial Review Reconciliation (round 4)
+
+A fourth, independent round of the same 5-agent review (run fresh, with no memory of rounds 1-3)
+independently re-derived and re-confirmed round 3's RMSE fix from first principles (two reviewers
+worked a concrete numeric example — a good low-RMSE result under the correct left-tail formula
+gives `p≈0.09`; under the buggy right-tail formula it gives `p≈1.0` — and both concluded the fixed
+spec is now statistically correct), re-verified the 20-scenario MODIFIED requirement a 4th time
+with zero drift, re-confirmed the `Generator` reproducibility caveat against real numpy behavior a
+second time, and found **no new regressions** in anything fixed by rounds 1-3. But two reviewers
+**independently** surfaced the same new, real gap — the strongest possible corroboration signal
+this program's process has produced — plus two reviewers independently found that one of round 3's
+own new oracle tests doesn't actually test what its own description claims:
+
+- **IMPORTANT (new, corroborated independently by 2 of 5 reviewers) — the non-finite-value guard
+  covered only null values, never the observed value.** `permutation_test()`'s entire design
+  premise (Decision 1) is that it's self-contained for direct Python-API use, with no upstream
+  pipeline guard to rely on — but a caller passing a constant `y` (legal per `logo_cv_predict`'s
+  own documented contract) would get a non-finite `observed_spearman_rho` that was never scanned,
+  crashing unnamed at `to_json()` — the exact failure mode the null-side guard (round 1) was built
+  to prevent, just on the other side of the same function. Fixed: the Permutation Test requirement
+  now scans observed values first (cheap, fails immediately, before wasting `n_permutations` calls
+  on unusable input), then the null distributions as before; a new scenario and task (2.13b) cover
+  it.
+- **IMPORTANT (new, corroborated independently by 2 of 5 reviewers) — task 9.1a's K-S calibration
+  test for `p_value_rmse` has zero detection power for the exact regression it was added to guard.**
+  Both reviewers independently derived the same symmetry argument: under a pure-noise null, the
+  observed value's rank among the null draws is uniform regardless of which tail the p-value
+  formula uses, so a correct left-tail formula and an incorrectly-reverted right-tail formula both
+  pass a K-S-against-`Uniform(0,1)` test identically — pure noise has no asymmetry for either
+  formula to get wrong. Only 9.2a (a genuinely low-RMSE *signal* result must read as significant)
+  actually depends on the tail direction. Fixed: 9.1a's task text now states explicitly that it
+  verifies calibration only, not direction, and points to 9.2a as the real direction guard — so a
+  future maintainer doesn't mistake 9.1a passing as evidence the direction is still correct.
+- **IMPORTANT (new) — task 2.11's "(etc.)" wording, if implemented literally, would test the wrong
+  (right-tail) formula for RMSE**, directly contradicting the fixed spec and 9.2a. Fixed: split
+  into 2.11 (R²/ρ, right-tail) and 2.11a (RMSE, explicit left-tail), removing the "(etc.)"
+  generalization that caused the ambiguity.
+- **IMPORTANT (new) — the Section 7a `permutation_n_jobs=1` mocking-across-process-boundary note
+  (added round 3) didn't cover 7c.5/7c.6**, which also monkeypatch `logo_cv_predict`/
+  `permutation_test` to inject a failing result, the same pattern the note was written to protect
+  against. Fixed: both tasks now explicitly require the same pinning; the Section 7a note's
+  applies-to list extended to include them.
+- **IMPORTANT (new) — task 9.6's "measure and record wall time" named an outcome with no concrete
+  mechanism**, risking the same kind of vague, unfalsifiable instruction this program's own
+  process exists to catch. Fixed: pinned to reading the `tests` CI job's own `pytest --durations`
+  output per OS — no new tooling needed, already part of the standard `uv run pytest` invocation.
+- **SUGGESTION (new) — the CI-time estimate note (added round 3) didn't fold 9.1a/9.2a into its
+  arithmetic**, understating the total by roughly one test's worth of compute. Fixed: recomputed
+  to ~9 minutes (from ~8), noting 9.2a adds no extra `permutation_test` calls of its own (it reads
+  an already-computed value from 9.2's fixture run).
+- **SUGGESTION (new) — one stale "Section 6" cross-reference survived round 3's own staleness
+  sweep** (a round-1 SUGGESTION bullet about commit granularity). Fixed in place, with a note
+  explaining the cross-reference itself needed correcting — the same class of finding round 3
+  fixed for its neighboring bullets, just missed for this one.
+- **SUGGESTION (new, documentation) — the RMSE tail-direction and `Generator`-statefulness caveats
+  existed only in the OpenSpec proposal, which is not shipped documentation and moves to
+  `openspec/changes/archive/...` on merge.** Both are genuine Python-API footguns subtle enough to
+  have taken multiple internal review rounds to catch — a future direct caller deserves the same
+  warning. Fixed: task 12.3 now requires both stated explicitly in `permutation_test`'s own
+  docstring and its `API.md` entry, not just internally in this proposal.
+- **SUGGESTION (new, documentation) — the shipped-doc `2q/n` example (task 12.2) still showed only
+  a single-point figure ("≈52.6% at n=19"),** not round 3's own corrected range, risking a reader
+  treating that single number as a fixed constant rather than an n-dependent range. Fixed: widened
+  to state the full ≈44-55% range across this program's real n=15-24 scale, with the single-point
+  figure kept only as one worked example within that range.
+- **SUGGESTION (new, documentation) — tasks.md's Section 6/7 headers never stated which test file
+  each section's tests land in**, leaving the two disambiguating test-file names
+  (`test_visualize_prediction.py` vs. `test_step_visualize_prediction.py`, added in proposal.md
+  during round 3) only inferable from that separate file, not stated where an implementer would
+  actually be reading task-by-task. Fixed: both section headers now name their test file directly.
+- **Verified clean, no action needed:** the RMSE formula's correctness itself (re-derived twice,
+  independently, from first principles, with a concrete numeric walkthrough both times); all four
+  metrics' directions (R², Spearman ρ, RMSE, top-quartile recovery — the last of which has no
+  p-value at all, so no direction-inversion is even possible for it); the `Generator`
+  reproducibility caveat (re-verified against real numpy behavior a second time); the 20-scenario
+  MODIFIED requirement (re-counted a 4th time, zero drift); `SeedSequence.spawn` determinism;
+  task 7b.7's positioning (hardcodes `permutation_n_jobs=4` in its own task text, so it can't
+  accidentally degrade to the in-process fast path and fail to test real parallel dispatch); task
+  6.4a's positioning (correctly ordered before 6.5, which must make it green).
+
+Full re-validation (`openspec validate add-prediction-permutation-and-figure --strict`) passes
+after all round-4 fixes (100 tasks, up from 98). Round-over-round severity: round 1: 5 BLOCKING;
+round 2: 2 new BLOCKING; round 3: 1 new BLOCKING + 1 BLOCKING-adjacent; round 4: **0 new BLOCKING**
+— every round-4 finding was IMPORTANT-or-lower, and the two most substantive findings (the missing
+observed-value guard, the toothless 9.1a test) were each independently corroborated by 2 of 5
+reviewers rather than surfacing fresh, previously-unseen defect categories. This is the first round
+showing a genuine severity drop, consistent with (though not yet as clean as) Tiers 3/3.5's own
+convergence pattern — a reasonable point to bring to Elizabeth for a decision on whether a 5th
+round is warranted or this is ready for approval.

--- a/openspec/changes/add-prediction-permutation-and-figure/design.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/design.md
@@ -56,9 +56,14 @@ representative_names=None, n_permutations=1000, random_state=42) -> PermutationR
 `logo_cv_predict(X, y, genotypes, reduction_method, representative_names)` once, on the real
 (unshuffled) `y`, to populate `observed_r2`/`observed_rmse`/`observed_spearman_rho`/
 `observed_top_quartile_recovery`. It then draws `n_permutations` independent shuffles of `y`
-relative to `genotypes` (a single seeded `numpy.random.Generator(random_state)`, one shuffle per
-iteration, no shared mutable state across iterations) and calls `logo_cv_predict()` once per
-shuffle, collecting the four metrics' null distributions and computing one-sided p-values
+relative to `genotypes` (a single generator built via `numpy.random.default_rng(random_state)` —
+**not** `numpy.random.Generator(random_state)` directly, which requires a `BitGenerator` instance
+and rejects a bare `int`; `default_rng` accepts `int`, `SeedSequence`, or `Generator` uniformly,
+which is what lets `VisualizePredictionStep` pass per-target `SeedSequence` children through with
+no int-extraction step — see round 2's reconciliation below, this replaces an invalid API call an
+earlier draft of this decision specified — one shuffle per iteration, no shared mutable state
+across iterations) and calls `logo_cv_predict()` once per shuffle, collecting the four metrics'
+null distributions and computing one-sided p-values
 (`p = (#null >= observed + 1) / (n_permutations + 1)`) for R², RMSE, and Spearman ρ.
 
 **Added during `/review-openspec` round 1:** a permutation's LOGO-CV fold structure can
@@ -447,3 +452,119 @@ implementation began. 5 BLOCKING and 11 IMPORTANT findings, reconciled as follow
 
 Full re-validation (`openspec validate add-prediction-permutation-and-figure --strict`) passes
 after all round-1 fixes.
+
+## Adversarial Review Reconciliation (round 2)
+
+A second, independent round of the same 5-agent review (run fresh, with no memory of round 1,
+specifically to catch anything round 1 missed) found round 1's investigative work mostly held up
+under direct re-verification (the restored 19-scenario MODIFIED requirement, the `2q/n` math, the
+`predictor_matrices` collision invariant, and the `SeedSequence`/`loky`/tolerance language were all
+independently confirmed against the current spec/tasks text, not just design.md's own narrative).
+But it also found 2 new BLOCKING issues — both real implementation-blocking bugs, not polish — plus
+a further batch of IMPORTANT gaps:
+
+- **BLOCKING (new) — round 1's own RNG fix was itself invalid.** `numpy.random.Generator(random_state)`
+  requires a `BitGenerator` instance and raises `TypeError` on a bare `int` — the exact API round 1's
+  fix specified. Separately, the `SeedSequence.spawn(N)` → `permutation_test(random_state=...)`
+  handoff (also introduced in round 1) was left completely unspecified: `spawn()` returns
+  `SeedSequence` objects, not ints, and `permutation_test`'s signature was still typed as a plain
+  `int`. Fixed: `permutation_test` now builds its RNG via `numpy.random.default_rng(random_state)`,
+  which uniformly accepts `int`, `SeedSequence`, or `Generator` — resolving both problems at once,
+  with no int-extraction step needed anywhere. Decision 1, Decision 4, and the
+  `cross-platform-prediction` spec's Permutation Test requirement all now state this explicitly;
+  task 2.8 gained a parametrized case covering both input types, and task 2.14 states the exact
+  constructor to use and why (`default_rng`, not `Generator` directly).
+- **BLOCKING (new) — Section 6 (`VisualizePredictionStep`) depended on `create_prediction_figure()`
+  (the old Section 8) without that section being sequenced first.** Task 6.8's own test mocked "the
+  figure-building function," which didn't exist yet at that point in the task ordering — a real
+  sequencing bug missed by every round-1 reviewer (including the git-workflow lens, which checked
+  ordering but not this specific cross-section dependency). Fixed: the figure-content module
+  (`visualize_prediction.py`'s `create_prediction_figure()`) is now Section 6, sequenced *before*
+  the step (now Section 7) that consumes it — a pure renumbering, not a behavior change.
+- **IMPORTANT (new) — Section 6's (now Section 7's) "3 test-commits, then 1 implementation commit
+  at the end" pattern didn't achieve real commit atomicity.** Verified against Tier 3.5's actual
+  commit history (its own analogous section landed tests and implementation together in one
+  commit, never split): committing round 1's 3 test-only groups in sequence would leave
+  `uv run pytest` red at each of those 3 commit boundaries, only turning green at the final,
+  separate implementation commit — worse than Tier 3.5's own precedent, not better. Fixed:
+  restructured into 3 genuine red→green pairs (7a: wiring/reuse, 7b: `joblib` parallelization, 7c:
+  JSON/figure I/O), each landing its own working implementation increment.
+- **IMPORTANT (new) — oracle tests (9.2/9.3/9.4b) never stated a reduced `n_permutations` for CI**,
+  unlike 9.1, which did. At the production default (`n_permutations=1000`) across the existing
+  N=20-seed fixture, these could individually cost minutes and collectively threaten the shared
+  30-minute CI job timeout across 3 OSes. Fixed: 9.2/9.3/9.4b now explicitly state
+  `n_permutations=200`, matching 9.1's own CI-fast convention.
+- **IMPORTANT (new) — round 1's Section 11 timing claim was factually wrong, not just imprecise.**
+  Verified directly against Tier 3.5's real commit timestamps (branch `add-prediction-pipeline-step`,
+  still available locally): manual validation (`5d5b8e6`, `b5e5cf0`) landed *after* **both**
+  5-subagent review rounds (`718260b`/`afb4b91`, then `e5294e0`), with a further CI-driven fix
+  (`d401cf0`) landing even after Elizabeth's sign-off — not "between" two rounds, as round 1's text
+  claimed. Fixed: Section 11's timing note corrected to state validation is a late-stage gate that
+  can trail every review round, not one reliably sandwiched between two.
+- **IMPORTANT (new) — 2 previously-untested `PredictionConfig` fields had no validation at all**:
+  `permutation_n_jobs` (a non-positive value would surface `joblib.Parallel`'s own raw error deep
+  inside the step) and `permutation_random_state` (an invalid seed would surface
+  `numpy.random.SeedSequence`'s own raw error). Fixed: both gain the same
+  validated-only-when-`visualize=True` treatment as `n_permutations`, with named `ValueError`s and
+  corresponding tests (tasks.md 4.4a/4.4b).
+- **IMPORTANT (new) — the seed-enumeration order underlying `SeedSequence.spawn(N)` was never
+  pinned down.** Tests could pass regardless of which `(target, method)` enumeration order was
+  chosen (a rerun of the same code reproduces the same order trivially), silently leaving the
+  actual order — dict-iteration order of `results_by_method`, easy to perturb in a future refactor
+  — unspecified as a real contract. Fixed: the `cross-platform-analysis` spec now states the exact
+  canonical order (methods first, then target names in `CrossPlatformPredictionResult.predictions`
+  order), and task 7b.3 tests against it explicitly.
+- **IMPORTANT (new) — partial-failure/atomic-write semantics for `VisualizePredictionStep`'s JSON
+  output were unspecified.** If one `(target, method)` combination failed while others for the same
+  pair would have succeeded, it was unstated whether already-computed methods' JSON files should
+  still be written. Fixed: the `cross-platform-analysis` spec now states all-or-nothing per pair
+  (no partial JSON output on any failure), with a corresponding test (tasks.md 7c.6).
+- **IMPORTANT (new) — the non-finite-null guard's fail-fast-vs-complete-then-report choice was
+  undiscussed**, despite being cost-relevant in a ~27-minute parallel run. Fixed: the
+  `cross-platform-prediction` spec now states and justifies the choice (complete-then-report,
+  since a genuine bug is expected to affect many permutations, not one rare occurrence — failing
+  fast saves little wall-clock time while complicating which-permutations-ran accounting).
+- **IMPORTANT (new) — `assert_allclose(rtol=1e-6, atol=1e-9)` reused a tolerance convention
+  established for smaller arrays** (PCA loadings/eigenvalues/cluster centers), applied here
+  element-wise across null distributions of up to 1000 values across many targets/methods, without
+  stating what fixture size bounds the resulting false-failure-rate risk. Fixed: task 7b.5 now
+  states an explicit, small `n_permutations` (50) for this specific test, bounding the comparison
+  surface.
+- **IMPORTANT (new) — no wiring-correctness oracle existed for `observed_top_quartile_recovery`
+  specifically** (unlike the other 3 observed metrics, which have an explicit direct-`logo_cv_predict`-
+  call cross-check). Fixed: task 2.5 now asserts this metric against an independent
+  `top_quartile_recovery(y, y_pred)` computation from the same observed call.
+- **IMPORTANT (new) — the pooled-null violin panel's implicit invariant (every target within a pair
+  shares the same genotype count) was unstated**, and the independent per-target seeding fix (round
+  1) raised a legitimate question about whether pooling nulls from targets with wildly different
+  counts still makes sense. Verified: task 6's `dropna(axis=1, how="any")` trait-column filtering
+  never changes the row/genotype count, so this concern doesn't actually arise — but the invariant
+  was worth stating explicitly rather than leaving a future reviewer to re-derive it. Fixed: added
+  to the Visualize step's requirement body (step 5).
+- **IMPORTANT (new, documentation) — the round-1 fix of "cross-reference `design.md`'s Decisions"
+  for shipped-doc content was itself a documentation anti-pattern.** `design.md` moves to
+  `openspec/changes/archive/<change-id>/design.md` on archival — a shipped-doc pointer to it goes
+  stale/dangling the moment this change archives. Fixed: task 12.2 now states the two key numbers
+  (the parallelization headline, the `2q/n` chance-level baseline) directly in
+  `docs/CROSS_PLATFORM_ANALYSIS.md`, rather than deferring to a soon-to-be-archived file.
+- **IMPORTANT (new, documentation) — `top_quartile_recovery` and the full 4-field YAML example
+  were under-specified in task 12.2.** Fixed: both named explicitly.
+- **SUGGESTION (new) — missing an explicit-invalid-`q` scenario for `top_quartile_recovery`**
+  (only the *default*-`q` small-`n` case was covered). Fixed: added, with a corresponding test
+  (tasks.md 2.3b).
+- **SUGGESTION (new) — the bit-identical (single-process, task 2.8) and tolerance-based
+  (cross-`joblib`-worker, task 7b.5) determinism claims could read as contradictory** without an
+  explicit note that they concern different variables. Fixed: one clarifying sentence added to the
+  "Same random_state" scenario.
+- **SUGGESTION (new, documentation) — `theory.md`'s external-vault addendum has no repo-side
+  pointer anywhere**, making it discoverable only via archived OpenSpec history or vault access.
+  Documented as a known, accepted gap (task 10.1) — not fixed in this tier, no obvious low-cost fix
+  identified.
+- **Verified clean, no action needed:** the `2q/n` arithmetic was independently re-derived via the
+  hypergeometric mean and confirmed correct; the `predictor_matrices` key-collision invariant was
+  re-checked against the current `_VALID_REDUCTION_METHODS` tuple and still holds; the K-S
+  calibration test's fixture-seed-pinning (round 1's fix) was confirmed unambiguous.
+
+Full re-validation (`openspec validate add-prediction-permutation-and-figure --strict`) passes
+after all round-2 fixes (94 tasks, up from 88 — 2 new BLOCKING fixes and the Section 6/7
+restructuring account for most of the growth).

--- a/openspec/changes/add-prediction-permutation-and-figure/design.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/design.md
@@ -1,0 +1,321 @@
+## Context
+
+This is Tier 4 (`add-prediction-permutation-and-figure`) of the wheat EDPIE cross-platform
+genotype-prediction program. See the program roadmap and statistical grounding at
+`c:\vaults\sleap-roots\wheat-edpie-paper\cross-platform-prediction\{roadmap,theory}.md` (external
+to this repo; referenced here for provenance only). The full brainstormed design — including this
+session's empirical runtime benchmarks — was written and approved by Elizabeth before this
+proposal, at
+`docs/superpowers/specs/2026-07-16-prediction-permutation-and-figure-design.md`; this file
+restates it in this program's established Decisions-with-rationale format for adversarial review.
+
+Tier 3 (`add-cross-platform-prediction`, merged #195, archived
+`2026-07-16-add-cross-platform-prediction`) shipped `logo_cv_predict()`, `fit_pca_on_fold()`, and
+`CrossPlatformPredictionResult` as stateless Python-API functions, explicitly designed (Tier 3
+Decision 3) to support a future permutation loop without refactoring. Tier 3.5
+(`add-prediction-pipeline-step`, merged #199, archived `2026-07-17-add-prediction-pipeline-step`)
+wired the observed prediction into `CrossPlatformPipeline` as `PredictCrossPlatformStep` (task 6).
+Neither tier is in scope to change here except by strictly additive extension.
+
+Prior investigation this session (recorded in the design doc) established:
+
+- Individual `logo_cv_predict()` calls cost ~16ms (`pls_latent`/`representatives`) to ~27ms
+  (`pc1`) on a `(19, 15)` synthetic matrix.
+- `joblib.Parallel` parallelizing individual permutation calls is measurably **slower** than
+  serial at every tested `n_jobs` (4/8/16, both `loky` and `threading` backends, with and without
+  BLAS-thread-count pinning) — worker/thread overhead dwarfs a ~16-20ms task.
+- Parallelizing across independent **targets** (each worker runs one target's own full, serial
+  1000-permutation loop — a ~16s unit of work) measured 3.85× speedup at `n_jobs=8` on a 16-core
+  machine; `n_jobs=16` measured worse (oversubscription).
+- Real EDPIE target-trait counts per pair range from ~15-24 (Turface19/Field as target) up to
+  ~129 (Cylinder as target), per Tier 3.5's own Section 8 manual validation.
+
+## Goals / Non-Goals
+
+- **Goals:** `permutation_test()`/`top_quartile_recovery()` (Python API, `cross_platform_
+  prediction.py`, hard-depends on Tier 3 only); `PermutationResult`/
+  `CrossPlatformPermutationResult` (`result_types.py`); a `joblib.Parallel`-across-targets runtime
+  strategy verified (this session, and again against real data in Section 5's manual gate) to fit
+  the roadmap's 30-minute feasibility gate; an additive extension to `PredictCrossPlatformStep`
+  exposing its already-computed predictor matrices; `VisualizePredictionStep` as an optional 7th
+  pipeline task producing one permutation-results JSON per method and one composite figure per
+  pair; a `theory.md` permutation-null pseudo-code addendum.
+- **Non-Goals:** any change to `logo_cv_predict`, `fit_pca_on_fold`, `CrossPlatformPredictionResult`,
+  `cluster_correlated_traits`, `select_cluster_representatives`, or any of `PredictCrossPlatformStep`'s
+  existing (Tier 3.5) behavior/outputs — this tier only adds; `CrossPlatformSummaryGenerator`
+  surfacing permutation/prediction results (#197); `/configure-run-all`/`/dry-run`/`/validate-config`
+  coverage (#198); heritability-based `representative_selection_metric` (Tier 3.5 Decision 7,
+  still deferred — this tier does not revisit it).
+
+## Decisions
+
+### Decision 1: `permutation_test()` is self-contained — computes the observed value itself, not just the null
+
+**What:** `permutation_test(X, y, genotypes, reduction_method="pls_latent",
+representative_names=None, n_permutations=1000, random_state=42) -> PermutationResult` first calls
+`logo_cv_predict(X, y, genotypes, reduction_method, representative_names)` once, on the real
+(unshuffled) `y`, to populate `observed_r2`/`observed_rmse`/`observed_spearman_rho`/
+`observed_top_quartile_recovery`. It then draws `n_permutations` independent shuffles of `y`
+relative to `genotypes` (a single seeded `numpy.random.Generator(random_state)`, one shuffle per
+iteration, no shared mutable state across iterations) and calls `logo_cv_predict()` once per
+shuffle, collecting the four metrics' null distributions and computing one-sided p-values
+(`p = (#null >= observed + 1) / (n_permutations + 1)`) for R², RMSE, and Spearman ρ.
+
+**Why:** A caller using the Python API directly (this tier's explicit design goal — permutation
+testing is Python-API-only, not pipeline-only) should get a complete, self-describing result from
+one call, without first calling `logo_cv_predict()` separately purely to obtain the observed value
+for comparison. The extra call is cheap (one `logo_cv_predict()` invocation, ~16-27ms) relative to
+the `n_permutations` calls that follow. In `VisualizePredictionStep`, this observed value is
+expected to exactly reproduce Tier 3.5's already-reported `TargetPrediction` for the same
+target/method (both call `logo_cv_predict` with identical inputs, and the function is
+deterministic) — enforced as a wiring-correctness regression test (see tasks.md), the same
+"wiring correctness, not just existence" pattern as Tier 3.5's own Section 6 oracle.
+
+**Alternatives considered:**
+- **`permutation_test()` takes the observed `LOGOCVResult` as a parameter instead of recomputing
+  it.** Rejected: saves one ~16-27ms call per invocation at the cost of a less self-contained
+  function signature and an extra caller-side responsibility (computing the observed result
+  correctly with matching inputs) that has no enforcement if done wrong.
+
+### Decision 2: `top_quartile_recovery()` is a standalone, reusable function
+
+**What:** `top_quartile_recovery(y_true, y_pred, q=None) -> float` computes the fraction of the
+true top-`q` genotypes (ranked by `y_true`) that appear in the predicted top-`2q` (ranked by
+`y_pred`). `q` defaults to `round(len(y_true) / 4)`. Used both for the observed value (real `y`,
+real LOGO-CV predictions) and, once per permutation inside `permutation_test()`, for the null
+distribution — where that permutation's *shuffled* `y` is the ground truth for that call, not the
+original unshuffled `y` (the null must reflect chance-level recovery under the shuffled labeling,
+not recovery of the real ranking against a scrambled prediction).
+
+**Why:** This metric is new in this tier (absent from Tier 3's `LOGOCVResult`/`TargetPrediction`)
+and needed identically in two places (observed computation, per-permutation null computation) —
+a standalone function avoids duplicating the ranking/recovery logic.
+
+**Alternatives considered:**
+- **Inline the recovery calculation separately in the observed-value and null-loop code paths.**
+  Rejected: duplicates non-trivial ranking logic for no benefit.
+
+### Decision 3: `CrossPlatformPermutationResult` is a separate result type, not nested inside `CrossPlatformPredictionResult`
+
+**What:** `PermutationResult` (per-target) and `CrossPlatformPermutationResult` (per pair/method,
+holding a `predictions: list[PermutationResult]`) mirror `TargetPrediction`/
+`CrossPlatformPredictionResult`'s shape and `to_dict()`/`to_json()` convention exactly, but are
+new, independent dataclasses in `result_types.py` — not new fields grafted onto
+`CrossPlatformPredictionResult`/`TargetPrediction`.
+
+**Why:** Permutation is optional (gated by `PredictionConfig.visualize`) and substantially more
+expensive than the observed-result computation it wraps. A caller who only wants the observed
+prediction (Tier 3.5's existing, unchanged use case) should not need `CrossPlatformPredictionResult`
+to carry permutation fields that are frequently absent/irrelevant. Keeping the types separate also
+means Tier 3.5's already-shipped `CrossPlatformPredictionResult`/`TargetPrediction` contract is
+untouched by this tier, satisfying the Non-Goals above literally.
+
+**Alternatives considered:**
+- **Add `null_r2`/`p_value_r2`/etc. as optional fields directly on `TargetPrediction`.** Rejected:
+  would change an already-shipped, already-tested dataclass's shape for every existing consumer
+  (even if the new fields default to `None`), and conflates two orthogonal concerns (an observed
+  LOGO-CV result vs. a permutation-null significance test) in one type.
+
+### Decision 4: `joblib.Parallel` parallelizes across targets, not across individual permutation calls — empirically verified, not assumed
+
+**What:** `VisualizePredictionStep` (not `permutation_test()` itself, which stays internally
+serial) calls `joblib.Parallel(n_jobs=config.prediction.permutation_n_jobs)` over the full list of
+`(target_name, method)` units for a pair, each invoking one complete `permutation_test()` call
+(its own internal `n_permutations`-length loop stays serial, single-process).
+`PredictionConfig.permutation_n_jobs: int = 8` (not `-1`/all-cores).
+
+**Why:** Measured this session (design doc Section 2, reproduced above in Context): parallelizing
+individual `logo_cv_predict` calls (~16-27ms each) via `joblib.Parallel` is **slower than serial**
+at every tested `n_jobs`, on both `loky` and `threading` backends — process/thread overhead
+dwarfs the task. Parallelizing whole per-target permutation loops (~16s units of work) instead
+measured 3.85× speedup at `n_jobs=8`; `n_jobs=16` measured *worse* (oversubscription) — so `8`,
+not the number of logical cores, is the chosen default. Applying this to the worst real case
+(Cylinder-as-target pair, ~129 targets, both `reduction_method` + one `comparison_methods` entry,
+N=1000, all 4 pairs): serial ≈105.5 min, parallel (n_jobs=8) ≈27.4 min — under the roadmap's
+30-minute gate.
+
+The 27.4-minute figure is a synthetic-fixture extrapolation (`n_traits=15`), not a measurement
+against real Cylinder-scale data (hundreds of raw traits pre-clustering) — re-verified against
+real EDPIE data in Section 5's manual gate before merge (see Risks).
+
+**Alternatives considered:**
+- **Parallelize individual permutation calls (the "obvious" axis).** Empirically measured
+  slower than serial at this workload's task size — rejected on direct evidence, not intuition.
+- **`n_jobs=-1` (use all logical cores).** Rejected: measured worse than `n_jobs=8` on the same
+  16-core machine (oversubscription) — "more cores" is not "faster" for this specific workload
+  shape.
+- **Reduce the permutation scope (fewer targets, primary-method-only) instead of parallelizing.**
+  Considered and rejected by Elizabeth during brainstorming — full per-representative-trait
+  permutation nulls were explicitly requested for the paper; documented as the fallback if the
+  Section 5 real-data re-measurement exceeds 30 minutes (see Risks), not the primary plan.
+
+### Decision 5: `joblib` becomes an explicit direct dependency
+
+**What:** `joblib` is added to `pyproject.toml`'s dependency list, not left as an implicit
+transitive dependency of `scikit-learn`.
+
+**Why:** This tier imports `joblib.Parallel`/`joblib.delayed` directly in
+`visualize_prediction.py`. Relying on a transitive pin (which `scikit-learn` could change or drop
+in a future version, outside this package's control) for a direct import is fragile.
+
+**Alternatives considered:**
+- **Rely on the transitive pin, no `pyproject.toml` change.** Rejected: a direct import of a
+  package not declared as a direct dependency is a latent break waiting for an unrelated
+  `scikit-learn` version bump.
+
+### Decision 6: `PredictCrossPlatformStep` is extended additively to expose its predictor matrices
+
+**What:** `PredictCrossPlatformStep.execute()`'s returned `StepResult.data` gains a new key,
+`predictor_matrices`, holding the already-computed `source_clean`/`target_clean` DataFrames and
+`source_representative_names`/`target_representatives` (all computed during the step's own
+execution, previously discarded after use). Every existing `data`/`metadata`/`files_generated` key
+is unchanged in shape and content.
+
+**Why:** `VisualizePredictionStep` needs the same source/target predictor matrices
+`PredictCrossPlatformStep` already builds (BLUP loading, NaN-column dropping, canonical-genotype
+alignment, representative-name selection — Tier 3.5 Decisions 2/13/14/16/17) to run permutations.
+Duplicating that logic in a second step would create two places to keep in sync if it ever
+changes — a real drift risk this program has hit before (Tier 3.5's own Decision 8 bug, where a
+"fix" reintroduced a data-pollution risk because the fix wasn't traced through the one place that
+mattered). Reusing task 6's already-computed matrices via an additive `StepResult.data` extension
+keeps Decisions 2/13/14/16/17's logic in exactly one place.
+
+**Alternatives considered:**
+- **`VisualizePredictionStep` independently rebuilds the matrices from `source_blup_path`/
+  `target_blup_path`/task 1's raw data.** Rejected: duplicates BLUP-loading/NaN-dropping/alignment
+  logic in a second step, the drift risk described above.
+
+### Decision 7: New `PredictionConfig` fields nest on the existing config, not a new sibling
+
+**What:** `PredictionConfig` gains `visualize: bool = False`, `n_permutations: int = 1000`,
+`permutation_random_state: int = 42`, `permutation_n_jobs: int = 8`. No new top-level or sibling
+config dataclass. `CrossPlatformConfig.__post_init__` gains one more cross-check: `visualize=True`
+with `enabled=False` raises `ValueError` at construction time (same plain-`ValueError` convention
+as every other Tier 3.5 validation — no new exception type).
+
+**Why:** `VisualizePredictionStep` is only ever meaningful when `PredictCrossPlatformStep` has
+actually run (`enabled=True`) — a separate sibling config (e.g. a `VisualizationConfig`) would
+just recreate the same enabled-gate coupling `PredictionConfig` already provides, per Tier 3.5
+Decision 1's reasoning about nesting matching the actual per-pair workflow (one command, one run
+directory, one config file per directed pair).
+
+**Alternatives considered:**
+- **A new sibling `VisualizationConfig` field on `CrossPlatformConfig`.** Rejected: introduces a
+  second `enabled`-equivalent flag to keep in sync with `prediction.enabled`, for no benefit over
+  nesting on the config that already gates the step it depends on.
+
+### Decision 8: `VisualizePredictionStep`'s dependency on task 6 is for both data and ordering
+
+**What:** `VisualizePredictionStep`'s `depends_on=["06_predict_cross_platform"]` supplies both the
+`predictor_matrices` and observed `CrossPlatformPredictionResult`(s) data (Decision 6) *and*
+guarantees task 6 completes before task 7 runs.
+
+**Why:** Unlike Tier 3.5 Decision 15 (where task 6's second dependency, on task 5, was ordering-
+only because task 6 never needed task 5's data), task 7 genuinely needs task 6's data — there is
+no analogous ordering-only-dependency ambiguity to resolve here.
+
+**Alternatives considered:** None — this is the direct, un-ambiguous case Tier 3.5 Decision 15 had
+to disambiguate away from.
+
+### Decision 9: Figure scope — PC1 scatter + pooled all-targets violin, primary method only, one PNG per pair
+
+**What:** `create_prediction_figure()` (new module, `visualize_prediction.py`) builds one
+3-panel `matplotlib.Figure` per directed pair, using only the primary `reduction_method`'s
+results (not each `comparison_methods` entry):
+1. **Obs-vs-pred scatter** — PC1 target only, one point per genotype.
+2. **CV-R²-vs-null strip/violin** — every representative-trait target's observed R² as points,
+   overlaid on a violin of the *pooled* null R² distribution (every target's permutation null
+   combined into one set).
+3. **Top-quartile recovery bar chart** — 2 bars: mean observed recovery rate across all targets
+   vs. the corresponding mean null expectation.
+
+Saved as `run_dir / "07_prediction_figure.png"` (`dpi=300, bbox_inches="tight"`, matching
+`visualize_cross_platform.py`'s existing convention). `comparison_methods` still get full
+permutation JSON output (Decision 10) for the paper's numeric tables/appendix, just not their own
+PNG.
+
+**Why:** Elizabeth confirmed this scope directly during brainstorming (design doc Section 4).
+PC1 is the one target that is always exactly 1-per-pair and comparable across all 4 directed
+pairs, making it the natural "headline" scatter; pooling all targets' nulls into one violin
+surfaces the full per-trait breadth the "for the paper" full-scope permutation run was built to
+support, in one glance, without needing dozens of per-trait panels.
+
+**Alternatives considered:**
+- **PC1 only, for all three panels.** Considered; rejected as the primary design — doesn't
+  surface the per-representative-trait breadth the full-scope permutation run exists to support.
+- **One figure per (pair, method).** Considered; rejected in favor of one clean headline PNG per
+  pair, with `comparison_methods` numeric data still available via the JSON outputs.
+
+### Decision 10: Permutation output naming
+
+**What:** One `CrossPlatformPermutationResult` JSON per method: `07_permutation_<method>.json`
+(mirroring Tier 3.5's `06_prediction_<method>.json` naming exactly). One figure per pair:
+`07_prediction_figure.png`.
+
+**Why:** Consistent with this pipeline's existing numbered-step-file convention; the method-in-
+filename pattern is a direct, unmodified precedent from Tier 3.5.
+
+**Alternatives considered:** None — straightforward continuation of an existing convention.
+
+### Decision 11: Oracle fixtures reuse Tier 3's precedent; the top-quartile-recovery null value is verified, not assumed
+
+**What:**
+- **Uniformity oracle:** a K-S calibration test running `permutation_test()` on ~30-50
+  independent pure-noise fixtures (real `X`, unrelated `y`), K-S-testing the resulting p-values
+  against `Uniform(0,1)`, asserting `p > 0.05`. Uses a reduced `n_permutations` (e.g. 200) to stay
+  CI-fast, distinct from the `n_permutations=1000` production default.
+- **Signal-separation oracle:** reuses Tier 3's N=20-seed-averaged planted-signal/noise fixtures
+  (Tier 3 Decision 6) — asserts mean signal R² is comfortably above that fixture's own
+  permutation-null median, and mean noise-fixture R² falls within its own null's median ± 1σ.
+- **Top-quartile-recovery oracle:** same fixtures; asserts ≥80% (signal) vs. an **empirically
+  verified** null expectation — the roadmap's "≈25%" is a starting estimate, not a value to pin
+  blind; the real number is computed and recorded during implementation, the same discipline that
+  caught Tier 3 Decision 6's wrong assumed single-seed R².
+- **Figure provenance oracle:** PNG exists, non-empty, and a hash/timestamp check confirms it was
+  regenerated from the current run's input CSVs, following Tier 3.5's golden-fixture-snapshot
+  pattern.
+
+**Why:** This program has twice caught a wrong assumed statistical value by verifying it
+empirically instead of trusting a plausible-sounding number (Tier 3 Decision 6's single-seed
+fixture; Tier 3.5's data-vintage correction) — the same discipline applies here to a metric with
+no prior empirical basis in this codebase.
+
+**Alternatives considered:** None — this is a direct continuation of an established program
+convention, not a new design choice.
+
+## Risks / Trade-offs
+
+- **27.4-minute estimate is close to the 30-minute gate and extrapolated from a small synthetic
+  fixture (`n_traits=15`), not real Cylinder-scale data.** Must be re-measured during Section 5's
+  manual validation before merge. If real timing exceeds 30 minutes, documented fallback: drop
+  `comparison_methods` from the *pipeline-computed* permutation JSON (primary method only),
+  keeping the full sweep available via direct Python-API calls for anyone who wants it — roughly
+  halves the estimate. A second fallback, not preferred: reduce `n_permutations` below 1000 for
+  the pipeline-computed run only (Python-API callers keep the 1000 default).
+- **`joblib` becomes a direct dependency**, contradicting the program roadmap's Goal-section
+  language ("no new dependencies"). Low practical risk (already vendored transitively via
+  `scikit-learn`, already imported transitively everywhere `scikit-learn` runs) but disclosed here
+  explicitly as a deviation from that stated intent, since it is a real `pyproject.toml` change.
+- **Full per-trait permutation scope produces large JSON files** for Cylinder-target pairs
+  (~129 targets × 1000 null values × 3 metrics ≈ 387,000 floats per method-pair). Acceptable for a
+  research artifact; noted as meaningfully larger than Tier 3.5's `06_prediction_<method>.json`
+  files.
+- **Pooling all targets' null R² into one violin (Decision 9, panel 2) discards per-target null
+  identity in the figure** — a reader cannot tell from the PNG alone which specific traits'
+  nulls contribute to which part of the pooled distribution. Mitigated: the full per-target
+  breakdown remains in the `07_permutation_<method>.json` files; the figure is a summary view, not
+  the complete record.
+
+## Migration Plan
+
+Purely additive when `visualize=False` (the default) — every existing `CrossPlatformConfig` YAML
+and every existing Tier 3.5 test is unaffected. `PredictCrossPlatformStep`'s extended
+`StepResult.data` is additive (new key only); `CrossPlatformPipeline` gains one new,
+conditionally-included task. No existing function, CLI flag, or config field changes shape.
+
+## Open Questions
+
+None blocking prior to `/review-openspec`. Carried forward, not this tier's job: `#197`
+(`CrossPlatformSummaryGenerator` not surfacing prediction/permutation results — this tier's new
+figures/JSON outputs increase the pressure to fix this, worth flagging again, not fixing here) and
+`#198` (`/configure-run-all`/`/dry-run`/`/validate-config` coverage gaps, pre-existing).

--- a/openspec/changes/add-prediction-permutation-and-figure/design.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/design.md
@@ -61,6 +61,16 @@ iteration, no shared mutable state across iterations) and calls `logo_cv_predict
 shuffle, collecting the four metrics' null distributions and computing one-sided p-values
 (`p = (#null >= observed + 1) / (n_permutations + 1)`) for R², RMSE, and Spearman ρ.
 
+**Added during `/review-openspec` round 1:** a permutation's LOGO-CV fold structure can
+independently produce a non-finite `spearman_rho` (a model-degeneracy event — e.g. a degenerate
+fold with constant predictions) even when that permutation's shuffled `y` is itself non-constant;
+this is distinct from, and not ruled out by, the data-degeneracy check `PredictCrossPlatformStep`
+already performs on *observed* values before `permutation_test()` is ever called. The function
+therefore scans every null distribution for non-finite entries before returning, raising
+`ValueError` naming both the offending metric and the permutation index — otherwise a single
+degenerate fold, buried inside a ~27-minute parallel run, would surface as an unnamed crash deep
+inside `CrossPlatformPermutationResult.to_json()`'s `allow_nan=False` contract.
+
 **Why:** A caller using the Python API directly (this tier's explicit design goal — permutation
 testing is Python-API-only, not pipeline-only) should get a complete, self-describing result from
 one call, without first calling `logo_cv_predict()` separately purely to obtain the observed value
@@ -119,10 +129,17 @@ untouched by this tier, satisfying the Non-Goals above literally.
 ### Decision 4: `joblib.Parallel` parallelizes across targets, not across individual permutation calls — empirically verified, not assumed
 
 **What:** `VisualizePredictionStep` (not `permutation_test()` itself, which stays internally
-serial) calls `joblib.Parallel(n_jobs=config.prediction.permutation_n_jobs)` over the full list of
-`(target_name, method)` units for a pair, each invoking one complete `permutation_test()` call
-(its own internal `n_permutations`-length loop stays serial, single-process).
-`PredictionConfig.permutation_n_jobs: int = 8` (not `-1`/all-cores).
+serial) calls `joblib.Parallel(n_jobs=config.prediction.permutation_n_jobs, backend="loky")` over
+the full list of `(target_name, method)` units for a pair, each invoking one complete
+`permutation_test()` call (its own internal `n_permutations`-length loop stays serial,
+single-process). `PredictionConfig.permutation_n_jobs: int = 8` (not `-1`/all-cores).
+
+**Added during `/review-openspec` round 1:** each `(target_name, method)` combination is given an
+independently-derived `random_state`, via `numpy.random.SeedSequence(permutation_random_state)
+.spawn(N)` (`N` = the total combination count), rather than reusing the single configured seed
+identically for every combination. Results across different `permutation_n_jobs` values are
+verified via `numpy.testing.assert_allclose(rtol=1e-6, atol=1e-9)`, not bit-identical — see the
+round-1 reconciliation below for why both of these were originally wrong.
 
 **Why:** Measured this session (design doc Section 2, reproduced above in Context): parallelizing
 individual `logo_cv_predict` calls (~16-27ms each) via `joblib.Parallel` is **slower than serial**
@@ -170,6 +187,15 @@ in a future version, outside this package's control) for a direct import is frag
 `source_representative_names`/`target_representatives` (all computed during the step's own
 execution, previously discarded after use). Every existing `data`/`metadata`/`files_generated` key
 is unchanged in shape and content.
+
+**Added during `/review-openspec` round 1:** `StepResult.data` is, concretely, a plain dict keyed
+by method name (`results_by_method`, one entry per `reduction_method`/`comparison_methods` value).
+Adding a sibling `"predictor_matrices"` key is safe *only* because no valid `reduction_method`/
+`comparison_methods` value can itself equal `"predictor_matrices"` — both are constrained to
+`{"pls_latent", "representatives", "pc1"}`. This is a load-bearing invariant on the reduction-method
+enum, not an incidental fact; it is now stated explicitly in the `cross-platform-analysis` spec
+delta and covered by a test, so a future change extending that enum can't silently collide with
+this key.
 
 **Why:** `VisualizePredictionStep` needs the same source/target predictor matrices
 `PredictCrossPlatformStep` already builds (BLUP loading, NaN-column dropping, canonical-genotype
@@ -270,7 +296,14 @@ filename pattern is a direct, unmodified precedent from Tier 3.5.
 - **Top-quartile-recovery oracle:** same fixtures; asserts ≥80% (signal) vs. an **empirically
   verified** null expectation — the roadmap's "≈25%" is a starting estimate, not a value to pin
   blind; the real number is computed and recorded during implementation, the same discipline that
-  caught Tier 3 Decision 6's wrong assumed single-seed R².
+  caught Tier 3 Decision 6's wrong assumed single-seed R². **Added during `/review-openspec` round
+  1:** the roadmap's "≈25%" is not just unverified but arithmetically wrong at this program's real
+  scale. Under a random (uninformative) `y_pred`, the expected recovery of a fixed top-`q` set in a
+  randomly-drawn top-`2q` set is `2q / n` by linearity of expectation — at `n=19, q=5`, that's
+  `10/19 ≈ 52.6%`, not `25%`. This must be stated explicitly (now in the `cross-platform-prediction`
+  spec's Top-Quartile Recovery Metric requirement) so the empirical measurement in tasks.md 9.4a is
+  correctly interpreted against the right theoretical baseline, not "sanity-checked" against a
+  wrong number that happens to sound plausible.
 - **Figure provenance oracle:** PNG exists, non-empty, and a hash/timestamp check confirms it was
   regenerated from the current run's input CSVs, following Tier 3.5's golden-fixture-snapshot
   pattern.
@@ -315,7 +348,102 @@ conditionally-included task. No existing function, CLI flag, or config field cha
 
 ## Open Questions
 
-None blocking prior to `/review-openspec`. Carried forward, not this tier's job: `#197`
-(`CrossPlatformSummaryGenerator` not surfacing prediction/permutation results — this tier's new
-figures/JSON outputs increase the pressure to fix this, worth flagging again, not fixing here) and
-`#198` (`/configure-run-all`/`/dry-run`/`/validate-config` coverage gaps, pre-existing).
+None blocking after `/review-openspec` round 1's reconciliation (see below). Carried forward, not
+this tier's job: `#197` (`CrossPlatformSummaryGenerator` not surfacing prediction/permutation
+results — this tier's new figures/JSON outputs increase the pressure to fix this, worth flagging
+again, not fixing here) and `#198` (`/configure-run-all`/`/dry-run`/`/validate-config` coverage
+gaps, pre-existing).
+
+## Adversarial Review Reconciliation (round 1)
+
+`/review-openspec` ran 5 parallel reviewers (spec quality, TDD/testing, pipeline architecture &
+statistical correctness, documentation, git workflow) against this proposal before any
+implementation began. 5 BLOCKING and 11 IMPORTANT findings, reconciled as follows:
+
+- **BLOCKING — the MODIFIED "Predict Cross-Platform Genotype Values Pipeline Step" requirement
+  silently dropped 7 of the current spec's 19 scenarios.** My own initial read of the current spec
+  (to build the MODIFIED delta) cut off partway through the requirement (line 1560 of 1615) without
+  my noticing — a mechanical transcription error, not a judgment call. Per `openspec/AGENTS.md`'s
+  own explicit warning ("the archiver will replace the entire requirement with what you provide
+  here; partial deltas will drop previous details"), archiving as-is would have permanently deleted
+  7 real acceptance criteria, including the backward-compatibility byte-identical guarantee and
+  both dry-run scenarios — directly contradicting this proposal's own "all extensions are additive"
+  claim. Fixed: the full original 19 scenarios restored verbatim, in original order, plus this
+  tier's 1 new scenario.
+- **BLOCKING — no finiteness guard on the permutation null distributions before
+  `to_json(allow_nan=False)`.** A permutation's LOGO-CV fold structure can independently produce a
+  non-finite `spearman_rho` even when that permutation's shuffled `y` is non-constant (a
+  model-degeneracy event, distinct from the data-degeneracy check `PredictCrossPlatformStep`
+  already performs on observed values) — previously unaddressed, would have surfaced as an unnamed
+  crash deep inside a ~27-minute parallel run. Fixed: Decision 1 and the `cross-platform-prediction`
+  spec's Permutation Test requirement now specify a proactive non-finite scan naming both the
+  offending metric and the permutation index, with a corresponding test (tasks.md 2.13a).
+- **BLOCKING — `top_quartile_recovery`'s null baseline is `2q/n` ≈ 52.6% at real scale
+  (`n=19, q=5`), not the roadmap's unverified "≈25%".** Arithmetic (expected recovery of a random
+  top-`2q` draw), not opinion. Fixed: Decision 11 and the `cross-platform-prediction` spec's
+  Top-Quartile Recovery Metric requirement now state this explicitly, so tasks.md 9.4a's empirical
+  measurement is checked against the correct theoretical baseline, not a plausible-sounding wrong
+  number.
+- **BLOCKING — task 12.3's premise was factually backwards.** Verified directly:
+  `CrossPlatformPredictionResult`/`TargetPrediction` are in `__all__` but have **no** `docs/API.md`
+  entries. Fixed: task 12.3 rewritten to state the verified truth (no `API.md` change for the new
+  dataclasses either; `permutation_test`/`top_quartile_recovery` do get entries, matching
+  `logo_cv_predict`/`fit_pca_on_fold`'s precedent).
+- **BLOCKING — task 12.2 missed correcting a stale forward-reference** in
+  `docs/CROSS_PLATFORM_ANALYSIS.md` calling this tier "a separate, later change" — exactly the trap
+  Tier 3.5's own review caught and fixed once already for a different sentence. Fixed: task 12.2
+  now explicitly includes this correction, plus the missing `top_quartile_recovery` doc mention,
+  the new output-file-naming documentation, and a `#197`-pressure note.
+- **IMPORTANT — every target/method reused one `permutation_random_state`**, correlating (not
+  independently sampling) the null draws Decision 9's pooled violin panel combines across targets.
+  Fixed: Decision 4 and the `cross-platform-analysis` spec now derive one independent seed per
+  `(target, method)` combination via `numpy.random.SeedSequence(...).spawn(N)`.
+- **IMPORTANT — the K-S calibration test (tasks.md 9.1) was an intrinsically flaky CI gate** unless
+  every fixture seed and the oracle's own `random_state` are pinned to committed literals (a K-S
+  test against `Uniform(0,1)` on ~30-50 samples has a real, non-negligible false-failure rate by
+  chance). Fixed: tasks.md 1.2 now requires fixed, committed literal seeds throughout.
+- **IMPORTANT — tasks.md 6.5's "bit-identical parallel vs. serial" claim conflicted with real
+  `joblib`/BLAS behavior.** `loky` worker processes may resolve a different default BLAS thread
+  count than the main process — a documented source of ULP-level floating-point differences,
+  independent of this step's own correctness (this codebase already has an established convention
+  for exactly this class of cross-BLAS difference, `rtol=1e-6, atol=1e-9`,
+  `docs/reproducibility.md`). Fixed: the `cross-platform-analysis` spec and tasks.md 6.5 now assert
+  `numpy.testing.assert_allclose` at that established tolerance, not bit-identical equality; the
+  `joblib` backend (`loky`) is now stated explicitly rather than left unspecified.
+- **IMPORTANT — the additive `predictor_matrices` key relies on an unstated invariant** (no valid
+  `reduction_method`/`comparison_methods` value can collide with the string
+  `"predictor_matrices"`). Fixed: Decision 6 and the `cross-platform-analysis` spec now state this
+  explicitly, with a corresponding scenario.
+- **IMPORTANT — `joblib`'s dependency addition (originally task 10.1) was numbered *after* Section
+  6, which imports it.** Fixed: moved to a new Section 5a, explicitly ordered before Section 6.
+- **IMPORTANT — task 9.4 conflated an empirical spike with "write failing test".** You cannot
+  write a meaningful assertion against a value that hasn't been computed yet. Fixed: split into
+  9.4a (a spike, explicitly not a red/green TDD step) and 9.4b (the actual test, written against
+  9.4a's now-known value).
+- **IMPORTANT — missing edge-case tests**: `n_permutations=1` boundary, an explicit
+  `comparison_methods=[]` (`K=0`) case, `VisualizePredictionStep` with zero representative-trait
+  (PC1-only) targets under `joblib.Parallel`, and 5.2's regression test not explicitly asserting
+  `predictor_matrices` is the *only* new key. Fixed: tasks.md 2.12a, 6.2a, 6.1a, and an explicit
+  key-set assertion added to 5.2, respectively.
+- **IMPORTANT — Section 11's timing relative to the PR lifecycle was ambiguous.** Tier 3.5's own
+  real commit history (PR #199) shows manual validation running *between* two rounds of PR-review
+  fix commits, not strictly pre-PR-open. Fixed: tasks.md Section 11 now states this explicitly.
+- **IMPORTANT — task 10.2 (now 10.1) didn't state `theory.md` lives in a separate external git
+  repository**, so a PR reviewer might expect to find it in this repo's diff. Fixed: stated
+  explicitly.
+- **IMPORTANT — `CrossPlatformPermutationResult`'s requirement was missing the "no sklearn/numpy
+  object" parity scenario** its sibling `CrossPlatformPredictionResult` requirement has. Fixed:
+  added to the `serializable-result-types` spec delta, with a corresponding test (tasks.md 3.3a).
+- **SUGGESTION — Section 2 (14 tasks) and Section 6 (8 tasks) were too coarse for this program's
+  established per-commit granularity.** Fixed: both split, with explicit commit-boundary notes
+  (Section 2: `top_quartile_recovery` vs. `permutation_test`; Section 6: wiring/reuse →
+  parallelization → JSON/figure I/O).
+- **SUGGESTION — no boundary scenario for `top_quartile_recovery` when `q` rounds to 0 or exceeds
+  `n/2`.** Fixed: added to the `cross-platform-prediction` spec, with a corresponding test
+  (tasks.md 2.3a).
+- **SUGGESTION — doc tasks risked restating `design.md`'s benchmark/rationale prose (DRY).**
+  Fixed: task 12.2 now explicitly scopes to usage documentation, cross-referencing `design.md`'s
+  Decisions for rationale detail.
+
+Full re-validation (`openspec validate add-prediction-permutation-and-figure --strict`) passes
+after all round-1 fixes.

--- a/openspec/changes/add-prediction-permutation-and-figure/design.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/design.md
@@ -308,7 +308,15 @@ filename pattern is a direct, unmodified precedent from Tier 3.5.
   `10/19 ≈ 52.6%`, not `25%`. This must be stated explicitly (now in the `cross-platform-prediction`
   spec's Top-Quartile Recovery Metric requirement) so the empirical measurement in tasks.md 9.4a is
   correctly interpreted against the right theoretical baseline, not "sanity-checked" against a
-  wrong number that happens to sound plausible.
+  wrong number that happens to sound plausible. **Empirically measured during implementation (task
+  9.4a):** on the N=20-seed pure-noise fixture, at `n_permutations=200`, `reduction_method=
+  "pls_latent"`, the actual pooled mean null top-quartile-recovery is **≈44.3%** (4000 pooled draws)
+  — close to, but measurably below, the `2q/n ≈ 52.6%` theoretical baseline. The gap is expected:
+  the theoretical value assumes a uniformly random `y_pred`, whereas the empirical null instead
+  reflects this fixture's real (LOGO-CV-fit, not uniformly random) predictions fed through
+  `logo_cv_predict`. The noise fixture's own *observed* recovery (≈45%) is, as designed, close to
+  this empirical null, not the theoretical one — confirming 9.4b's assertion is checked against the
+  right (measured) number.
 - **Figure provenance oracle:** PNG exists, non-empty, and a hash/timestamp check confirms it was
   regenerated from the current run's input CSVs, following Tier 3.5's golden-fixture-snapshot
   pattern.

--- a/openspec/changes/add-prediction-permutation-and-figure/design.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/design.md
@@ -407,12 +407,13 @@ implementation began. 5 BLOCKING and 11 IMPORTANT findings, reconciled as follow
   every fixture seed and the oracle's own `random_state` are pinned to committed literals (a K-S
   test against `Uniform(0,1)` on ~30-50 samples has a real, non-negligible false-failure rate by
   chance). Fixed: tasks.md 1.2 now requires fixed, committed literal seeds throughout.
-- **IMPORTANT — tasks.md 6.5's "bit-identical parallel vs. serial" claim conflicted with real
-  `joblib`/BLAS behavior.** `loky` worker processes may resolve a different default BLAS thread
-  count than the main process — a documented source of ULP-level floating-point differences,
-  independent of this step's own correctness (this codebase already has an established convention
-  for exactly this class of cross-BLAS difference, `rtol=1e-6, atol=1e-9`,
-  `docs/reproducibility.md`). Fixed: the `cross-platform-analysis` spec and tasks.md 6.5 now assert
+- **IMPORTANT — the "bit-identical parallel vs. serial" claim (task numbered 6.5 at the time of
+  this fix; renumbered to 7b.5 by round 2's Section 6/7 restructuring, see below) conflicted with
+  real `joblib`/BLAS behavior.** `loky` worker processes may resolve a different default BLAS
+  thread count than the main process — a documented source of ULP-level floating-point
+  differences, independent of this step's own correctness (this codebase already has an
+  established convention for exactly this class of cross-BLAS difference, `rtol=1e-6, atol=1e-9`,
+  `docs/reproducibility.md`). Fixed: the `cross-platform-analysis` spec and that task now assert
   `numpy.testing.assert_allclose` at that established tolerance, not bit-identical equality; the
   `joblib` backend (`loky`) is now stated explicitly rather than left unspecified.
 - **IMPORTANT — the additive `predictor_matrices` key relies on an unstated invariant** (no valid
@@ -420,7 +421,10 @@ implementation began. 5 BLOCKING and 11 IMPORTANT findings, reconciled as follow
   `"predictor_matrices"`). Fixed: Decision 6 and the `cross-platform-analysis` spec now state this
   explicitly, with a corresponding scenario.
 - **IMPORTANT — `joblib`'s dependency addition (originally task 10.1) was numbered *after* Section
-  6, which imports it.** Fixed: moved to a new Section 5a, explicitly ordered before Section 6.
+  6, which imported it at the time** (Section 6 was `VisualizePredictionStep` before round 2's
+  restructuring; the step is now Section 7, specifically 7b, and Section 6 is the figure-content
+  module, which does not import `joblib`). Fixed: moved to a new Section 5a, ordered before every
+  section that could plausibly need it.
 - **IMPORTANT — task 9.4 conflated an empirical spike with "write failing test".** You cannot
   write a meaningful assertion against a value that hasn't been computed yet. Fixed: split into
   9.4a (a spike, explicitly not a red/green TDD step) and 9.4b (the actual test, written against
@@ -428,8 +432,11 @@ implementation began. 5 BLOCKING and 11 IMPORTANT findings, reconciled as follow
 - **IMPORTANT — missing edge-case tests**: `n_permutations=1` boundary, an explicit
   `comparison_methods=[]` (`K=0`) case, `VisualizePredictionStep` with zero representative-trait
   (PC1-only) targets under `joblib.Parallel`, and 5.2's regression test not explicitly asserting
-  `predictor_matrices` is the *only* new key. Fixed: tasks.md 2.12a, 6.2a, 6.1a, and an explicit
-  key-set assertion added to 5.2, respectively.
+  `predictor_matrices` is the *only* new key. Fixed: tasks.md 2.12a and an explicit key-set
+  assertion added to 5.2 at the time (the `K=0` and PC1-only cases were tasks numbered 6.2a/6.1a at
+  the time of this fix; renumbered to 7a.4/7a.2 by round 2's Section 6/7 restructuring, see below —
+  and round 3 found the PC1-only case still needs re-verification under real `joblib` dispatch, not
+  just the pre-parallelization serial path these renumbered tasks actually test).
 - **IMPORTANT — Section 11's timing relative to the PR lifecycle was ambiguous.** Tier 3.5's own
   real commit history (PR #199) shows manual validation running *between* two rounds of PR-review
   fix commits, not strictly pre-PR-open. Fixed: tasks.md Section 11 now states this explicitly.
@@ -464,8 +471,9 @@ But it also found 2 new BLOCKING issues — both real implementation-blocking bu
 a further batch of IMPORTANT gaps:
 
 - **BLOCKING (new) — round 1's own RNG fix was itself invalid.** `numpy.random.Generator(random_state)`
-  requires a `BitGenerator` instance and raises `TypeError` on a bare `int` — the exact API round 1's
-  fix specified. Separately, the `SeedSequence.spawn(N)` → `permutation_test(random_state=...)`
+  requires a `BitGenerator` instance and raises (empirically confirmed: `AttributeError`, since an
+  `int` has no `.capsule` attribute — not `TypeError`, corrected during round 3) on a bare `int` —
+  the exact API round 1's fix specified. Separately, the `SeedSequence.spawn(N)` → `permutation_test(random_state=...)`
   handoff (also introduced in round 1) was left completely unspecified: `spawn()` returns
   `SeedSequence` objects, not ints, and `permutation_test`'s signature was still typed as a plain
   `int`. Fixed: `permutation_test` now builds its RNG via `numpy.random.default_rng(random_state)`,
@@ -568,3 +576,101 @@ a further batch of IMPORTANT gaps:
 Full re-validation (`openspec validate add-prediction-permutation-and-figure --strict`) passes
 after all round-2 fixes (94 tasks, up from 88 — 2 new BLOCKING fixes and the Section 6/7
 restructuring account for most of the growth).
+
+## Adversarial Review Reconciliation (round 3)
+
+A third, independent round of the same 5-agent review (run fresh, with no memory of rounds 1-2)
+re-verified nearly everything from both prior rounds directly (the restored 20-scenario MODIFIED
+requirement re-counted a third time with no drift found; the `2q/n` math re-derived independently
+and confirmed correct including the small-`n=3` edge case; `numpy.random.default_rng`'s accepted-
+input claim confirmed against real numpy behavior; the `predictor_matrices` collision invariant
+re-checked against current source; Tier 3.5's manual-validation timing claim re-verified against
+real commit timestamps a second time). But it also found 1 new BLOCKING issue — a genuine
+statistical bug that both prior rounds missed entirely — plus a real, concrete implementation risk
+in the round-2 restructuring, and several smaller staleness/precision gaps this proposal's own
+churn across two rounds had introduced:
+
+- **BLOCKING (new) — the RMSE p-value formula was directionally inverted.** The R²/ρ formula
+  (`count(null >= observed)`, right-tail — correct, since higher R²/ρ means better prediction) was
+  applied uniformly to RMSE too, where *lower* is better prediction — meaning a genuinely good
+  (low-RMSE) result would read as non-significant (`p ≈ 1`) and a genuinely bad (high-RMSE) result
+  would read as highly significant (`p ≈ 0`), exactly backwards. Verified by direct simulation
+  during the review. Neither round 1 nor round 2 caught this, and no planned oracle test would have
+  either — 9.1's K-S calibration only checked `p_value_r2`; 9.2/9.3 only checked mean R². Fixed:
+  the Permutation Test requirement now states the correct, metric-specific formula (right-tail for
+  R²/ρ, **left-tail**, `count(null <= observed)`, for RMSE), with two new scenarios and two new
+  oracle tests (9.1a: RMSE-specific K-S calibration; 9.2a: a direct regression test that a good
+  low-RMSE planted-signal result reads as significant, not the reverse).
+- **BLOCKING (new) — mock-based spy tests (7a.1/7a.3/7a.4/7b.4) would silently break or stop
+  testing anything once real `joblib` multi-process dispatch is wired in by 7b.6.** `loky` dispatches
+  work to separate worker *processes*; a `unittest.mock.patch` applied in the parent/test process
+  is invisible inside a worker — the worker either calls the real, unmocked function (silently
+  defeating the spy) or a non-picklable `Mock` raises `PicklingError`. This is concretely avoidable
+  only because `joblib.Parallel(n_jobs=1)` is documented to run sequentially in-process, never
+  touching `loky` — but nothing in the original task text said these tests must pin
+  `permutation_n_jobs=1` to rely on that fast path. Fixed: an explicit note added at the top of
+  Section 7a stating this requirement for 7a.1/7a.3/7a.4/7b.4, and clarifying that 7b.1/7b.2 (which
+  inspect the `joblib.Parallel`/`delayed` construction directly, not `permutation_test`) and 7b.5
+  (which calls the real function, no mocking) are unaffected.
+- **IMPORTANT (new) — 7a.2's PC1-only-targets test only exercises the pre-`joblib` serial path**,
+  never re-verified after 7b.6 wires in real parallel dispatch, despite the `cross-platform-
+  analysis` spec's own scenario text requiring this degenerate case to work "dispatching `N=1`...
+  through `joblib.Parallel`." Fixed: new task 7b.7 re-runs the same fixture through real
+  `joblib.Parallel(n_jobs=4)` (no mocking) as a completeness/regression check.
+- **IMPORTANT (new) — `create_prediction_figure()` (Section 6) had no test for a single-target
+  input**, even though 7c.7 will call it for exactly the PC1-only degenerate case Section 7 already
+  handles at the step level — an untested risk that the violin/bar-chart panels might not degrade
+  gracefully to `N=1`. Fixed: task 6.4a.
+- **IMPORTANT (new) — the "`default_rng` accepts `int`/`SeedSequence`/`Generator` uniformly" claim
+  overclaimed semantic equivalence.** `numpy.random.default_rng(existing_generator)` returns that
+  *exact instance*, unaltered — unlike `int`/`SeedSequence` (stateless value-seeds, always
+  reproduce the same stream), a `Generator` is mutable and stateful, so reusing the *same instance*
+  across two `permutation_test()` calls does **not** reproduce the same null arrays the second
+  time (its state has advanced). This silently contradicted the "Same random_state produces
+  identical null distributions" scenario for a caller who (reasonably, per the original claim)
+  passed a `Generator`. Fixed: the requirement body now states this caveat explicitly (only
+  `int`/`SeedSequence` carry the reproducibility guarantee; `VisualizePredictionStep` never passes
+  a bare `Generator` for exactly this reason), and the determinism scenario is now scoped to
+  `int`/`SeedSequence` only, explicitly noting it is not tested (or expected to hold) for a bare
+  `Generator`.
+- **IMPORTANT (new, self-referential) — this proposal's own round-1 reconciliation text had gone
+  stale after round 2's Section 6/7 renumbering**, still citing "tasks.md 6.5," "6.2a," "6.1a," and
+  "Section 6, which imports `joblib`" for things now at 7b.5, 7a.4, 7a.2, and Section 7b
+  respectively — the exact "stale reference after renumbering" trap this review brief warned
+  about, missed by round 2's own restructuring pass. Fixed: round 1's bullets above annotated
+  in-place with the current locations; `tasks.md`'s 5a.1 and Section 10's header corrected from
+  "Section 6" to "Section 7b."
+- **IMPORTANT (new) — CI timing for Section 9's oracle tests was asserted (`n_permutations=200`
+  is "CI-fast"), never actually measured**, and the K-S calibration fixture count was left as
+  "~30-50" rather than an exact, reproducible number. Fixed: pinned to exactly 40 fixtures (task
+  1.2/9.1); task 9.6 now requires recording Section 9's actual measured wall time per OS, not
+  trusting the ~8-minute estimate.
+- **SUGGESTION (new) — the top-quartile-recovery chance-level range ("≈45-53%") was slightly too
+  narrow** given Python's banker's rounding across the real `n=15-24` scale (actual range ≈44.4%
+  at `n=18` to ≈54.5% at `n=22`). Fixed: widened to "≈44-55%," with the exact per-`n` figures shown.
+- **SUGGESTION (new) — the claimed exception type for `numpy.random.Generator(int)` was wrong**
+  (stated as `TypeError`; numpy actually raises `AttributeError`). Fixed, cosmetic only — the
+  underlying design conclusion (avoid this constructor, use `default_rng`) was already correct.
+- **SUGGESTION (new) — the two new same-basename files
+  (`visualize_prediction.py` in two different subpackages) had no explicit acknowledgment anywhere
+  that this was a deliberate, considered naming choice.** Fixed: one clarifying note added to
+  `proposal.md`, plus disambiguating test-file names (`test_step_visualize_prediction.py` vs.
+  `test_visualize_prediction.py`, matching this repo's existing `test_step_visualize_cross_platform.py`
+  convention for step tests).
+- **Verified clean, no action needed:** `SeedSequence.spawn(N)`'s determinism is a real, numpy-
+  documented stream-stability guarantee, not an assumption; the non-finite-null scan's memory
+  footprint is negligible (thousands of floats, not gigabytes) even for the worst-case Cylinder
+  pair; `joblib.Parallel(backend="loky")`'s fail-fast-on-first-exception behavior (confirmed
+  empirically during the review) means "collect all results in memory, write JSON only after
+  `Parallel(...)` returns" is a correct, simple implementation of the all-or-nothing partial-
+  failure contract, with no additional engineering needed; 7b.5's small `n_permutations=50` is a
+  determinism check, not a statistical-power check, so a small `N` doesn't weaken it the way it
+  would for a calibration oracle.
+
+Full re-validation (`openspec validate add-prediction-permutation-and-figure --strict`) passes
+after all round-3 fixes (98 tasks, up from 94). Given the pattern across three rounds — round 1:
+5 BLOCKING; round 2: 2 new BLOCKING; round 3: 1 new BLOCKING (a genuine, previously-undetected
+statistical bug) + 1 new BLOCKING-adjacent implementation risk — severity has **not** cleanly
+diminished round-over-round the way Tiers 3/3.5's own review history did. Each round has still
+found at least one substantive, non-cosmetic defect. A fourth round is recommended before treating
+this as settled, rather than stopping here on volume alone.

--- a/openspec/changes/add-prediction-permutation-and-figure/proposal.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/proposal.md
@@ -101,7 +101,14 @@ No changes to `logo_cv_predict`, `fit_pca_on_fold`, `CrossPlatformPredictionResu
 - `src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py` (new) —
   `VisualizePredictionStep`.
 - `src/sleap_roots_analyze/visualize_prediction.py` (new) — `create_prediction_figure()` and
-  supporting plotting functions.
+  supporting plotting functions. **Naming note**: this repo already has an analogous pair —
+  `pipeline/steps/visualize_cross_platform.py` (the step) vs. `cross_experiment_analysis.py` (the
+  plotting functions it calls, under a different name) — but this tier's two new files share the
+  same basename (`visualize_prediction.py`) in two different subpackages. Full import paths never
+  collide (`sleap_roots_analyze.visualize_prediction` vs.
+  `sleap_roots_analyze.pipeline.steps.visualize_prediction`), but a bare `grep -r
+  visualize_prediction.py` or an IDE "go to file" will surface both — test files are named to
+  disambiguate (see below), and each module's own docstring notes the other's existence and path.
 - `src/sleap_roots_analyze/pipeline/config/components.py` — 4 new `PredictionConfig` fields;
   extended `CrossPlatformConfig.__post_init__` cross-check.
 - `src/sleap_roots_analyze/pipeline/pipelines/cross_platform_pipeline.py` — conditional 7th task.
@@ -110,8 +117,12 @@ No changes to `logo_cv_predict`, `fit_pca_on_fold`, `CrossPlatformPredictionResu
 - `tests/fixtures.py` / `tests/fixtures/` — new synthetic fixtures (planted-signal/noise reuse
   from Tier 3, pure-noise fixtures for the K-S calibration test).
 - `tests/test_cross_platform_prediction.py` (extended), `tests/test_result_types.py` (extended),
-  `tests/test_predict_cross_platform.py` (extended), `tests/test_visualize_prediction.py` (new),
-  `tests/test_cross_platform_config.py` (extended).
+  `tests/test_predict_cross_platform.py` (extended), `tests/test_cross_platform_config.py`
+  (extended), and two new test files matching the naming-note above's disambiguation:
+  `tests/test_step_visualize_prediction.py` (new, `VisualizePredictionStep` — matching this repo's
+  existing `test_step_visualize_cross_platform.py` convention for step tests) and
+  `tests/test_visualize_prediction.py` (new, `create_prediction_figure()` and its plotting
+  helpers).
 - `docs/API.md`, `docs/CHANGELOG.md`, `docs/CROSS_PLATFORM_ANALYSIS.md` — new function/step/config
   entries.
 - `c:\vaults\sleap-roots\wheat-edpie-paper\cross-platform-prediction\theory.md` (external vault) —

--- a/openspec/changes/add-prediction-permutation-and-figure/proposal.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/proposal.md
@@ -1,0 +1,130 @@
+## Why
+
+Tier 3 (`add-cross-platform-prediction`, merged #195) shipped `logo_cv_predict()`,
+`fit_pca_on_fold()`, and `CrossPlatformPredictionResult` as plain, stateless Python-API functions
+— deliberately written (Tier 3 Decision 3) so a future permutation loop could wrap them without
+refactoring. Tier 3.5 (`add-prediction-pipeline-step`, merged #199) wired the *observed*
+(non-permuted) prediction into `CrossPlatformPipeline` as an optional `PredictCrossPlatformStep`.
+
+Neither tier answers the question Wolfgang's original ask (roadmap.md Goal section) actually
+requires: is a given cross-platform R² distinguishable from chance at n≈19 genotypes? Tier 3's own
+Decision 9 documents `spearman_p`'s asymptotic p-value as unreliable below n≈20-30 — exactly the
+gap this tier closes with an empirical, shuffled-label permutation null. Neither tier produces a
+paper-ready figure either. This is Tier 4 (`add-prediction-permutation-and-figure`) of the wheat
+EDPIE cross-platform genotype-prediction program: a permutation-null significance test (Python API,
+hard-depends on Tier 3 only) and `VisualizePredictionStep` (a new optional pipeline step,
+soft-depends on Tier 3.5) that renders a 3-panel figure per directed pair.
+
+Full design, alternatives considered, and empirical runtime benchmarks (this program's own
+"verify, don't assume" convention) are recorded in
+`docs/superpowers/specs/2026-07-16-prediction-permutation-and-figure-design.md`, brainstormed and
+approved by Elizabeth before this proposal was drafted.
+
+## What Changes
+
+- **New `permutation_test()`** (`cross_platform_prediction.py`, Tier 3's existing stateless
+  module — Python API only, no pipeline dependency): given `X`, `y`, `genotypes`,
+  `reduction_method`, `representative_names`, `n_permutations=1000`, `random_state=42`, computes
+  the observed R²/RMSE/Spearman ρ/top-quartile-recovery via one `logo_cv_predict()` call on the
+  real `y`, then the same four metrics' null distributions via `n_permutations` shuffled-`y`
+  `logo_cv_predict()` calls, plus one-sided p-values for R²/RMSE/Spearman ρ. Self-contained: a
+  caller gets a complete result from one call.
+- **New `top_quartile_recovery(y_true, y_pred, q=None)`** (same module): the roadmap's settled
+  metric — fraction of the true top-`q` genotypes recovered in the predicted top-`2q`
+  (`q` defaults to `round(n/4)`).
+- **New `PermutationResult`/`CrossPlatformPermutationResult`** (`result_types.py`), mirroring the
+  `LOGOCVResult`/`TargetPrediction`/`CrossPlatformPredictionResult` pattern exactly (frozen
+  dataclasses, `to_dict()`/`to_json()` with the finite-floats contract). Kept **separate** from
+  `CrossPlatformPredictionResult` (not nested inside it) — permutation is an optional, heavier
+  concern orthogonal to the observed-result type.
+- **Parallelization strategy, empirically verified this session** (not assumed): `joblib.Parallel`
+  parallelizing across independent *targets* (each worker runs one target's own full, serial
+  1000-permutation loop) — individual permutation calls are too fast (~16-27ms) for process-based
+  parallelism to pay off, and measured *slower* than serial when parallelized directly. Worst-case
+  real-EDPIE estimate (Cylinder-as-target pair, ~129 representative traits, both `reduction_method`
+  + one `comparison_methods` entry, N=1000, all 4 pairs): ~105.5 min serial → ~27.4 min parallel
+  (`n_jobs=8`) — under the roadmap's 30-minute feasibility gate. `joblib` becomes an explicit
+  direct dependency in `pyproject.toml` (previously only transitive via `scikit-learn`).
+- **Additive extension to `PredictCrossPlatformStep`** (Tier 3.5, already merged): `StepResult.data`
+  gains a new `predictor_matrices` key holding the already-computed `source_clean`/`target_clean`
+  matrices and `source_representative_names`/`target_representatives` — no existing `data`/
+  `metadata`/`files_generated` key changes shape.
+- **New `VisualizePredictionStep`**, an optional 7th task on `CrossPlatformPipeline`
+  (`depends_on=["06_predict_cross_platform"]`, for both data and ordering), entirely absent from
+  `create_tasks()` unless `config.prediction.visualize=True`. For every `(target, method)`
+  combination, runs `permutation_test()` via the parallel strategy above, saves one
+  `CrossPlatformPermutationResult` JSON per method (`07_permutation_<method>.json`), and builds one
+  composite 3-panel figure per pair using only the primary `reduction_method`
+  (`07_prediction_figure.png`): PC1 obs-vs-pred scatter, all-targets R²-vs-pooled-null
+  violin/strip, and an aggregate top-quartile-recovery bar chart.
+- **`PredictionConfig` gains 4 new fields** (nested, not a new sibling config — `visualize` is
+  meaningless without `enabled`): `visualize: bool = False`, `n_permutations: int = 1000`,
+  `permutation_random_state: int = 42`, `permutation_n_jobs: int = 8`.
+  `CrossPlatformConfig.__post_init__` gains one more cross-check: `visualize=True` with
+  `enabled=False` raises `ValueError` at construction time.
+- **`theory.md` (Tier 0) gains a permutation-null pseudo-code addendum**, including the
+  per-target (not per-permutation) parallelization lesson from this tier's benchmark — a Tier 0
+  erratum contribution, matching the "carry lessons forward" convention already used for Tier 3's
+  own single-seed-fixture correction.
+- **Manual, non-CI, sign-off-gated real-EDPIE-data validation** (Section 5 of the design doc,
+  mirroring Tier 3/3.5's own manual validation gate exactly): re-measures real wall time against
+  the worst-case pair (superseding the synthetic-fixture-derived 27.4-minute estimate), sanity-
+  checks permutation-based p-values against Tier 3.5's Section 8 findings, and requires Elizabeth's
+  explicit sign-off before merge.
+
+No changes to `logo_cv_predict`, `fit_pca_on_fold`, `CrossPlatformPredictionResult`, or any of
+`PredictCrossPlatformStep`'s existing (Tier 3.5) behavior/outputs — all extensions are additive.
+
+## Impact
+
+### Affected specs
+
+- `cross-platform-prediction` (ADDED) — `Permutation Test`, `Top-Quartile Recovery Metric`,
+  `Permutation Test Input Validation` requirements (Python-API-only, Tier 3's module).
+- `serializable-result-types` (ADDED) — `Serializable Cross-Platform Permutation Result Type`,
+  `CrossPlatformPermutationResult Adapter From permutation_test Output`,
+  `CrossPlatformPermutationResult Public Export` requirements.
+- `cross-platform-analysis` (MODIFIED) — `Cross-Platform Prediction Configuration` gains the 4 new
+  `PredictionConfig` fields and the `visualize`-requires-`enabled` cross-check;
+  `Predict Cross-Platform Genotype Values Pipeline Step` gains the additive `predictor_matrices`
+  exposure. (ADDED) — new `Visualize Cross-Platform Prediction Pipeline Step` requirement.
+
+### Affected code
+
+- `src/sleap_roots_analyze/cross_platform_prediction.py` — new `permutation_test()`,
+  `top_quartile_recovery()`.
+- `src/sleap_roots_analyze/result_types.py` — new `PermutationResult`,
+  `CrossPlatformPermutationResult`.
+- `src/sleap_roots_analyze/__init__.py` — new exports.
+- `src/sleap_roots_analyze/pipeline/steps/predict_cross_platform.py` — additive
+  `predictor_matrices` extension to `StepResult.data`.
+- `src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py` (new) —
+  `VisualizePredictionStep`.
+- `src/sleap_roots_analyze/visualize_prediction.py` (new) — `create_prediction_figure()` and
+  supporting plotting functions.
+- `src/sleap_roots_analyze/pipeline/config/components.py` — 4 new `PredictionConfig` fields;
+  extended `CrossPlatformConfig.__post_init__` cross-check.
+- `src/sleap_roots_analyze/pipeline/pipelines/cross_platform_pipeline.py` — conditional 7th task.
+- `src/sleap_roots_analyze/cli.py` — dry-run step list gains a conditional 7th entry.
+- `pyproject.toml` — `joblib` added as an explicit direct dependency.
+- `tests/fixtures.py` / `tests/fixtures/` — new synthetic fixtures (planted-signal/noise reuse
+  from Tier 3, pure-noise fixtures for the K-S calibration test).
+- `tests/test_cross_platform_prediction.py` (extended), `tests/test_result_types.py` (extended),
+  `tests/test_predict_cross_platform.py` (extended), `tests/test_visualize_prediction.py` (new),
+  `tests/test_cross_platform_config.py` (extended).
+- `docs/API.md`, `docs/CHANGELOG.md`, `docs/CROSS_PLATFORM_ANALYSIS.md` — new function/step/config
+  entries.
+- `c:\vaults\sleap-roots\wheat-edpie-paper\cross-platform-prediction\theory.md` (external vault) —
+  permutation-null pseudo-code addendum.
+
+### Explicitly out of scope
+
+- Any change to `logo_cv_predict`, `fit_pca_on_fold`, `CrossPlatformPredictionResult`,
+  `cluster_correlated_traits`, `select_cluster_representatives`, or `PredictCrossPlatformStep`'s
+  existing (Tier 3.5) behavior/outputs — all reused/extended additively.
+- `CrossPlatformSummaryGenerator`/`.claude/commands/cross-platform-summary.md` not surfacing
+  prediction *or* permutation results — still follow-up
+  [#197](https://github.com/talmolab/sleap-roots-analyze/issues/197).
+- `/configure-run-all`, `/dry-run`, `/validate-config` cross-platform/prediction coverage gaps —
+  still follow-up [#198](https://github.com/talmolab/sleap-roots-analyze/issues/198), pre-existing.
+- Heritability-based `representative_selection_metric` — still deferred (Tier 3.5 Decision 7).

--- a/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-analysis/spec.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-analysis/spec.md
@@ -254,14 +254,78 @@ and SHALL NOT list it when disabled. No new CLI command or flag SHALL be introdu
 - **WHEN** the step runs for each
 - **THEN** the resulting `CrossPlatformPredictionResult`s SHALL be identical
 
+#### Scenario: logo_cv_predict called once per target trait per method
+
+- **GIVEN** N target traits (representatives + PC1) and M methods (`reduction_method` +
+  `comparison_methods`)
+- **WHEN** the step runs
+- **THEN** `logo_cv_predict` SHALL be called exactly N × M times
+
+#### Scenario: One JSON result file saved per method
+
+- **WHEN** the step completes
+- **THEN** one `CrossPlatformPredictionResult` JSON file SHALL be written to the run directory per
+  method, with no filename collisions (guaranteed by `comparison_methods` never duplicating
+  `reduction_method`)
+
+#### Scenario: Clear error when common genotypes are below the minimum
+
+- **WHEN** the source and target predictor matrices share fewer common genotypes than
+  `logo_cv_predict` requires (including zero overlap)
+- **THEN** the step SHALL raise `ValueError` naming the source/target platforms and the
+  common-genotype count, not a bare pass-through of `logo_cv_predict`'s generic message
+
+#### Scenario: Backward compatible when disabled
+
+- **GIVEN** an existing `CrossPlatformConfig` YAML with no `prediction:` key
+- **WHEN** `CrossPlatformPipeline` runs
+- **THEN** the run's analysis output (file list and content for the 5 existing steps — correlation
+  CSVs, alignment summary, figures, `pipeline_summary.json`) SHALL be byte-identical to the same run
+  before this requirement existed
+- **AND** `config.yaml` is exempted from this comparison: it SHALL gain a new `prediction: {...}`
+  block reflecting the `prediction` field's existence, regardless of `enabled`, since the pipeline's
+  config-provenance serialization (`cli-pipeline`'s "Pipeline Run Config Provenance" requirement)
+  serializes every field of the resolved config, including nested dataclasses at their default
+  values — this is an expected, harmless side effect, not a behavior change
+
+#### Scenario: PC1 target uses whole-dataset PCA, not per-fold
+
+- **WHEN** the step computes the `target_name="PC1"` value
+- **THEN** it SHALL use `pca.fit_pca()` (with `StandardScaler` applied first, `random_state=42`
+  fixed) on the full common-genotype set
+- **AND** `fit_pca_on_fold` SHALL NOT be called for this purpose
+- **AND** the computed values SHALL match an independently-computed
+  `pca.fit_pca(StandardScaler().fit_transform(X), n_components=1, random_state=42)` on the same data
+
+#### Scenario: Dry-run lists the prediction step when enabled
+
+- **WHEN** `sleap-roots-analyze cross-platform <config> --dry-run` runs with
+  `config.prediction.enabled=True`
+- **THEN** the printed step list SHALL include a 6th entry for the prediction step
+
+#### Scenario: Dry-run omits the prediction step when disabled
+
+- **WHEN** `sleap-roots-analyze cross-platform <config> --dry-run` runs with
+  `config.prediction.enabled=False` (or the `prediction:` key absent)
+- **THEN** the printed step list SHALL contain exactly the existing 5 entries
+
 #### Scenario: predictor_matrices is exposed for downstream reuse without changing existing outputs
+
+`StepResult.data` is a plain dict keyed by method name (one `CrossPlatformPredictionResult.to_dict()`
+per `reduction_method`/`comparison_methods` entry). Adding a sibling `"predictor_matrices"` key is
+safe only because no valid `reduction_method`/`comparison_methods` value can itself equal
+`"predictor_matrices"` (both are constrained to `{"pls_latent", "representatives", "pc1"}`) — this
+is a load-bearing invariant on the reduction-method enum, not an incidental fact.
 
 - **WHEN** the step runs to completion
 - **THEN** `StepResult.data["predictor_matrices"]` SHALL hold the `source_clean`/`target_clean`
   DataFrames and `source_representative_names`/`target_representatives` computed during this run
-- **AND** every other key in `StepResult.data`, `StepResult.metadata`, and
-  `StepResult.files_generated` SHALL be unchanged in shape and content relative to this step's
-  behavior before this key was added
+- **AND** every method-keyed entry in `StepResult.data` (one per `reduction_method`/
+  `comparison_methods` value) SHALL be unchanged in shape and content relative to this step's
+  behavior before this key was added, and `StepResult.metadata`/`StepResult.files_generated` SHALL
+  likewise be unchanged
+- **AND** `"predictor_matrices"` SHALL NOT collide with any valid `reduction_method`/
+  `comparison_methods` value, now or if that enum is ever extended by a future change
 
 ## ADDED Requirements
 
@@ -277,16 +341,32 @@ step never runs without task 6 having already run in the same pipeline.
 For a given directed pair, the step SHALL:
 1. Read `predictor_matrices` and the observed `CrossPlatformPredictionResult`(s) from task 6's
    `StepResult.data`.
-2. For every `(target_name, method)` combination present in task 6's results (both
+2. Derive one independent `random_state` per `(target_name, method)` combination from
+   `config.prediction.permutation_random_state` via
+   `numpy.random.SeedSequence(permutation_random_state).spawn(N)` (`N` = the total number of
+   `(target_name, method)` combinations for this pair), rather than reusing the single configured
+   seed identically for every combination — reusing one seed would make every target draw the
+   identical permutation-index sequence, correlating (not independently sampling) the null draws
+   this step later pools across targets into one figure panel (see the pooled-violin scenario
+   below). The whole run remains deterministic given `permutation_random_state`, since
+   `SeedSequence.spawn` is itself deterministic.
+3. For every `(target_name, method)` combination present in task 6's results (both
    `reduction_method` and every `comparison_methods` entry), run `permutation_test()`
-   (`cross_platform_prediction.py`) with `n_permutations=config.prediction.n_permutations`,
-   `random_state=config.prediction.permutation_random_state`. These calls SHALL be parallelized
-   via `joblib.Parallel(n_jobs=config.prediction.permutation_n_jobs)`, with each parallel unit of
-   work being one complete `(target_name, method)` permutation test (not individual permutation
-   iterations within one test).
-3. Save one `CrossPlatformPermutationResult` per method as JSON to the run directory:
+   (`cross_platform_prediction.py`) with `n_permutations=config.prediction.n_permutations` and that
+   combination's derived `random_state` (step 2). These calls SHALL be parallelized via
+   `joblib.Parallel(n_jobs=config.prediction.permutation_n_jobs, backend="loky")`, with each
+   parallel unit of work being one complete `(target_name, method)` permutation test (not
+   individual permutation iterations within one test). Because each `permutation_test()` call is a
+   pure function of its own arguments with no shared mutable state, `loky`'s process-based
+   isolation cannot introduce cross-call RNG interference or change *which* values are computed —
+   results at different `permutation_n_jobs` settings SHALL agree within this codebase's
+   established cross-BLAS numerical tolerance (`rtol=1e-6, atol=1e-9`, `docs/reproducibility.md`),
+   not necessarily bit-for-bit, since `loky` worker processes may resolve a different default BLAS
+   thread count than the main process, a documented source of ULP-level floating-point differences
+   independent of this step's own logic.
+4. Save one `CrossPlatformPermutationResult` per method as JSON to the run directory:
    `07_permutation_<method>.json`.
-4. Build one composite figure per pair (not per method) using only the primary
+5. Build one composite figure per pair (not per method) using only the primary
    `reduction_method`'s results: a PC1 observed-vs-predicted scatter, an all-targets observed-R²-
    vs-pooled-permutation-null strip/violin plot, and an aggregate top-quartile-recovery bar chart
    (observed mean vs. null mean). Save as `07_prediction_figure.png`.
@@ -310,6 +390,16 @@ For a given directed pair, the step SHALL:
 - **THEN** `joblib.Parallel` SHALL distribute the `N` combinations across
   `config.prediction.permutation_n_jobs` workers, with each worker running one combination's
   complete, internally-serial `permutation_test()` call
+
+#### Scenario: Each (target, method) combination draws an independent permutation seed
+
+- **GIVEN** `N` `(target_name, method)` combinations for a pair
+- **WHEN** task 7 derives each combination's `random_state` via
+  `numpy.random.SeedSequence(config.prediction.permutation_random_state).spawn(N)`
+- **THEN** no two combinations SHALL receive the same derived seed
+- **AND** re-running the step with the same `permutation_random_state` and the same `N`
+  combinations (same order) SHALL reproduce identical derived seeds, and therefore identical
+  results, for every combination
 
 #### Scenario: One permutation JSON per method
 

--- a/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-analysis/spec.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-analysis/spec.md
@@ -1,0 +1,337 @@
+## MODIFIED Requirements
+
+### Requirement: Cross-Platform Prediction Configuration
+
+The system SHALL provide a `PredictionConfig` dataclass (nested as the `prediction` field on
+`CrossPlatformConfig`) with the following parameters:
+
+- `enabled`: bool, default `False`. When `False`, `__post_init__` SHALL perform no validation at
+  all (not even structural checks on other fields), so every existing `CrossPlatformConfig` that
+  predates this requirement remains valid unchanged.
+- `predictor_source`: `"blup"` or `"genotype_means"`, default `"blup"`.
+- `reduction_method`: the primary dimensionality-reduction method passed to `logo_cv_predict`
+  (`"pls_latent"`, `"representatives"`, or `"pc1"`), default `"pls_latent"`.
+- `comparison_methods`: list of additional reduction methods for robustness reporting, each drawn
+  from the same `{"pls_latent", "representatives", "pc1"}` set as `reduction_method`, default
+  `["representatives"]`. SHALL NOT contain `reduction_method`'s own value (would silently produce
+  two methods writing to the same output file).
+- `representative_selection_metric`: `"variance"` only for this tier. `"heritability"` is not a
+  valid value here — `select_cluster_representatives` (reused unchanged) has no metric parameter to
+  select by heritability, so this option is deferred to a future change.
+- `platform_pairs`: list of `{"source": str, "target": str}` dicts, default empty. When
+  `enabled=True`, SHALL contain **exactly one** entry (not zero, not more than one) naming which of
+  the enclosing `CrossPlatformConfig`'s `exp1_name`/`exp2_name` is the predictor and which is
+  predicted.
+- `blup_refit_per_fold`: bool, default `False`. Present in the schema for forward compatibility with
+  a future heritability-based `representative_selection_metric`, but currently inert in this tier —
+  no valid `representative_selection_metric` value triggers any auto-force or validation on it.
+- `source_blup_path` / `target_blup_path`: `Optional[str]`, default `None`. Required and
+  existence-checked on disk only when `enabled=True` and `predictor_source="blup"`. Not required
+  when `predictor_source="genotype_means"`.
+- `visualize`: bool, default `False`. Gates whether `VisualizePredictionStep` (see the Visualize
+  Cross-Platform Prediction Pipeline Step requirement) is added to `CrossPlatformPipeline`.
+  Requires `enabled=True` — validated in `CrossPlatformConfig.__post_init__` (see below), since
+  visualization has nothing to visualize without a prior prediction run.
+- `n_permutations`: int, default `1000`. Number of shuffled-label permutations `permutation_test()`
+  draws per (target, method) combination when `visualize=True`. Only meaningful (and only
+  validated) when `visualize=True`.
+- `permutation_random_state`: int, default `42`. Seed for the permutation shuffles.
+- `permutation_n_jobs`: int, default `8`. Number of `joblib.Parallel` workers `VisualizePredictionStep`
+  uses to parallelize permutation testing across independent prediction targets.
+
+`PredictionConfig.__post_init__` SHALL raise `ValueError` (not a new exception type) for any
+validation failure, matching every other config dataclass's existing convention in this codebase.
+`CrossPlatformConfig.__post_init__` SHALL additionally raise `ValueError` when
+`prediction.visualize=True` and `prediction.enabled=False`.
+
+#### Scenario: Validation is a full no-op when disabled
+
+- **WHEN** `PredictionConfig(enabled=False, predictor_source="not_a_real_value",
+  source_blup_path="/does/not/exist")` is constructed
+- **THEN** no exception SHALL be raised
+
+#### Scenario: Invalid enum field rejected when enabled
+
+- **GIVEN** `enabled=True`
+- **WHEN** `predictor_source`, `reduction_method`, `representative_selection_metric`, or any entry
+  in `comparison_methods` is not one of its documented valid values
+- **THEN** `ValueError` SHALL be raised naming the invalid field and value
+
+#### Scenario: heritability metric is rejected, not accepted, in this tier
+
+- **GIVEN** `enabled=True`
+- **WHEN** `representative_selection_metric="heritability"`
+- **THEN** `ValueError` SHALL be raised (same as any other invalid enum value) — this tier only
+  supports `"variance"`
+
+#### Scenario: comparison_methods rejects a duplicate of reduction_method
+
+- **GIVEN** `enabled=True, reduction_method="pls_latent"`
+- **WHEN** `comparison_methods` contains `"pls_latent"`
+- **THEN** `ValueError` SHALL be raised at construction time
+
+#### Scenario: comparison_methods rejects a duplicate entry within itself
+
+- **GIVEN** `enabled=True`
+- **WHEN** `comparison_methods` contains the same method twice (e.g.
+  `["representatives", "representatives"]`), independent of `reduction_method`'s value
+- **THEN** `ValueError` SHALL be raised at construction time (the same silent output-overwrite risk
+  as the cross-field case above, just self-inflicted within the list)
+
+#### Scenario: blup predictor_source requires resolvable paths (pre-flight guard)
+
+- **GIVEN** `enabled=True, predictor_source="blup"`
+- **WHEN** `source_blup_path` or `target_blup_path` does not resolve to an existing file
+- **THEN** `ValueError` SHALL be raised at config-construction time, before any pipeline step runs
+
+#### Scenario: genotype_means predictor_source does not require BLUP paths
+
+- **GIVEN** `enabled=True, predictor_source="genotype_means"`
+- **WHEN** `source_blup_path` and `target_blup_path` are both `None`
+- **THEN** no exception SHALL be raised
+
+#### Scenario: visualize=True requires enabled=True
+
+- **GIVEN** `prediction.visualize=True` on a `CrossPlatformConfig`
+- **WHEN** `prediction.enabled=False`
+- **THEN** `CrossPlatformConfig.__post_init__` SHALL raise `ValueError`
+
+#### Scenario: visualize field validation is skipped when visualize is False
+
+- **GIVEN** `enabled=True, visualize=False`
+- **WHEN** `n_permutations` is set to an invalid value (e.g. `0` or negative)
+- **THEN** no exception SHALL be raised from `PredictionConfig`/`CrossPlatformConfig`
+  construction — `n_permutations` is only meaningful, and only validated, when `visualize=True`
+
+#### Scenario: n_permutations must be positive when visualize is True
+
+- **GIVEN** `enabled=True, visualize=True`
+- **WHEN** `n_permutations <= 0`
+- **THEN** `ValueError` SHALL be raised at construction time
+
+### Requirement: Predict Cross-Platform Genotype Values Pipeline Step
+
+The system SHALL provide `PredictCrossPlatformStep`, an optional pipeline step consuming
+`PredictionConfig` and Tier 3's `logo_cv_predict`/`fit_pca_on_fold`/`CrossPlatformPredictionResult`
+(all unchanged), wired as task 6 (`depends_on=["01_load_cross_platform_data",
+"05_visualize_cross_platform"]`). The step SHALL read data from task 1's result only; the
+dependency on task 5 exists solely to guarantee ordering (steps 1-5 complete before prediction
+runs), not for data. The task SHALL be entirely absent from `create_tasks()`'s return value — not
+merely skipped at run time — when `config.prediction.enabled=False`.
+
+For a given directed pair, the step SHALL:
+1. Build the source and target predictor matrices per `predictor_source`: BLUP CSVs
+   (`source_blup_path`/`target_blup_path`, with the genotype column resolved as `"Genotype"` then
+   `"genotype"` — distinct from `exp1_genotype_col`/`exp2_genotype_col`, which govern the unrelated
+   raw per-sample CSVs for steps 1-5; a clear `ValueError` naming both attempted column names if
+   neither is present), or task 1's own raw `exp1`/`exp2` data — selected via task 1's already-
+   `exclude_cols`-filtered `exp1_trait_names`/`exp2_trait_names` metadata **before** aggregating by
+   genotype mean (`predictor_source="genotype_means"` — reading task 1's result directly, so this
+   ablation always uses the full raw trait set even when `trait_reduction_method="clustering"` has
+   reduced the data by the time it reaches later steps; task 1's raw DataFrame is NOT trait-only, so
+   this trait-name selection step is required, not optional). Any trait column containing any `NaN`
+   value among the common-genotype set SHALL be dropped before further use, on both source and
+   target sides; if this leaves the source matrix with zero trait columns, the step SHALL raise a
+   clear `ValueError`.
+2. Derive `X`, every per-target `y`, and the `genotypes` list from one canonical, sorted, explicitly-
+   indexed common-genotype list — never from incidental row-order agreement between independently-
+   loaded/joined DataFrames.
+3. Select the **target** platform's cluster-representative traits (via the existing
+   `cluster_correlated_traits`/`select_cluster_representatives`, unchanged) as the primary
+   prediction targets, per `representative_selection_metric` (`"variance"` only, this tier).
+4. Compute one additional target, `target_name="PC1"`: the **target** platform's own first
+   principal component via `pca.fit_pca()` with `StandardScaler` applied first and
+   `random_state=42` fixed, called directly (not `fit_pca_on_fold`, which remains reserved for
+   reducing the **source** predictor matrix per-fold when `reduction_method="pc1"`; not
+   `PCAAnalysisStep`, which is config-driven via a `PCAConfig` this pipeline does not have).
+5. Call `logo_cv_predict` once per target trait × per method (`reduction_method` plus each of
+   `comparison_methods` — guaranteed distinct from each other), assembling one
+   `CrossPlatformPredictionResult` per method.
+6. Save each `CrossPlatformPredictionResult` as JSON to the run directory, one file per method.
+7. Additionally include, under a `predictor_matrices` key in the returned `StepResult.data`
+   (alongside the existing, unchanged `data`/`metadata`/`files_generated` contents), the already-
+   computed `source_clean`/`target_clean` predictor matrices and `source_representative_names`/
+   `target_representatives` computed in steps 1-4 above — so that a downstream consumer (e.g.
+   `VisualizePredictionStep`) can reuse them without independently rebuilding them.
+
+If the common-genotype count between source and target is below `logo_cv_predict`'s own minimum,
+the step SHALL raise a clear `ValueError` naming the pair and the common-genotype count, rather than
+passing through `logo_cv_predict`'s generic message.
+
+The existing `cross-platform` CLI command's `--dry-run` output SHALL list this step when enabled,
+and SHALL NOT list it when disabled. No new CLI command or flag SHALL be introduced.
+
+#### Scenario: Step present only when enabled
+
+- **WHEN** `CrossPlatformPipeline(config).create_tasks()` is called
+- **THEN** a 6th task SHALL be present if and only if `config.prediction.enabled=True`
+
+#### Scenario: Predictor matrix built from BLUP CSVs when predictor_source is blup
+
+- **GIVEN** `predictor_source="blup"`
+- **WHEN** the step runs
+- **THEN** `source_blup_path`/`target_blup_path` SHALL be loaded as the predictor matrices
+
+#### Scenario: Predictor matrix built from genotype means when predictor_source is genotype_means
+
+- **GIVEN** `predictor_source="genotype_means"`
+- **WHEN** the step runs
+- **THEN** task 1's raw `exp1`/`exp2` data SHALL be filtered to `exp1_trait_names`/`exp2_trait_names`
+  (task 1's own already-`exclude_cols`-filtered metadata) before aggregating via genotype-mean
+  grouping, read directly from task 1's own result — not aggregated over every column in task 1's
+  raw DataFrame (which also contains `genotype`, `replicate`, and other non-trait columns)
+
+#### Scenario: genotype_means ablation is unaffected by trait_reduction_method=clustering
+
+- **GIVEN** `predictor_source="genotype_means"` and `trait_reduction_method="clustering"` are both
+  set on the same `CrossPlatformConfig`
+- **WHEN** the step runs
+- **THEN** the predictor matrix's columns SHALL exactly equal task 1's `exp1_trait_names`/
+  `exp2_trait_names` (the full, already-filtered trait set), not the cluster-representative-reduced
+  subset task 2 (`ReduceTraitRedundancyStep`) produces, and not task 1's raw DataFrame's every column
+
+#### Scenario: Target-side cluster-representative trait selection
+
+- **WHEN** the step selects the target platform's prediction targets
+- **THEN** `select_cluster_representatives` SHALL be applied to the target platform's aligned
+  predictor matrix (BLUP or genotype-mean, per `predictor_source`), independent of and using a
+  separate application from the **source** platform's own representative selection (used only when
+  a method is `"representatives"`, per the "logo_cv_predict called once per target trait per
+  method" scenario below)
+
+#### Scenario: X, y, and genotypes are derived from one canonical common-genotype index
+
+- **GIVEN** the source and target predictor matrices have their genotype rows in different orders
+  (same genotype set, different order)
+- **WHEN** the step builds `X`, any per-target `y`, and `genotypes` for `logo_cv_predict`
+- **THEN** each SHALL be indexed from one canonical, sorted, common-genotype list, so that source
+  and target values for the same genotype are correctly paired regardless of either input's
+  original row order — including for the PC1 target, not only representative-trait targets
+
+#### Scenario: Task 5's dependency is for ordering only, never data
+
+- **GIVEN** `kwargs["05_visualize_cross_platform"]` holds any value (including a sentinel or
+  otherwise-unusable `TaskResult`), while `kwargs["01_load_cross_platform_data"]` is a normal, valid
+  result
+- **WHEN** the step runs
+- **THEN** it SHALL produce a correct `CrossPlatformPredictionResult`, never reading
+  `kwargs["05_visualize_cross_platform"].data`
+
+#### Scenario: Trait columns containing any NaN are dropped before use
+
+- **GIVEN** a source or target predictor matrix with one trait column containing a `NaN` value for
+  at least one common genotype (e.g. a failed-model trait in a real `08_blup_adjusted_means.csv`)
+- **WHEN** the step builds `X` or selects target-side candidate traits
+- **THEN** that column SHALL be dropped before `logo_cv_predict` is called, rather than passed
+  through to raise `logo_cv_predict`'s generic NaN-rejection error
+
+#### Scenario: Clear error when the source matrix is empty after dropping NaN columns
+
+- **WHEN** every trait column in the source predictor matrix contains at least one `NaN` value
+  among the common genotypes
+- **THEN** the step SHALL raise a clear `ValueError`, distinct from the zero-target-representative-
+  traits case (which still has PC1 to fall back on)
+
+#### Scenario: BLUP CSV genotype column resolved by fixed convention
+
+- **GIVEN** `predictor_source="blup"`
+- **WHEN** the step loads `source_blup_path`/`target_blup_path`
+- **THEN** it SHALL resolve the genotype column as `"Genotype"` first, falling back to `"genotype"`
+  — not `exp1_genotype_col`/`exp2_genotype_col`, which govern the unrelated raw per-sample CSVs
+- **AND** if neither `"Genotype"` nor `"genotype"` is present, it SHALL raise a clear `ValueError`
+  naming both attempted column names, not a bare pandas `KeyError`
+
+#### Scenario: Step still runs with only the PC1 target when zero representative traits are selected
+
+- **WHEN** `select_cluster_representatives` returns an empty list for the target platform
+- **THEN** the step SHALL still run successfully, producing a `CrossPlatformPredictionResult` with
+  only the PC1 target, not a crash
+
+#### Scenario: blup_refit_per_fold has no observable effect
+
+- **GIVEN** two otherwise-identical configs differing only in `blup_refit_per_fold` (`True` vs.
+  `False`)
+- **WHEN** the step runs for each
+- **THEN** the resulting `CrossPlatformPredictionResult`s SHALL be identical
+
+#### Scenario: predictor_matrices is exposed for downstream reuse without changing existing outputs
+
+- **WHEN** the step runs to completion
+- **THEN** `StepResult.data["predictor_matrices"]` SHALL hold the `source_clean`/`target_clean`
+  DataFrames and `source_representative_names`/`target_representatives` computed during this run
+- **AND** every other key in `StepResult.data`, `StepResult.metadata`, and
+  `StepResult.files_generated` SHALL be unchanged in shape and content relative to this step's
+  behavior before this key was added
+
+## ADDED Requirements
+
+### Requirement: Visualize Cross-Platform Prediction Pipeline Step
+
+The system SHALL provide `VisualizePredictionStep`, an optional pipeline step wired as task 7,
+`depends_on=["06_predict_cross_platform"]` (for both data and ordering). The task SHALL be
+entirely absent from `create_tasks()`'s return value — not merely skipped at run time — when
+`config.prediction.visualize=False` (the default). Per Cross-Platform Prediction Configuration's
+scenario, `visualize=True` implies `enabled=True` (enforced at config-construction time), so this
+step never runs without task 6 having already run in the same pipeline.
+
+For a given directed pair, the step SHALL:
+1. Read `predictor_matrices` and the observed `CrossPlatformPredictionResult`(s) from task 6's
+   `StepResult.data`.
+2. For every `(target_name, method)` combination present in task 6's results (both
+   `reduction_method` and every `comparison_methods` entry), run `permutation_test()`
+   (`cross_platform_prediction.py`) with `n_permutations=config.prediction.n_permutations`,
+   `random_state=config.prediction.permutation_random_state`. These calls SHALL be parallelized
+   via `joblib.Parallel(n_jobs=config.prediction.permutation_n_jobs)`, with each parallel unit of
+   work being one complete `(target_name, method)` permutation test (not individual permutation
+   iterations within one test).
+3. Save one `CrossPlatformPermutationResult` per method as JSON to the run directory:
+   `07_permutation_<method>.json`.
+4. Build one composite figure per pair (not per method) using only the primary
+   `reduction_method`'s results: a PC1 observed-vs-predicted scatter, an all-targets observed-R²-
+   vs-pooled-permutation-null strip/violin plot, and an aggregate top-quartile-recovery bar chart
+   (observed mean vs. null mean). Save as `07_prediction_figure.png`.
+
+#### Scenario: Step present only when visualize is enabled
+
+- **WHEN** `CrossPlatformPipeline(config).create_tasks()` is called
+- **THEN** a 7th task SHALL be present if and only if `config.prediction.visualize=True`
+
+#### Scenario: Step reuses task 6's predictor matrices without rebuilding them
+
+- **GIVEN** task 6 has already run and its `StepResult.data["predictor_matrices"]` holds the
+  computed `source_clean`/`target_clean` matrices
+- **WHEN** task 7 runs
+- **THEN** it SHALL use those matrices directly (via `kwargs["06_predict_cross_platform"]`),
+  not independently reload BLUP CSVs or re-aggregate genotype means
+
+#### Scenario: Permutation tests are parallelized across targets, not within one target's permutations
+
+- **WHEN** task 7 runs permutation tests for `N` `(target, method)` combinations
+- **THEN** `joblib.Parallel` SHALL distribute the `N` combinations across
+  `config.prediction.permutation_n_jobs` workers, with each worker running one combination's
+  complete, internally-serial `permutation_test()` call
+
+#### Scenario: One permutation JSON per method
+
+- **WHEN** task 7 runs for a pair with `reduction_method` plus `K` `comparison_methods` entries
+- **THEN** exactly `K + 1` `07_permutation_<method>.json` files SHALL be saved, one per method
+
+#### Scenario: One figure per pair, using the primary method only
+
+- **WHEN** task 7 runs for a pair with `comparison_methods` non-empty
+- **THEN** exactly one `07_prediction_figure.png` SHALL be saved, built from the primary
+  `reduction_method`'s permutation results only
+
+#### Scenario: Figure PNG is non-empty and reflects the current run's inputs
+
+- **WHEN** task 7 completes
+- **THEN** `07_prediction_figure.png` SHALL exist, be non-empty, and (via a hash or timestamp
+  comparison in the acceptance test) SHALL be verifiably produced from the current run's input
+  CSVs, not a stale file from a prior run
+
+#### Scenario: Observed values in the permutation JSON match task 6's prediction JSON exactly
+
+- **WHEN** task 7's `07_permutation_<method>.json` and task 6's `06_prediction_<method>.json` are
+  compared for the same target and method
+- **THEN** the permutation result's `observed_r2`/`observed_rmse`/`observed_spearman_rho` SHALL
+  exactly match the prediction result's `r2`/`rmse`/`spearman_rho` for that target

--- a/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-analysis/spec.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-analysis/spec.md
@@ -109,6 +109,22 @@ validation failure, matching every other config dataclass's existing convention 
 - **WHEN** `n_permutations <= 0`
 - **THEN** `ValueError` SHALL be raised at construction time
 
+#### Scenario: permutation_n_jobs must be positive when visualize is True
+
+- **GIVEN** `enabled=True, visualize=True`
+- **WHEN** `permutation_n_jobs <= 0`
+- **THEN** `ValueError` SHALL be raised at construction time naming the field, rather than
+  surfacing `joblib.Parallel`'s own raw `ValueError` for a non-positive `n_jobs` deep inside
+  `VisualizePredictionStep`
+
+#### Scenario: permutation_random_state must be a valid seed when visualize is True
+
+- **GIVEN** `enabled=True, visualize=True`
+- **WHEN** `permutation_random_state` is not a non-negative integer (e.g. negative, or not an
+  `int`)
+- **THEN** `ValueError` SHALL be raised at construction time naming the field, rather than
+  surfacing `numpy.random.SeedSequence`'s own raw error deep inside `VisualizePredictionStep`
+
 ### Requirement: Predict Cross-Platform Genotype Values Pipeline Step
 
 The system SHALL provide `PredictCrossPlatformStep`, an optional pipeline step consuming
@@ -349,7 +365,14 @@ For a given directed pair, the step SHALL:
    identical permutation-index sequence, correlating (not independently sampling) the null draws
    this step later pools across targets into one figure panel (see the pooled-violin scenario
    below). The whole run remains deterministic given `permutation_random_state`, since
-   `SeedSequence.spawn` is itself deterministic.
+   `SeedSequence.spawn` is itself deterministic, **provided the `N` combinations are always
+   enumerated in the same canonical order**: methods first, in `[reduction_method] +
+   comparison_methods` order, then within each method, `target_names` in task 6's own
+   `CrossPlatformPredictionResult.predictions` list order (representative traits in
+   `select_cluster_representatives`'s returned order, followed by `"PC1"` last) — the `i`-th
+   spawned child is assigned to the `i`-th combination in this fixed enumeration, not an
+   unspecified iteration order (e.g. Python dict-iteration order, which is insertion-order-
+   dependent and easy to accidentally perturb in a future refactor).
 3. For every `(target_name, method)` combination present in task 6's results (both
    `reduction_method` and every `comparison_methods` entry), run `permutation_test()`
    (`cross_platform_prediction.py`) with `n_permutations=config.prediction.n_permutations` and that
@@ -369,7 +392,19 @@ For a given directed pair, the step SHALL:
 5. Build one composite figure per pair (not per method) using only the primary
    `reduction_method`'s results: a PC1 observed-vs-predicted scatter, an all-targets observed-R²-
    vs-pooled-permutation-null strip/violin plot, and an aggregate top-quartile-recovery bar chart
-   (observed mean vs. null mean). Save as `07_prediction_figure.png`.
+   (observed mean vs. null mean). Save as `07_prediction_figure.png`. Pooling every target's
+   `null_r2` into one distribution for the violin panel is coherent because every target within
+   one pair shares the same common-genotype count `n` (task 6's `dropna(axis=1, how="any")`
+   trait-column filtering never changes the row/genotype count — see Decision 16 in the
+   `cross-platform-analysis` capability's Predict Cross-Platform Genotype Values Pipeline Step
+   requirement) — the independent per-target seeds (step 2) mean each target's null draws are
+   independent samples of the *same* null distribution shape, not draws from differently-shaped
+   nulls.
+6. If any `(target_name, method)` combination's `permutation_test()` call raises (including the
+   non-finite-null-value error from the `cross-platform-prediction` capability's Permutation Test
+   requirement), the step SHALL propagate that error and SHALL NOT write any
+   `07_permutation_<method>.json` file for this pair — all-or-nothing per pair, not a partial set
+   of successfully-computed methods' files alongside a missing one.
 
 #### Scenario: Step present only when visualize is enabled
 
@@ -405,6 +440,44 @@ For a given directed pair, the step SHALL:
 
 - **WHEN** task 7 runs for a pair with `reduction_method` plus `K` `comparison_methods` entries
 - **THEN** exactly `K + 1` `07_permutation_<method>.json` files SHALL be saved, one per method
+
+#### Scenario: Exactly one permutation JSON when comparison_methods is empty
+
+- **GIVEN** `comparison_methods=[]` (`K=0`)
+- **WHEN** task 7 runs
+- **THEN** exactly 1 `07_permutation_<method>.json` file SHALL be saved (for `reduction_method`
+  alone), not `K + 1` misapplied as `0 + 1` via some other, coincidentally-matching code path
+
+#### Scenario: Step still runs with only the PC1 target when zero representative traits are selected
+
+- **GIVEN** task 6's results contain only a `target_name="PC1"` entry (zero representative-trait
+  targets, e.g. `select_cluster_representatives` returned an empty list for the target platform —
+  the same degenerate case the Predict Cross-Platform Genotype Values Pipeline Step requirement
+  already documents)
+- **WHEN** task 7 runs, dispatching `N=1` total `(target, method)` unit per method through
+  `joblib.Parallel`
+- **THEN** the step SHALL still run successfully, producing a valid `CrossPlatformPermutationResult`
+  with only the PC1 target, not a crash
+
+#### Scenario: Parallel and serial execution agree within this codebase's cross-BLAS tolerance
+
+- **WHEN** the same pair is run once with `permutation_n_jobs=1` and once with
+  `permutation_n_jobs=4`
+- **THEN** the two runs' `CrossPlatformPermutationResult`s SHALL agree via
+  `numpy.testing.assert_allclose(rtol=1e-6, atol=1e-9)` for every numeric field, including every
+  element of every null distribution — **not** bit-for-bit equality, since `loky` worker processes
+  may resolve a different default BLAS thread count than the main process
+
+#### Scenario: A non-finite permutation result propagates as a named error, with no partial output
+
+- **GIVEN** one `(target_name, method)` combination's `permutation_test()` call raises `ValueError`
+  for a non-finite null value (per the `cross-platform-prediction` capability's Permutation Test
+  requirement), while every other combination for this pair would have succeeded
+- **WHEN** task 7 runs
+- **THEN** it SHALL propagate that `ValueError` (naming the offending target/method/permutation
+  index)
+- **AND** no `07_permutation_<method>.json` file SHALL be written for this pair — not even for
+  methods whose own combinations all individually succeeded
 
 #### Scenario: One figure per pair, using the primary method only
 

--- a/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-prediction/spec.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-prediction/spec.md
@@ -6,16 +6,25 @@ The package SHALL provide `permutation_test(X, y, genotypes, reduction_method="p
 representative_names=None, n_permutations=1000, random_state=42)` in
 `src/sleap_roots_analyze/cross_platform_prediction.py` that computes a shuffled-genotype-label
 permutation-null significance test for `logo_cv_predict()`'s R², RMSE, and Spearman ρ, plus the
-top-quartile recovery metric (see the Top-Quartile Recovery Metric requirement).
+top-quartile recovery metric (see the Top-Quartile Recovery Metric requirement). `random_state`
+SHALL accept anything `numpy.random.default_rng()` itself accepts — an `int`, a
+`numpy.random.SeedSequence`, or a `numpy.random.Generator` — since the caller (see the
+`cross-platform-analysis` capability's Visualize Cross-Platform Prediction Pipeline Step
+requirement) derives per-`(target, method)` seeds as `numpy.random.SeedSequence` children via
+`SeedSequence(...).spawn(N)`, not as plain integers, and passes each child through unchanged
+(`numpy.random.default_rng` accepts a `SeedSequence` directly — no int-extraction step exists or
+is needed).
 
 The function SHALL first call `logo_cv_predict(X, y, genotypes, reduction_method,
 representative_names)` once, on the real (unshuffled) `y`, to obtain the observed R², RMSE,
-Spearman ρ, and top-quartile recovery. It SHALL then draw `n_permutations` independent
-permutations of `y` relative to `genotypes` (using a single `numpy.random.Generator` seeded with
-`random_state`), calling `logo_cv_predict()` once per permutation with the same `X`,
-`reduction_method`, and `representative_names`, and computing top-quartile recovery for that
-permutation using its own shuffled `y` as ground truth (not the original, unshuffled `y`) against
-that same call's leave-one-genotype-out predictions.
+Spearman ρ, and top-quartile recovery. It SHALL then construct one `numpy.random.Generator` via
+`numpy.random.default_rng(random_state)` (not `numpy.random.Generator(random_state)` directly,
+which requires a `BitGenerator` instance and rejects a bare `int`) and draw `n_permutations`
+independent permutations of `y` relative to `genotypes` from that one generator, calling
+`logo_cv_predict()` once per permutation with the same `X`, `reduction_method`, and
+`representative_names`, and computing top-quartile recovery for that permutation using its own
+shuffled `y` as ground truth (not the original, unshuffled `y`) against that same call's
+leave-one-genotype-out predictions.
 
 The function SHALL return a `PermutationResult` (see the `serializable-result-types` capability)
 holding the observed values, the four null distributions (each of length `n_permutations`), and
@@ -32,6 +41,12 @@ before returning, and SHALL raise `ValueError` naming both the offending metric 
 0-indexed permutation number(s) at which it occurred, rather than allowing a non-finite value to
 propagate into `PermutationResult`/`CrossPlatformPermutationResult.to_json()`'s
 `allow_nan=False` contract as an unnamed failure deep inside a long-running `joblib.Parallel` loop.
+This scan runs **after** all `n_permutations` calls complete, not fail-fast on the first
+occurrence — chosen for implementation simplicity (one deterministic pass reporting every
+offending index at once, rather than a per-iteration check that changes the function's control
+flow) and because a genuinely non-finite-producing bug is expected to affect many permutations
+within one target, not a rare one-off, so failing fast saves little wall-clock time in the case
+that matters, while complicating the accounting of *which* permutations were and weren't run.
 
 #### Scenario: Observed value matches a direct logo_cv_predict call on the unshuffled y
 
@@ -39,6 +54,9 @@ propagate into `PermutationResult`/`CrossPlatformPermutationResult.to_json()`'s
 - **THEN** its returned `observed_r2`/`observed_rmse`/`observed_spearman_rho` SHALL exactly match
   the result of an independent `logo_cv_predict(X, y, genotypes, reduction_method)` call made
   with the same inputs
+- **AND** `observed_top_quartile_recovery` SHALL exactly equal
+  `top_quartile_recovery(y, that_call.y_pred)` — derived from the same observed call's predictions,
+  not a separately-shuffled or stale value
 
 #### Scenario: Null distributions have length n_permutations
 
@@ -55,9 +73,12 @@ propagate into `PermutationResult`/`CrossPlatformPermutationResult.to_json()`'s
 #### Scenario: Same random_state produces identical null distributions
 
 - **WHEN** `permutation_test(X, y, genotypes, reduction_method, n_permutations=N,
-  random_state=S)` is called twice with identical arguments
+  random_state=S)` is called twice, in the same process, with identical arguments
 - **THEN** both calls SHALL produce bit-identical `null_r2`/`null_rmse`/`null_spearman_rho`/
-  `null_top_quartile_recovery` arrays
+  `null_top_quartile_recovery` arrays — this in-process determinism guarantee is distinct from the
+  `cross-platform-analysis` capability's cross-`joblib`-worker-process tolerance requirement
+  (`assert_allclose(rtol=1e-6, atol=1e-9)`, not bit-identical), which concerns a different variable
+  (worker-process BLAS thread count), not this function's own determinism
 
 #### Scenario: Different random_state produces different null distributions
 
@@ -132,6 +153,15 @@ roadmap's earlier, unverified estimate.
   this program's smallest real scale (`n=3`, `logo_cv_predict`'s own minimum)
 - **THEN** the effective `q` used SHALL be at least `1` (not `0`, which would make the metric
   vacuously `0/0`-undefined), and `2q` SHALL NOT exceed `len(y_true)`
+
+#### Scenario: An explicitly-supplied invalid q is rejected
+
+- **WHEN** a caller explicitly passes `q=0`, a negative `q`, or a `q` such that `2 * q >
+  len(y_true)`
+- **THEN** `top_quartile_recovery` SHALL raise `ValueError` naming the invalid `q` and
+  `len(y_true)`, rather than silently computing a vacuous or out-of-range recovery fraction — this
+  is a stricter contract than the *default*-`q` case above, which the function itself computes and
+  guarantees valid
 
 ### Requirement: Permutation Test Input Validation
 

--- a/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-prediction/spec.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-prediction/spec.md
@@ -51,14 +51,23 @@ one-sided p-values for R², RMSE, and Spearman ρ — **not the same formula for
 A permutation's LOGO-CV fold structure can independently produce a non-finite `spearman_rho` (e.g.
 a degenerate fold whose predictions are constant) even when that permutation's shuffled `y` is
 itself non-constant — this is a model-degeneracy event distinct from, and not ruled out by, the
-data-degeneracy check `PredictCrossPlatformStep` already performs on *observed* values before this
-function is ever called. The function SHALL therefore scan every null distribution
-(`null_r2`/`null_rmse`/`null_spearman_rho`/`null_top_quartile_recovery`) for non-finite entries
-before returning, and SHALL raise `ValueError` naming both the offending metric and the
-0-indexed permutation number(s) at which it occurred, rather than allowing a non-finite value to
-propagate into `PermutationResult`/`CrossPlatformPermutationResult.to_json()`'s
-`allow_nan=False` contract as an unnamed failure deep inside a long-running `joblib.Parallel` loop.
-This scan runs **after** all `n_permutations` calls complete, not fail-fast on the first
+data-degeneracy check `PredictCrossPlatformStep` already performs on *observed* values **before
+that pipeline step calls this function**. That upstream guard does not exist for a direct
+Python-API caller (Decision 1's own explicit design goal — this function is Python-API-only, not
+pipeline-only, and is self-contained precisely so a caller doesn't need a separate upstream check):
+a caller passing data with a constant `y` or a model that degenerates to constant predictions on
+the real, unshuffled call gets exactly the same non-finite-`spearman_rho`/`r2` risk, on the
+*observed* side, that this requirement already addresses for the null side. The function SHALL
+therefore scan **both** the observed values (`observed_r2`/`observed_rmse`/`observed_spearman_rho`)
+**and** every null distribution (`null_r2`/`null_rmse`/`null_spearman_rho`/
+`null_top_quartile_recovery`) for non-finite entries before returning, and SHALL raise `ValueError`
+naming the offending metric and, for a null-side failure, the 0-indexed permutation number(s) at
+which it occurred (for an observed-side failure, naming that it is the observed value, not a
+permutation index) — rather than allowing a non-finite value to propagate into
+`PermutationResult`/`CrossPlatformPermutationResult.to_json()`'s `allow_nan=False` contract as an
+unnamed failure. The observed-side check SHALL run first (cheap, one call, fails immediately
+rather than after `n_permutations` further calls that would be wasted on unusable input); the
+null-side scan runs **after** all `n_permutations` calls complete, not fail-fast on the first
 occurrence — chosen for implementation simplicity (one deterministic pass reporting every
 offending index at once, rather than a per-iteration check that changes the function's control
 flow) and because a genuinely non-finite-producing bug is expected to affect many permutations
@@ -143,6 +152,17 @@ that matters, while complicating the accounting of *which* permutations were and
   rather than returning a `PermutationResult` that would later fail
   `CrossPlatformPermutationResult.to_json()`'s finite-floats contract with no indication of which
   permutation caused it
+
+#### Scenario: Non-finite observed values are rejected before any permutation runs
+
+- **GIVEN** `y` is constant (zero variance), or the observed `logo_cv_predict` call otherwise
+  produces a non-finite `spearman_rho` — a legal `logo_cv_predict` input/output (per that
+  function's own "Constant y does not raise" contract), reachable by a direct Python-API caller
+  with no upstream pipeline guard
+- **WHEN** `permutation_test()` runs
+- **THEN** it SHALL raise `ValueError` naming the offending observed metric, immediately after the
+  observed-value call and before drawing any of the `n_permutations` null values (not after
+  wastefully completing the full permutation loop on data already known to be unusable)
 
 ### Requirement: Top-Quartile Recovery Metric
 

--- a/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-prediction/spec.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-prediction/spec.md
@@ -1,0 +1,115 @@
+## ADDED Requirements
+
+### Requirement: Permutation Test
+
+The package SHALL provide `permutation_test(X, y, genotypes, reduction_method="pls_latent",
+representative_names=None, n_permutations=1000, random_state=42)` in
+`src/sleap_roots_analyze/cross_platform_prediction.py` that computes a shuffled-genotype-label
+permutation-null significance test for `logo_cv_predict()`'s R², RMSE, and Spearman ρ, plus the
+top-quartile recovery metric (see the Top-Quartile Recovery Metric requirement).
+
+The function SHALL first call `logo_cv_predict(X, y, genotypes, reduction_method,
+representative_names)` once, on the real (unshuffled) `y`, to obtain the observed R², RMSE,
+Spearman ρ, and top-quartile recovery. It SHALL then draw `n_permutations` independent
+permutations of `y` relative to `genotypes` (using a single `numpy.random.Generator` seeded with
+`random_state`), calling `logo_cv_predict()` once per permutation with the same `X`,
+`reduction_method`, and `representative_names`, and computing top-quartile recovery for that
+permutation using its own shuffled `y` as ground truth (not the original, unshuffled `y`) against
+that same call's leave-one-genotype-out predictions.
+
+The function SHALL return a `PermutationResult` (see the `serializable-result-types` capability)
+holding the observed values, the four null distributions (each of length `n_permutations`), and
+one-sided p-values for R², RMSE, and Spearman ρ, computed as
+`(count(null >= observed) + 1) / (n_permutations + 1)`.
+
+#### Scenario: Observed value matches a direct logo_cv_predict call on the unshuffled y
+
+- **WHEN** `permutation_test(X, y, genotypes, reduction_method)` is called
+- **THEN** its returned `observed_r2`/`observed_rmse`/`observed_spearman_rho` SHALL exactly match
+  the result of an independent `logo_cv_predict(X, y, genotypes, reduction_method)` call made
+  with the same inputs
+
+#### Scenario: Null distributions have length n_permutations
+
+- **WHEN** `permutation_test(..., n_permutations=N)` completes
+- **THEN** `null_r2`, `null_rmse`, `null_spearman_rho`, and `null_top_quartile_recovery` SHALL
+  each have exactly `N` elements
+
+#### Scenario: Each permutation shuffles y relative to genotypes, not X
+
+- **WHEN** any single permutation iteration runs
+- **THEN** `X` and `genotypes` SHALL be passed to that iteration's `logo_cv_predict()` call
+  unmodified, and only `y`'s association with `genotypes`/`X`'s rows SHALL be shuffled
+
+#### Scenario: Same random_state produces identical null distributions
+
+- **WHEN** `permutation_test(X, y, genotypes, reduction_method, n_permutations=N,
+  random_state=S)` is called twice with identical arguments
+- **THEN** both calls SHALL produce bit-identical `null_r2`/`null_rmse`/`null_spearman_rho`/
+  `null_top_quartile_recovery` arrays
+
+#### Scenario: Different random_state produces different null distributions
+
+- **WHEN** `permutation_test(X, y, genotypes, reduction_method, n_permutations=N,
+  random_state=S1)` and the same call with `random_state=S2` (`S1 != S2`) are both run
+- **THEN** the two calls' `null_r2` arrays SHALL NOT be element-wise identical
+
+#### Scenario: A permutation's top-quartile recovery uses that permutation's shuffled y as truth
+
+- **WHEN** one permutation iteration's shuffled `y` is `y_shuffled` and its LOGO-CV predictions
+  are `y_pred_shuffled`
+- **THEN** that iteration's `null_top_quartile_recovery` entry SHALL equal
+  `top_quartile_recovery(y_shuffled, y_pred_shuffled)`, not
+  `top_quartile_recovery(y, y_pred_shuffled)` (the original, unshuffled `y`)
+
+#### Scenario: One-sided p-values follow the standard permutation-test formula
+
+- **WHEN** `permutation_test()` completes with observed value `obs` and null distribution `null`
+  of length `N` for a given metric
+- **THEN** that metric's p-value SHALL equal `(count(v >= obs for v in null) + 1) / (N + 1)`
+
+### Requirement: Top-Quartile Recovery Metric
+
+The package SHALL provide `top_quartile_recovery(y_true, y_pred, q=None)` in
+`src/sleap_roots_analyze/cross_platform_prediction.py` that computes the fraction of the true
+top-`q` genotypes (ranked by `y_true`, descending) that appear among the predicted top-`2q`
+genotypes (ranked by `y_pred`, descending). `q` SHALL default to `round(len(y_true) / 4)` when not
+supplied.
+
+#### Scenario: Perfect prediction recovers all top-q genotypes
+
+- **WHEN** `y_pred` is a strictly monotonic function of `y_true` (e.g. `y_pred == y_true`)
+- **THEN** `top_quartile_recovery(y_true, y_pred)` SHALL equal `1.0`
+
+#### Scenario: Recovery is computed against the top-2q predicted set, not the top-q predicted set
+
+- **WHEN** `top_quartile_recovery(y_true, y_pred, q=Q)` is called
+- **THEN** the denominator of the recovery fraction SHALL be `Q` (the count of true top-`Q`
+  genotypes), and the predicted set checked for membership SHALL contain `2 * Q` genotypes
+  (the predicted top-`2Q`), not `Q`
+
+#### Scenario: Default q is one quarter of the genotype count, rounded
+
+- **WHEN** `top_quartile_recovery(y_true, y_pred)` is called with `q` omitted and
+  `len(y_true) == 19`
+- **THEN** the effective `q` used SHALL equal `round(19 / 4)` (`5`)
+
+### Requirement: Permutation Test Input Validation
+
+`permutation_test` SHALL validate its own arguments (`n_permutations`, `random_state`) before
+entering the permutation loop, and SHALL surface any `logo_cv_predict` input-validation failure
+(invalid `X`/`y`/`genotypes`/`reduction_method`/`representative_names`, per the
+`Leave-One-Genotype-Out Cross-Validated Prediction`/`Input Validation` requirements) from its
+initial observed-value call, before running any permutation.
+
+#### Scenario: Non-positive n_permutations is rejected
+
+- **WHEN** `n_permutations <= 0`
+- **THEN** `permutation_test` SHALL raise `ValueError`, before calling `logo_cv_predict` at all
+
+#### Scenario: Invalid logo_cv_predict inputs surface from the observed-value call
+
+- **WHEN** `X`, `y`, `genotypes`, or `reduction_method` would cause `logo_cv_predict` to raise
+  `ValueError` (e.g. mismatched lengths, an invalid `reduction_method`, duplicate genotype labels)
+- **THEN** `permutation_test` SHALL raise the same `ValueError`, from its initial observed-value
+  call, before entering the permutation loop

--- a/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-prediction/spec.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-prediction/spec.md
@@ -22,6 +22,17 @@ holding the observed values, the four null distributions (each of length `n_perm
 one-sided p-values for R², RMSE, and Spearman ρ, computed as
 `(count(null >= observed) + 1) / (n_permutations + 1)`.
 
+A permutation's LOGO-CV fold structure can independently produce a non-finite `spearman_rho` (e.g.
+a degenerate fold whose predictions are constant) even when that permutation's shuffled `y` is
+itself non-constant — this is a model-degeneracy event distinct from, and not ruled out by, the
+data-degeneracy check `PredictCrossPlatformStep` already performs on *observed* values before this
+function is ever called. The function SHALL therefore scan every null distribution
+(`null_r2`/`null_rmse`/`null_spearman_rho`/`null_top_quartile_recovery`) for non-finite entries
+before returning, and SHALL raise `ValueError` naming both the offending metric and the
+0-indexed permutation number(s) at which it occurred, rather than allowing a non-finite value to
+propagate into `PermutationResult`/`CrossPlatformPermutationResult.to_json()`'s
+`allow_nan=False` contract as an unnamed failure deep inside a long-running `joblib.Parallel` loop.
+
 #### Scenario: Observed value matches a direct logo_cv_predict call on the unshuffled y
 
 - **WHEN** `permutation_test(X, y, genotypes, reduction_method)` is called
@@ -68,6 +79,18 @@ one-sided p-values for R², RMSE, and Spearman ρ, computed as
   of length `N` for a given metric
 - **THEN** that metric's p-value SHALL equal `(count(v >= obs for v in null) + 1) / (N + 1)`
 
+#### Scenario: Non-finite null values are rejected with a named, actionable error
+
+- **GIVEN** a permutation iteration whose LOGO-CV fold structure produces a non-finite
+  `spearman_rho` (e.g. a degenerate fold with constant predictions), independent of whether that
+  permutation's shuffled `y` was itself constant
+- **WHEN** `permutation_test()` finishes drawing all `n_permutations` null values
+- **THEN** it SHALL raise `ValueError` naming the offending metric (`r2`/`rmse`/`spearman_rho`/
+  `top_quartile_recovery`) and the permutation index/indices at which a non-finite value occurred,
+  rather than returning a `PermutationResult` that would later fail
+  `CrossPlatformPermutationResult.to_json()`'s finite-floats contract with no indication of which
+  permutation caused it
+
 ### Requirement: Top-Quartile Recovery Metric
 
 The package SHALL provide `top_quartile_recovery(y_true, y_pred, q=None)` in
@@ -75,6 +98,15 @@ The package SHALL provide `top_quartile_recovery(y_true, y_pred, q=None)` in
 top-`q` genotypes (ranked by `y_true`, descending) that appear among the predicted top-`2q`
 genotypes (ranked by `y_pred`, descending). `q` SHALL default to `round(len(y_true) / 4)` when not
 supplied.
+
+Under a random (uninformative) `y_pred`, the expected recovery is `2q / len(y_true)` by linearity
+of expectation (a fixed top-`q` set has, in expectation, a `2q / len(y_true)` fraction of its
+members appear in a randomly-drawn top-`2q` set) — at this program's real scale
+(`len(y_true) ≈ 15-24`, `q = round(len(y_true) / 4)`), this is **≈45-53%**, not the roadmap's
+originally-estimated "≈25%". The permutation null's actual mean recovery under
+`permutation_test()` (see the Permutation Test requirement's oracle tests) SHALL be verified
+empirically against this `2q / n` expectation during implementation, not assumed from the
+roadmap's earlier, unverified estimate.
 
 #### Scenario: Perfect prediction recovers all top-q genotypes
 
@@ -93,6 +125,13 @@ supplied.
 - **WHEN** `top_quartile_recovery(y_true, y_pred)` is called with `q` omitted and
   `len(y_true) == 19`
 - **THEN** the effective `q` used SHALL equal `round(19 / 4)` (`5`)
+
+#### Scenario: Small n does not produce a zero or degenerate q
+
+- **WHEN** `top_quartile_recovery(y_true, y_pred)` is called with `q` omitted and `len(y_true)` at
+  this program's smallest real scale (`n=3`, `logo_cv_predict`'s own minimum)
+- **THEN** the effective `q` used SHALL be at least `1` (not `0`, which would make the metric
+  vacuously `0/0`-undefined), and `2q` SHALL NOT exceed `len(y_true)`
 
 ### Requirement: Permutation Test Input Validation
 

--- a/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-prediction/spec.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/specs/cross-platform-prediction/spec.md
@@ -13,7 +13,16 @@ SHALL accept anything `numpy.random.default_rng()` itself accepts — an `int`, 
 requirement) derives per-`(target, method)` seeds as `numpy.random.SeedSequence` children via
 `SeedSequence(...).spawn(N)`, not as plain integers, and passes each child through unchanged
 (`numpy.random.default_rng` accepts a `SeedSequence` directly — no int-extraction step exists or
-is needed).
+is needed). **Reproducibility caveat, `int`/`SeedSequence` vs. `Generator`:** `int` and
+`SeedSequence` are stateless value-seeds — reusing the same value across two calls always
+reproduces the same null draws (the "Same random_state produces identical null distributions"
+scenario below). A `Generator` instance is **mutable and stateful**
+(`numpy.random.default_rng(existing_generator)` returns that exact instance unaltered, per numpy's
+own documented behavior) — passing the *same* `Generator` instance to two separate
+`permutation_test()` calls advances its internal state between calls and will **not** reproduce
+the same null draws the second time. This function accepts a `Generator` for flexibility, but only
+`int`/`SeedSequence` inputs carry a reproducibility guarantee; `VisualizePredictionStep` never
+passes a bare `Generator` for exactly this reason (only `SeedSequence` children).
 
 The function SHALL first call `logo_cv_predict(X, y, genotypes, reduction_method,
 representative_names)` once, on the real (unshuffled) `y`, to obtain the observed R², RMSE,
@@ -28,8 +37,16 @@ leave-one-genotype-out predictions.
 
 The function SHALL return a `PermutationResult` (see the `serializable-result-types` capability)
 holding the observed values, the four null distributions (each of length `n_permutations`), and
-one-sided p-values for R², RMSE, and Spearman ρ, computed as
-`(count(null >= observed) + 1) / (n_permutations + 1)`.
+one-sided p-values for R², RMSE, and Spearman ρ — **not the same formula for all three**, since
+"more extreme" points in opposite directions for RMSE than for R²/ρ:
+- **R² and Spearman ρ** (higher is better prediction): `p = (count(null >= observed) + 1) /
+  (n_permutations + 1)` — an observed value in the right tail of the null is evidence of real
+  signal.
+- **RMSE** (lower is better prediction): `p = (count(null <= observed) + 1) / (n_permutations +
+  1)` — an observed value in the *left* tail of the null is evidence of real signal. Using the
+  R²/ρ-style formula for RMSE would invert the result: a genuinely good (low-RMSE) model would
+  read as non-significant (`p ≈ 1`), and a genuinely bad (high-RMSE) model would read as highly
+  significant (`p ≈ 0`).
 
 A permutation's LOGO-CV fold structure can independently produce a non-finite `spearman_rho` (e.g.
 a degenerate fold whose predictions are constant) even when that permutation's shuffled `y` is
@@ -70,15 +87,19 @@ that matters, while complicating the accounting of *which* permutations were and
 - **THEN** `X` and `genotypes` SHALL be passed to that iteration's `logo_cv_predict()` call
   unmodified, and only `y`'s association with `genotypes`/`X`'s rows SHALL be shuffled
 
-#### Scenario: Same random_state produces identical null distributions
+#### Scenario: Same int or SeedSequence random_state produces identical null distributions
 
 - **WHEN** `permutation_test(X, y, genotypes, reduction_method, n_permutations=N,
-  random_state=S)` is called twice, in the same process, with identical arguments
+  random_state=S)` is called twice, in the same process, with identical arguments, where `S` is
+  either a plain `int` or a `numpy.random.SeedSequence` value (parametrize both)
 - **THEN** both calls SHALL produce bit-identical `null_r2`/`null_rmse`/`null_spearman_rho`/
   `null_top_quartile_recovery` arrays — this in-process determinism guarantee is distinct from the
   `cross-platform-analysis` capability's cross-`joblib`-worker-process tolerance requirement
   (`assert_allclose(rtol=1e-6, atol=1e-9)`, not bit-identical), which concerns a different variable
-  (worker-process BLAS thread count), not this function's own determinism
+  (worker-process BLAS thread count), not this function's own determinism. **Not tested for a bare
+  `Generator` input**, which is stateful and does not carry this guarantee (see the requirement
+  body's reproducibility caveat above) — passing the same `Generator` instance twice is expected to
+  produce *different* results, not identical ones.
 
 #### Scenario: Different random_state produces different null distributions
 
@@ -94,11 +115,22 @@ that matters, while complicating the accounting of *which* permutations were and
   `top_quartile_recovery(y_shuffled, y_pred_shuffled)`, not
   `top_quartile_recovery(y, y_pred_shuffled)` (the original, unshuffled `y`)
 
-#### Scenario: One-sided p-values follow the standard permutation-test formula
+#### Scenario: One-sided p-values follow the standard permutation-test formula, per metric direction
 
 - **WHEN** `permutation_test()` completes with observed value `obs` and null distribution `null`
-  of length `N` for a given metric
+  of length `N`, for R² or Spearman ρ (higher is better)
 - **THEN** that metric's p-value SHALL equal `(count(v >= obs for v in null) + 1) / (N + 1)`
+- **WHEN** the same completes for RMSE (lower is better)
+- **THEN** `p_value_rmse` SHALL equal `(count(v <= obs for v in null) + 1) / (N + 1)` — the
+  opposite-tail formula, not the R²/ρ formula
+
+#### Scenario: A good (low-RMSE) result does not read as non-significant
+
+- **GIVEN** a planted-signal fixture where the observed RMSE is comfortably below the bulk of the
+  null RMSE distribution (a genuinely good model)
+- **WHEN** `permutation_test()` computes `p_value_rmse`
+- **THEN** `p_value_rmse` SHALL be small (comfortably below `0.5`), not large — proving the
+  left-tail formula is actually in effect, not the right-tail formula silently inverted
 
 #### Scenario: Non-finite null values are rejected with a named, actionable error
 
@@ -123,8 +155,10 @@ supplied.
 Under a random (uninformative) `y_pred`, the expected recovery is `2q / len(y_true)` by linearity
 of expectation (a fixed top-`q` set has, in expectation, a `2q / len(y_true)` fraction of its
 members appear in a randomly-drawn top-`2q` set) — at this program's real scale
-(`len(y_true) ≈ 15-24`, `q = round(len(y_true) / 4)`), this is **≈45-53%**, not the roadmap's
-originally-estimated "≈25%". The permutation null's actual mean recovery under
+(`len(y_true) ≈ 15-24`, `q = round(len(y_true) / 4)`), this ranges **≈44-55%** depending on `n` and
+Python's banker's rounding (e.g. `n=18 → q=4 → 44.4%`; `n=19 → q=5 → 52.6%`; `n=22 → q=6 → 54.5%`
+— computed directly for every `n` in this range, not a single illustrative figure), not the
+roadmap's originally-estimated "≈25%". The permutation null's actual mean recovery under
 `permutation_test()` (see the Permutation Test requirement's oracle tests) SHALL be verified
 empirically against this `2q / n` expectation during implementation, not assumed from the
 roadmap's earlier, unverified estimate.

--- a/openspec/changes/add-prediction-permutation-and-figure/specs/serializable-result-types/spec.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/specs/serializable-result-types/spec.md
@@ -41,6 +41,13 @@ entry per prediction target (mirroring `CrossPlatformPredictionResult`'s `predic
 - **THEN** it SHALL contain no field referencing `PermutationResult` or
   `CrossPlatformPermutationResult` — the two result families remain structurally independent
 
+#### Scenario: No sklearn or numpy object is present in the clean view
+
+- **WHEN** `dataclasses.asdict(result)` is inspected for a `CrossPlatformPermutationResult`
+- **THEN** it SHALL contain no sklearn `Pipeline`/`PLSRegression`/`Ridge`/`PCA`/`StandardScaler`
+  object, and no raw `numpy.ndarray` — every null-distribution list SHALL be a plain Python `list`
+  of `float`, matching `CrossPlatformPredictionResult`'s equivalent scenario
+
 ### Requirement: CrossPlatformPermutationResult Adapter From permutation_test Output
 
 The package SHALL provide an adapter that maps one or more `permutation_test()` return values,

--- a/openspec/changes/add-prediction-permutation-and-figure/specs/serializable-result-types/spec.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/specs/serializable-result-types/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Serializable Cross-Platform Permutation Result Type
+
+The package SHALL provide a frozen stdlib `@dataclass` `CrossPlatformPermutationResult` (with a
+nested `PermutationResult` dataclass) in `result_types.py` that captures only the
+JSON-serializable science of a `permutation_test()` run for one (platform pair, reduction method)
+combination, kept **separate from** (not nested inside) `CrossPlatformPredictionResult`. Every
+scalar field SHALL be a native Python type, so that `json.dumps(dataclasses.asdict(result))`
+succeeds without a custom serializer. `CrossPlatformPermutationResult` SHALL provide a `to_dict()`
+method returning `dataclasses.asdict(self)` and a `to_json(**kwargs)` method defaulting
+`allow_nan=False`.
+
+`CrossPlatformPermutationResult` SHALL hold `source_platform: str`, `target_platform: str`,
+`reduction_method: str`, and `predictions: list[PermutationResult]` — one `PermutationResult`
+entry per prediction target (mirroring `CrossPlatformPredictionResult`'s `predictions`/
+`TargetPrediction` shape). Each `PermutationResult` SHALL hold `target_name: str`,
+`observed_r2: float`, `observed_rmse: float`, `observed_spearman_rho: float`,
+`observed_top_quartile_recovery: float`, `null_r2: list[float]`, `null_rmse: list[float]`,
+`null_spearman_rho: list[float]`, `null_top_quartile_recovery: list[float]`,
+`p_value_r2: float`, `p_value_rmse: float`, `p_value_spearman_rho: float`, and
+`n_permutations: int`.
+
+#### Scenario: CrossPlatformPermutationResult round-trips through JSON as native types
+
+- **WHEN** a `CrossPlatformPermutationResult` built from one or more `permutation_test()` outputs
+  is passed to `json.dumps(dataclasses.asdict(result))`
+- **THEN** the call SHALL succeed without raising
+- **AND** parsing the string back with `json.loads` SHALL yield every numeric field, and every
+  element of every null-distribution list, as a Python `float` (no `np.float64`)
+
+#### Scenario: null distribution lists have length n_permutations
+
+- **WHEN** a `PermutationResult` is built from a `permutation_test(..., n_permutations=N)` output
+- **THEN** `null_r2`, `null_rmse`, `null_spearman_rho`, and `null_top_quartile_recovery` SHALL
+  each have length `N`, and `n_permutations` SHALL equal `N`
+
+#### Scenario: PermutationResult is independent of TargetPrediction
+
+- **WHEN** `dataclasses.fields(CrossPlatformPredictionResult)` is inspected
+- **THEN** it SHALL contain no field referencing `PermutationResult` or
+  `CrossPlatformPermutationResult` — the two result families remain structurally independent
+
+### Requirement: CrossPlatformPermutationResult Adapter From permutation_test Output
+
+The package SHALL provide an adapter that maps one or more `permutation_test()` return values,
+plus platform-pair and method metadata, into a `CrossPlatformPermutationResult`. The adapter
+SHALL NOT mutate its inputs.
+
+#### Scenario: Adapter maps fields from real permutation_test output
+
+- **WHEN** the adapter is called with `permutation_test()` outputs for each prediction target
+  (representative traits + PC1) for one platform pair and reduction method
+- **THEN** the resulting `CrossPlatformPermutationResult.predictions` list SHALL contain one
+  `PermutationResult` per target, with every field matching the corresponding
+  `permutation_test()` output exactly
+
+### Requirement: CrossPlatformPermutationResult Public Export
+
+The package SHALL export `CrossPlatformPermutationResult` and `PermutationResult` from the
+top-level `sleap_roots_analyze` namespace and list them in `__all__`.
+
+#### Scenario: Result types importable from package root
+
+- **WHEN** a consumer runs
+  `from sleap_roots_analyze import CrossPlatformPermutationResult, PermutationResult`
+- **THEN** the import SHALL succeed
+- **AND** both names SHALL appear in `sleap_roots_analyze.__all__` with no duplicate entries

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -624,8 +624,8 @@
 
 ## 12. Docs
 
-- [ ] 12.1 Add a `docs/CHANGELOG.md` `[Unreleased]` `### Added` entry.
-- [ ] 12.2 Extend `docs/CROSS_PLATFORM_ANALYSIS.md`'s existing `## Cross-Platform Genotype-Effect
+- [x] 12.1 Add a `docs/CHANGELOG.md` `[Unreleased]` `### Added` entry.
+- [x] 12.2 Extend `docs/CROSS_PLATFORM_ANALYSIS.md`'s existing `## Cross-Platform Genotype-Effect
       Prediction` section (Tier 3.5 already extended it once) with a new `###` subsection covering
       `permutation_test()` and `top_quartile_recovery()`, `VisualizePredictionStep`, and **all 4**
       new `PredictionConfig` fields (`visualize`, `n_permutations`, `permutation_random_state`,
@@ -656,7 +656,7 @@
       - **Extend the existing `### Current Limitations` subsection's #197 bullet in place** (found
         during round 2: a separate new bullet would read as a near-duplicate) to also note that
         `CrossPlatformSummaryGenerator` doesn't surface permutation/visualization output either.
-- [ ] 12.3 **No `docs/API.md` entry** for `PermutationResult`/`CrossPlatformPermutationResult`.
+- [x] 12.3 **No `docs/API.md` entry** for `PermutationResult`/`CrossPlatformPermutationResult`.
       Verified directly (found during `/review-openspec` round 1 that the original task's premise
       was backwards): `LOGOCVResult`/`CrossPlatformPredictionResult`/`TargetPrediction` are all in
       `__all__`, but **none** has an `API.md` entry — the `cross_platform_prediction` module

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -246,7 +246,7 @@
 
 ## 5a. `joblib` dependency (must land before Section 7b)
 
-- [ ] 5a.1 Add `joblib` to `pyproject.toml`'s direct dependencies (design.md Decision 5), pinned to
+- [x] 5a.1 Add `joblib` to `pyproject.toml`'s direct dependencies (design.md Decision 5), pinned to
       the version already resolved transitively via `scikit-learn` in this environment's lockfile,
       and regenerate `uv.lock` accordingly (found during `/review-openspec` round 3: the original
       task didn't mention the lockfile needs regenerating alongside the `pyproject.toml` edit) —

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -1,0 +1,285 @@
+> Full rationale for every design choice referenced below (self-contained `permutation_test()`,
+> per-target (not per-permutation) `joblib.Parallel` strategy and its empirical basis, separate
+> `CrossPlatformPermutationResult` type, additive `PredictCrossPlatformStep` extension, config
+> field placement, figure scope) is in `design.md`'s Decisions section and the brainstormed design
+> at `docs/superpowers/specs/2026-07-16-prediction-permutation-and-figure-design.md`.
+
+## 1. Fixtures (test-first)
+
+- [ ] 1.1 Reuse Tier 3's N=20-seed-averaged planted-signal fixture (`n_genotypes=19, n_traits=3,
+      signal_strength=0.8`, seeds `1..20`) and its pure-noise counterpart, per Tier 3 Decision 6 —
+      do not re-derive from `theory.md`'s single-seed recipe. Confirm these fixtures (or a thin
+      wrapper reusing their generator function) are importable from this tier's test module.
+- [ ] 1.2 Add a small set of independent pure-noise fixtures (real, non-degenerate `X`; `y`
+      independently drawn, no planted relationship) for the K-S permutation-calibration oracle —
+      ~30-50 independent realizations, each with a distinct seed, `n_genotypes=19` (matches the
+      other fixtures' scale).
+- [ ] 1.3 Add a small 2-platform synthetic BLUP fixture pair with `prediction.visualize: true`
+      wired into a harness YAML (extending Tier 3.5's own harness fixture at
+      `tests/fixtures/harness/cross_platform/`, or a sibling file) — used for wiring-correctness
+      tests in Sections 6-8, not for statistical oracle assertions (mirrors Tier 3.5 task 1.1/1.2's
+      "wiring correctness, not statistical claim" framing).
+
+## 2. `permutation_test()`/`top_quartile_recovery()` (test-first)
+
+- [ ] 2.1 Write failing test `test_top_quartile_recovery_perfect_prediction_recovers_all`: a
+      strictly monotonic `y_pred` (e.g. `y_pred == y_true`) gives `top_quartile_recovery == 1.0`.
+- [ ] 2.2 Write failing test `test_top_quartile_recovery_uses_top_2q_predicted_set`: construct a
+      case where the true top-`Q` genotypes are NOT in the predicted top-`Q` but ARE in the
+      predicted top-`2Q` — assert full recovery (proves the `2Q` window, not `Q`, is used).
+- [ ] 2.3 Write failing test `test_top_quartile_recovery_default_q_is_quarter_of_n`: with
+      `len(y_true) == 19` and `q` omitted, assert the effective `q` used equals `round(19 / 4)`
+      (inspect via a case constructed so a wrong `q` produces a different recovery fraction).
+- [ ] 2.4 Implement `top_quartile_recovery(y_true, y_pred, q=None)` in
+      `cross_platform_prediction.py`. Make 2.1-2.3 green.
+- [ ] 2.5 Write failing test `test_permutation_test_observed_matches_direct_logo_cv_predict_call`:
+      `permutation_test(X, y, genotypes, method).observed_r2` (etc.) exactly matches an
+      independent `logo_cv_predict(X, y, genotypes, method)` call's `r2` (etc.) on the same inputs.
+- [ ] 2.6 Write failing test `test_permutation_test_null_distributions_have_length_n_permutations`:
+      `null_r2`/`null_rmse`/`null_spearman_rho`/`null_top_quartile_recovery` each have length `N`
+      for `n_permutations=N`.
+- [ ] 2.7 Write failing test `test_permutation_test_shuffles_y_not_x_or_genotypes`: spy on
+      `logo_cv_predict` (or inspect its call arguments) to confirm each permutation iteration's `X`
+      and `genotypes` arguments are unchanged from the original inputs, only `y` differs.
+- [ ] 2.8 Write failing test `test_permutation_test_deterministic_given_same_random_state`: two
+      calls with identical arguments (including `random_state`) produce bit-identical null arrays.
+- [ ] 2.9 Write failing test `test_permutation_test_different_random_state_differs`: two calls
+      differing only in `random_state` produce non-identical `null_r2` arrays.
+- [ ] 2.10 Write failing test
+      `test_permutation_test_null_top_quartile_recovery_uses_shuffled_y_as_truth`: construct a
+      case where using the *original* `y` as truth (instead of that permutation's shuffled `y`)
+      would produce a detectably different recovery value — assert the shuffled-`y`-as-truth
+      behavior (Decision 2 in design.md).
+- [ ] 2.11 Write failing test `test_permutation_test_p_value_formula`: for a hand-constructed
+      `null` array and `observed` value, assert `p_value_r2` (etc.) equals
+      `(count(v >= observed) + 1) / (n_permutations + 1)` exactly.
+- [ ] 2.12 Write failing test `test_permutation_test_rejects_non_positive_n_permutations`:
+      `n_permutations=0` and `n_permutations=-1` both raise `ValueError`, before any
+      `logo_cv_predict` call (spy to confirm zero calls made).
+- [ ] 2.13 Write failing test `test_permutation_test_surfaces_logo_cv_predict_validation_errors`:
+      an invalid `reduction_method` (or mismatched-length `X`/`y`/`genotypes`, or duplicate
+      `genotypes`) raises the same `ValueError` `logo_cv_predict` itself would raise, from the
+      observed-value call, before any permutation runs.
+- [ ] 2.14 Implement `permutation_test(X, y, genotypes, reduction_method="pls_latent",
+      representative_names=None, n_permutations=1000, random_state=42)` in
+      `cross_platform_prediction.py`, returning a `PermutationResult` (Section 3). Make 2.5-2.13
+      green.
+
+## 3. `PermutationResult`/`CrossPlatformPermutationResult` (test-first)
+
+- [ ] 3.1 Write failing test `test_permutation_result_round_trips_through_json_as_native_types`:
+      `json.dumps(dataclasses.asdict(result))` succeeds; parsed-back numeric fields (including
+      every element of every null-distribution list) are Python `float`, not `np.float64`.
+- [ ] 3.2 Write failing test `test_permutation_result_null_lists_have_length_n_permutations`.
+- [ ] 3.3 Write failing test
+      `test_cross_platform_prediction_result_has_no_permutation_result_field`: inspect
+      `dataclasses.fields(CrossPlatformPredictionResult)` and `TargetPrediction`, assert neither
+      references `PermutationResult`/`CrossPlatformPermutationResult` (Decision 3 — types stay
+      structurally independent).
+- [ ] 3.4 Implement `PermutationResult`/`CrossPlatformPermutationResult` in `result_types.py`,
+      mirroring `TargetPrediction`/`CrossPlatformPredictionResult`'s `to_dict()`/`to_json()`
+      pattern exactly. Make 3.1-3.3 green.
+- [ ] 3.5 Write failing test
+      `test_cross_platform_permutation_result_adapter_maps_fields_from_real_output`: build a
+      `CrossPlatformPermutationResult` from real `permutation_test()` outputs for multiple targets,
+      assert every field matches exactly.
+- [ ] 3.6 Implement the `from_permutation_test_results`-style adapter (naming to match
+      `CrossPlatformPredictionResult.from_logo_cv_results`'s convention). Make 3.5 green.
+- [ ] 3.7 Write failing test
+      `test_permutation_result_types_importable_from_package_root`:
+      `from sleap_roots_analyze import CrossPlatformPermutationResult, PermutationResult`
+      succeeds; both names in `__all__`, no duplicates.
+- [ ] 3.8 Add both names to `__init__.py`'s import block and `__all__` (grouped by comment header,
+      matching the existing `pc_correlations`/cross-platform-prediction grouping convention). Make
+      3.7 green.
+
+## 4. `PredictionConfig` new fields + `CrossPlatformConfig` cross-check (test-first)
+
+- [ ] 4.1 Write failing test `test_prediction_config_visualize_defaults_to_false_and_no_op`:
+      `PredictionConfig()` has `visualize=False`, `n_permutations=1000`,
+      `permutation_random_state=42`, `permutation_n_jobs=8`; construction with these defaults does
+      not raise.
+- [ ] 4.2 Write failing test `test_cross_platform_config_rejects_visualize_true_with_enabled_false`:
+      `CrossPlatformConfig(..., prediction=PredictionConfig(enabled=False, visualize=True))`
+      raises `ValueError` at construction time.
+- [ ] 4.3 Write failing test `test_prediction_config_n_permutations_validation_skipped_when_visualize_false`:
+      `enabled=True, visualize=False, n_permutations=0` does not raise.
+- [ ] 4.4 Write failing test `test_prediction_config_rejects_non_positive_n_permutations_when_visualize_true`:
+      `enabled=True, visualize=True, n_permutations=0` (and `-1`) raises `ValueError`.
+- [ ] 4.5 Extend `PredictionConfig`/`CrossPlatformConfig.__post_init__` in
+      `pipeline/config/components.py` with the 4 new fields and the 4.2/4.4 validations. Make
+      4.1-4.4 green.
+
+## 5. `PredictCrossPlatformStep` additive extension (test-first)
+
+- [ ] 5.1 Write failing test `test_predict_step_exposes_predictor_matrices_in_step_result_data`:
+      after a normal run, `StepResult.data["predictor_matrices"]` holds `source_clean`/
+      `target_clean` (DataFrames matching the step's own internal computation) and
+      `source_representative_names`/`target_representatives`.
+- [ ] 5.2 Write failing test
+      `test_predict_step_existing_data_metadata_files_unchanged_by_predictor_matrices_addition`: a
+      full backward-compat regression test — every existing key in `StepResult.data`/`metadata`
+      and every path in `files_generated` is byte-for-byte/value-for-value identical to this step's
+      pre-Tier-4 behavior on the same fixture (guards against Decision 6's additive-only promise).
+- [ ] 5.3 Extend `PredictCrossPlatformStep.execute()` in `predict_cross_platform.py` to populate
+      `predictor_matrices`. Make 5.1-5.2 green.
+
+## 6. `VisualizePredictionStep` (test-first)
+
+- [ ] 6.1 Write failing test `test_visualize_prediction_step_reuses_task6_predictor_matrices`: spy
+      on any BLUP-loading/genotype-mean-aggregation function to confirm zero calls when
+      `predictor_matrices` is supplied via `kwargs["06_predict_cross_platform"]`.
+- [ ] 6.2 Write failing test
+      `test_visualize_prediction_step_calls_permutation_test_once_per_target_per_method`: for `N`
+      targets × `M` methods (`reduction_method` + `comparison_methods`), `permutation_test` is
+      called exactly `N * M` times.
+- [ ] 6.3 Write failing test
+      `test_visualize_prediction_step_parallelizes_across_target_method_units_not_within_one`:
+      inspect the `joblib.Parallel`/`delayed` call structure (or the list of dispatched callables)
+      to confirm one `delayed(...)` unit per `(target, method)` combination, not per permutation
+      iteration.
+- [ ] 6.4 Write failing test
+      `test_visualize_prediction_step_joblib_n_jobs_matches_config`:
+      `joblib.Parallel` is constructed with `n_jobs=config.prediction.permutation_n_jobs`.
+- [ ] 6.5 Write failing test
+      `test_visualize_prediction_step_produces_identical_results_parallel_vs_serial`: on a small
+      fixture, `permutation_n_jobs=1` and `permutation_n_jobs=4` produce bit-identical
+      `CrossPlatformPermutationResult`s (parallelization must not change results, only wall time).
+- [ ] 6.6 Write failing test `test_visualize_prediction_step_saves_one_json_per_method`: `K + 1`
+      `07_permutation_<method>.json` files for `reduction_method` + `K` `comparison_methods`.
+- [ ] 6.7 Write failing test
+      `test_visualize_prediction_step_permutation_observed_matches_task6_prediction_exactly`: for
+      each target/method, the permutation JSON's `observed_r2`/`observed_rmse`/
+      `observed_spearman_rho` exactly matches task 6's `06_prediction_<method>.json`'s `r2`/
+      `rmse`/`spearman_rho` for the same target.
+- [ ] 6.8 Write failing test `test_visualize_prediction_step_saves_one_figure_using_primary_method_only`:
+      exactly one `07_prediction_figure.png`, and (via a spy/mock on the figure-building function)
+      confirm it was called with only the primary `reduction_method`'s results, not
+      `comparison_methods`'.
+- [ ] 6.9 Implement `VisualizePredictionStep(BaseStep)` in new
+      `src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py`. Make 6.1-6.8 green.
+
+## 7. `CrossPlatformPipeline` task wiring (test-first)
+
+- [ ] 7.1 Write failing test `test_cross_platform_pipeline_appends_visualize_prediction_task_when_visualize_enabled`:
+      `create_tasks()` includes a 7th task, `depends_on=["06_predict_cross_platform"]`, when
+      `config.prediction.visualize=True`.
+- [ ] 7.2 Write failing test `test_cross_platform_pipeline_omits_visualize_prediction_task_when_disabled`:
+      `create_tasks()` returns exactly 6 tasks when `config.prediction.visualize=False` (the
+      default) — including when `config.prediction.enabled=True` (prediction alone, no
+      visualization).
+- [ ] 7.3 Add `_run_visualize_prediction` runner method + the conditional `Task(...)` entry to
+      `CrossPlatformPipeline.create_tasks()`. Make 7.1-7.2 green.
+- [ ] 7.4 Write failing test `test_cli_cross_platform_dry_run_lists_visualize_prediction_step_when_enabled`
+      and `test_cli_cross_platform_dry_run_omits_it_when_disabled` (mirroring Tier 3.5 tasks 7.1-7.2).
+- [ ] 7.5 Update `cli.py`'s dry-run steps list (conditional 7th entry) and docstring. Make 7.4 green.
+
+## 8. Figure content: `visualize_prediction.py` module (test-first)
+
+- [ ] 8.1 Write failing test `test_create_prediction_figure_scatter_panel_uses_pc1_target_only`:
+      given multiple targets' data, the obs-vs-pred scatter panel's plotted points correspond only
+      to the `PC1` target's `y_true`/`y_pred`.
+- [ ] 8.2 Write failing test `test_create_prediction_figure_violin_panel_pools_all_targets_nulls`:
+      the violin/strip panel's null data is the concatenation of every target's `null_r2`, and its
+      observed-points data is every target's `observed_r2` (one point per target).
+- [ ] 8.3 Write failing test `test_create_prediction_figure_bar_chart_shows_observed_vs_null_mean`:
+      the two bars' heights equal the mean observed and mean null top-quartile-recovery across all
+      targets.
+- [ ] 8.4 Write failing test `test_create_prediction_figure_returns_a_figure_with_three_axes`.
+- [ ] 8.5 Implement `create_prediction_figure(...)` (and any supporting per-panel helper functions)
+      in new `src/sleap_roots_analyze/visualize_prediction.py`, following
+      `cross_experiment_analysis.py`'s plotting-function convention (pure functions returning a
+      `matplotlib.Figure`, no file I/O). Make 8.1-8.4 green.
+- [ ] 8.6 Wire `create_prediction_figure()` into `VisualizePredictionStep` (Section 6), saving with
+      `dpi=300, bbox_inches="tight"` matching `visualize_cross_platform.py`'s convention.
+
+## 9. Oracle tests (test-first, per design.md Decision 11)
+
+- [ ] 9.1 Write failing test `test_permutation_test_p_values_are_uniform_under_null` (K-S
+      calibration oracle): run `permutation_test()` on ~30-50 independent pure-noise fixtures
+      (task 1.2) with a reduced `n_permutations` (e.g. 200, CI-fast), collect the resulting
+      `p_value_r2`s, K-S-test against `Uniform(0,1)`, assert `p > 0.05`.
+- [ ] 9.2 Write failing test `test_permutation_test_signal_r2_exceeds_its_own_null_median`: on the
+      N=20-seed planted-signal fixture (task 1.1), the mean observed R² across seeds is
+      comfortably above the mean permutation-null median across the same seeds.
+- [ ] 9.3 Write failing test `test_permutation_test_noise_r2_falls_within_its_own_null_band`: on the
+      pure-noise fixture (task 1.1), mean observed R² falls within mean-null-median ± 1σ.
+- [ ] 9.4 **Empirically determine** (via a real computation, run and recorded during
+      implementation — not assumed from the roadmap's "≈25%" estimate) the pure-noise fixture's
+      actual mean null top-quartile-recovery value. Write failing test
+      `test_permutation_test_top_quartile_recovery_signal_vs_noise`: signal fixture's observed
+      recovery ≥ 80%; noise fixture's observed recovery is comfortably separated from the
+      signal's, near the empirically-determined null value (not a blindly-pinned 25%).
+- [ ] 9.5 Write failing test `test_visualize_prediction_step_figure_provenance`: run the step
+      twice (different input CSV content between runs, e.g. a perturbed fixture), assert the two
+      resulting `07_prediction_figure.png` files differ (via content hash), and that a given run's
+      figure's mtime is at or after its input CSVs' mtimes.
+- [ ] 9.6 Implement whatever `permutation_test()`/fixture adjustments are needed to make 9.1-9.5
+      pass, recording the actual empirically-determined values from 9.4 in this file and in
+      `design.md`'s Decision 11 note (per this program's "verify, don't assume" convention).
+
+## 10. Dependency + `theory.md` addendum
+
+- [ ] 10.1 Add `joblib` to `pyproject.toml`'s direct dependencies (Decision 5), pinned to the
+      version already resolved transitively via `scikit-learn` in this environment's lockfile.
+- [ ] 10.2 Add a permutation-null pseudo-code section to
+      `c:\vaults\sleap-roots\wheat-edpie-paper\cross-platform-prediction\theory.md` (external
+      vault), matching its existing LOGO-CV/per-fold-PCA pseudo-code style, including the
+      per-target (not per-permutation) `joblib.Parallel` lesson from this tier's benchmark
+      (Decision 4) as a documented erratum/addendum for any future tier that loops
+      `logo_cv_predict`.
+
+## 11. Manual real-data validation gate (non-CI, pre-merge, sign-off required)
+
+> Mirrors Tier 3/3.5's Section 8 exactly — see design.md Section 5 for full rationale. Not
+> complete until Elizabeth has reviewed the findings and explicitly signed off; a green CI run is
+> necessary but not sufficient.
+
+- [ ] 11.1 Reuse Tier 3.5's Section 8 real BLUP tables and 4 directed-pair `CrossPlatformConfig`
+      YAMLs (`pipeline_runs/section8_manual_validation_20260716/`) if still valid; rebuild via the
+      same non-committed script pattern if the underlying QC vintage has moved. Extend each YAML's
+      `prediction:` block with `visualize: true`, `n_permutations: 1000`, `permutation_n_jobs: 8`.
+- [ ] 11.2 Run all 4 directed pairs through the full 7-task pipeline, including
+      `Turface19→Cylinder` (worst-case pair, ~129 representative traits).
+- [ ] 11.3 Re-measure and record real wall time, per pair and total — superseding the synthetic-
+      fixture-derived 27.4-minute estimate (design.md Decision 4/Risks). If any pair or the total
+      exceeds 30 minutes, apply a documented fallback (design.md Risks) before proceeding to 11.7.
+- [ ] 11.4 Sanity-check permutation-based p-values against Tier 3.5's Section 8.2/8.3 nominally-
+      significant findings (e.g. Cylinder→Field `Root Count 20cm`, asymptotic R²=0.25/ρ=+0.49/
+      p=0.033; Turface19→Cylinder `Seminal Angles Proximal Max Max`, asymptotic R²=0.38/ρ=+0.62/
+      p=0.004) — record whether these still look significant under the permutation-based p-value.
+- [ ] 11.5 Cross-check against Tier 3.5's Section 8.5 multiple-testing/power caveat (raw p<0.05
+      count 63/354, FDR-corrected count 9/354, all 9 negative ρ) — record whether permutation-based
+      inference reinforces or changes that caveat's conclusion.
+- [ ] 11.6 Visually inspect all 4 `07_prediction_figure.png` outputs for legibility and correctness.
+- [ ] 11.7 Present findings to Elizabeth; record her explicit sign-off here before this task (and
+      Section 12's `/pre-merge-check`) is considered complete.
+
+## 12. Docs
+
+- [ ] 12.1 Add a `docs/CHANGELOG.md` `[Unreleased]` `### Added` entry.
+- [ ] 12.2 Extend `docs/CROSS_PLATFORM_ANALYSIS.md`'s existing `## Cross-Platform Genotype-Effect
+      Prediction` section (Tier 3.5 already extended it once) with a new `###` subsection covering
+      `permutation_test()`, `VisualizePredictionStep`, the new `PredictionConfig` fields, and a
+      concrete YAML example with `visualize: true`.
+- [ ] 12.3 No `docs/API.md` entry — `PermutationResult`/`CrossPlatformPermutationResult` follow
+      the same `__all__`-driven pattern as their siblings and DO get an entry there (unlike
+      Configs/Steps, per Tier 3.5 task 9.1's finding); confirm and add if the existing
+      `CrossPlatformPredictionResult`/`TargetPrediction` entries set that precedent.
+
+## 13. Validation
+
+- [ ] 13.1 `openspec validate add-prediction-permutation-and-figure --strict` — resolve every
+      reported issue.
+- [ ] 13.2 `/lint` (black + ruff) on all changed files.
+- [ ] 13.3 Full `uv run pytest --cov --cov-branch` — no regressions, all new tests (Sections 2-9)
+      green.
+- [ ] 13.4 `/review-openspec` — adversarial proposal review, budget for multiple independent
+      rounds (this program's established pattern: 3-5 BLOCKING findings round 1, diminishing each
+      round). Reconcile literally into `design.md`.
+- [ ] 13.5 Wait for Elizabeth's explicit approval of the fully-reconciled proposal before starting
+      implementation (Sections 1-10).
+- [ ] 13.6 Section 11's manual real-data validation gate, complete with sign-off.
+- [ ] 13.7 Post-implementation code review: `/pre-merge-check` including a 5-subagent `/review-pr`
+      self-review pass before the PR opens, and a second fresh pass once CI runs on the open PR
+      (mirroring Tier 3/3.5's precedent — both passes have caught real bugs every tier so far).

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -12,8 +12,11 @@
       wrapper reusing their generator function) are importable from this tier's test module.
 - [ ] 1.2 Add a small set of independent pure-noise fixtures (real, non-degenerate `X`; `y`
       independently drawn, no planted relationship) for the K-S permutation-calibration oracle —
-      ~30-50 independent realizations, each with a distinct seed, `n_genotypes=19` (matches the
-      other fixtures' scale).
+      ~30-50 independent realizations, each with a **fixed, committed literal seed** (not
+      regenerated per test run) and a **fixed, committed literal `permutation_test` `random_state`**
+      for the oracle itself, `n_genotypes=19` (matches the other fixtures' scale). Pinning both to
+      literals makes task 9.1's K-S test a deterministic golden check rather than a live stochastic
+      draw with an intrinsic ~5%+ false-failure rate across 3 OSes × every PR.
 - [ ] 1.3 Add a small 2-platform synthetic BLUP fixture pair with `prediction.visualize: true`
       wired into a harness YAML (extending Tier 3.5's own harness fixture at
       `tests/fixtures/harness/cross_platform/`, or a sibling file) — used for wiring-correctness
@@ -30,8 +33,16 @@
 - [ ] 2.3 Write failing test `test_top_quartile_recovery_default_q_is_quarter_of_n`: with
       `len(y_true) == 19` and `q` omitted, assert the effective `q` used equals `round(19 / 4)`
       (inspect via a case constructed so a wrong `q` produces a different recovery fraction).
+- [ ] 2.3a Write failing test `test_top_quartile_recovery_small_n_gives_at_least_one_and_not_over_n`:
+      at `len(y_true)=3` (this program's smallest real scale), assert the effective `q` used is
+      `>= 1` and `2 * q <= len(y_true)` (guards against a vacuous `q=0` or an out-of-range window).
 - [ ] 2.4 Implement `top_quartile_recovery(y_true, y_pred, q=None)` in
-      `cross_platform_prediction.py`. Make 2.1-2.3 green.
+      `cross_platform_prediction.py`. Make 2.1-2.3a green.
+
+> **Commit boundary**: 2.1-2.4 (`top_quartile_recovery`, no dependency on `permutation_test`) is a
+> natural standalone commit; 2.5 onward (`permutation_test`, which calls `top_quartile_recovery`)
+> is a second.
+
 - [ ] 2.5 Write failing test `test_permutation_test_observed_matches_direct_logo_cv_predict_call`:
       `permutation_test(X, y, genotypes, method).observed_r2` (etc.) exactly matches an
       independent `logo_cv_predict(X, y, genotypes, method)` call's `r2` (etc.) on the same inputs.
@@ -56,14 +67,26 @@
 - [ ] 2.12 Write failing test `test_permutation_test_rejects_non_positive_n_permutations`:
       `n_permutations=0` and `n_permutations=-1` both raise `ValueError`, before any
       `logo_cv_predict` call (spy to confirm zero calls made).
+- [ ] 2.12a Write failing test `test_permutation_test_accepts_n_permutations_equal_1`:
+      `n_permutations=1` does not raise; `null_r2`/etc. each have length exactly `1`; the resulting
+      p-value formula degenerates correctly to `(count + 1) / 2` (either `0.5` or `1.0`) — a
+      boundary distinct from the general `n_permutations<=0` rejection in 2.12.
 - [ ] 2.13 Write failing test `test_permutation_test_surfaces_logo_cv_predict_validation_errors`:
       an invalid `reduction_method` (or mismatched-length `X`/`y`/`genotypes`, or duplicate
       `genotypes`) raises the same `ValueError` `logo_cv_predict` itself would raise, from the
       observed-value call, before any permutation runs.
+- [ ] 2.13a Write failing test `test_permutation_test_rejects_non_finite_null_values_with_named_error`:
+      construct a permutation iteration whose LOGO-CV fold structure produces a non-finite
+      `spearman_rho` (e.g. inject via a monkeypatched `logo_cv_predict` returning a degenerate
+      result for one specific permutation index, independent of whether that permutation's
+      shuffled `y` was itself constant) — assert `ValueError` naming both the offending metric and
+      the permutation index, not a downstream `to_json()` crash with no indication of which
+      permutation caused it (per the cross-platform-prediction spec's "Non-finite null values are
+      rejected" scenario).
 - [ ] 2.14 Implement `permutation_test(X, y, genotypes, reduction_method="pls_latent",
       representative_names=None, n_permutations=1000, random_state=42)` in
-      `cross_platform_prediction.py`, returning a `PermutationResult` (Section 3). Make 2.5-2.13
-      green.
+      `cross_platform_prediction.py`, returning a `PermutationResult` (Section 3), including the
+      non-finite-null scan from 2.13a. Make 2.5-2.13a green.
 
 ## 3. `PermutationResult`/`CrossPlatformPermutationResult` (test-first)
 
@@ -76,9 +99,18 @@
       `dataclasses.fields(CrossPlatformPredictionResult)` and `TargetPrediction`, assert neither
       references `PermutationResult`/`CrossPlatformPermutationResult` (Decision 3 — types stay
       structurally independent).
+- [ ] 3.3a Write failing test `test_permutation_result_has_no_sklearn_or_numpy_object`:
+      `dataclasses.asdict(result)` contains no sklearn `Pipeline`/`PLSRegression`/`Ridge`/`PCA`/
+      `StandardScaler` object and no raw `numpy.ndarray` — every null-distribution field is a
+      plain Python `list` of `float`.
 - [ ] 3.4 Implement `PermutationResult`/`CrossPlatformPermutationResult` in `result_types.py`,
       mirroring `TargetPrediction`/`CrossPlatformPredictionResult`'s `to_dict()`/`to_json()`
-      pattern exactly. Make 3.1-3.3 green.
+      pattern exactly. Make 3.1-3.3a green.
+
+> **Commit boundary**: 3.1-3.4 (the dataclasses themselves) have no import-time dependency on
+> `permutation_test` and can land before Section 2 finishes; 3.5-3.8 (the adapter, which calls
+> `permutation_test` in its own test) must land after Section 2 is green.
+
 - [ ] 3.5 Write failing test
       `test_cross_platform_permutation_result_adapter_maps_fields_from_real_output`: build a
       `CrossPlatformPermutationResult` from real `permutation_test()` outputs for multiple targets,
@@ -121,30 +153,72 @@
       full backward-compat regression test — every existing key in `StepResult.data`/`metadata`
       and every path in `files_generated` is byte-for-byte/value-for-value identical to this step's
       pre-Tier-4 behavior on the same fixture (guards against Decision 6's additive-only promise).
+      Explicitly assert `set(result.data.keys()) - {"predictor_matrices"}` equals the exact
+      pre-Tier-4 key set (method names only) — not just that pre-existing keys are unchanged, but
+      that `"predictor_matrices"` is the *only* addition, catching any accidental extra key leakage.
 - [ ] 5.3 Extend `PredictCrossPlatformStep.execute()` in `predict_cross_platform.py` to populate
       `predictor_matrices`. Make 5.1-5.2 green.
 
+## 5a. `joblib` dependency (must land before Section 6)
+
+- [ ] 5a.1 Add `joblib` to `pyproject.toml`'s direct dependencies (design.md Decision 5), pinned to
+      the version already resolved transitively via `scikit-learn` in this environment's lockfile
+      — moved ahead of Section 6, which imports `joblib.Parallel` directly at module level; adding
+      the dependency after that import would exist is backwards (found during `/review-openspec`
+      round 1).
+
 ## 6. `VisualizePredictionStep` (test-first)
+
+> Split into three commits (found during `/review-openspec` round 1: one implementation task for
+> 8 tests was too coarse-grained relative to this program's established per-commit granularity):
+> 6.1-6.2 (wiring/reuse), 6.3-6.5a (joblib parallelization — the riskiest, most novel piece, worth
+> isolated review), 6.6-6.8a (JSON/figure I/O).
 
 - [ ] 6.1 Write failing test `test_visualize_prediction_step_reuses_task6_predictor_matrices`: spy
       on any BLUP-loading/genotype-mean-aggregation function to confirm zero calls when
       `predictor_matrices` is supplied via `kwargs["06_predict_cross_platform"]`.
+- [ ] 6.1a Write failing test `test_visualize_prediction_step_handles_pc1_only_targets`: with zero
+      representative-trait targets (only `target_name="PC1"` present, e.g. a fixture where
+      `select_cluster_representatives` returned empty — Tier 3.5's own documented degenerate case),
+      the step runs successfully through the full `joblib.Parallel` dispatch with `N=1` total
+      `(target, method)` unit, producing a valid `CrossPlatformPermutationResult`, not a crash.
 - [ ] 6.2 Write failing test
       `test_visualize_prediction_step_calls_permutation_test_once_per_target_per_method`: for `N`
       targets × `M` methods (`reduction_method` + `comparison_methods`), `permutation_test` is
       called exactly `N * M` times.
+- [ ] 6.2a Write failing test
+      `test_visualize_prediction_step_calls_permutation_test_n_times_when_comparison_methods_empty`:
+      with `comparison_methods=[]` (`K=0`), `permutation_test` is called exactly `N` times (`N`
+      targets × 1 method) — an explicit `K=0` case, not just the general `N * M` formula in 6.2.
 - [ ] 6.3 Write failing test
       `test_visualize_prediction_step_parallelizes_across_target_method_units_not_within_one`:
       inspect the `joblib.Parallel`/`delayed` call structure (or the list of dispatched callables)
       to confirm one `delayed(...)` unit per `(target, method)` combination, not per permutation
       iteration.
 - [ ] 6.4 Write failing test
-      `test_visualize_prediction_step_joblib_n_jobs_matches_config`:
-      `joblib.Parallel` is constructed with `n_jobs=config.prediction.permutation_n_jobs`.
+      `test_visualize_prediction_step_joblib_n_jobs_and_backend_match_config`:
+      `joblib.Parallel` is constructed with `n_jobs=config.prediction.permutation_n_jobs,
+      backend="loky"` (per the cross-platform-analysis spec's explicit backend choice).
+- [ ] 6.4a Write failing test
+      `test_visualize_prediction_step_derives_independent_seed_per_target_method`: for `N`
+      `(target, method)` combinations, assert `numpy.random.SeedSequence(
+      config.prediction.permutation_random_state).spawn(N)` is used to derive `N` distinct seeds,
+      one passed to each `permutation_test()` call — no two combinations receive the same seed,
+      and re-running with the same `permutation_random_state` reproduces the same derived seeds
+      (per design.md Decision 4's finding that reusing one seed across all targets would
+      correlate, not independently sample, the pooled-null figure panel's null draws).
 - [ ] 6.5 Write failing test
-      `test_visualize_prediction_step_produces_identical_results_parallel_vs_serial`: on a small
-      fixture, `permutation_n_jobs=1` and `permutation_n_jobs=4` produce bit-identical
-      `CrossPlatformPermutationResult`s (parallelization must not change results, only wall time).
+      `test_visualize_prediction_step_parallel_vs_serial_results_agree_within_tolerance`: on a
+      small fixture, `permutation_n_jobs=1` and `permutation_n_jobs=4` produce
+      `CrossPlatformPermutationResult`s that agree via `numpy.testing.assert_allclose(...,
+      rtol=1e-6, atol=1e-9)` — **not bit-identical** (loky worker processes may resolve a
+      different default BLAS thread count than the main process, a documented source of
+      ULP-level floating-point differences per `docs/reproducibility.md`'s established
+      cross-BLAS tolerance convention, independent of this step's own correctness).
+- [ ] 6.5a Write failing test `test_visualize_prediction_step_permutation_test_receives_derived_seed`:
+      spy on `permutation_test` to confirm each call's `random_state` argument matches that
+      combination's derived seed from 6.4a, not the raw `config.prediction.permutation_random_state`
+      passed through unchanged.
 - [ ] 6.6 Write failing test `test_visualize_prediction_step_saves_one_json_per_method`: `K + 1`
       `07_permutation_<method>.json` files for `reduction_method` + `K` `comparison_methods`.
 - [ ] 6.7 Write failing test
@@ -156,8 +230,14 @@
       exactly one `07_prediction_figure.png`, and (via a spy/mock on the figure-building function)
       confirm it was called with only the primary `reduction_method`'s results, not
       `comparison_methods`'.
+- [ ] 6.8a Write failing test
+      `test_visualize_prediction_step_rejects_non_finite_permutation_result_with_named_error`:
+      when `permutation_test` (or its underlying `logo_cv_predict` calls) would produce a
+      non-finite null value for one target/method, the step surfaces `ValueError` naming the
+      target/method/permutation-index (propagated from `permutation_test`'s own guard, task
+      2.13a), before attempting to write any `07_permutation_<method>.json`.
 - [ ] 6.9 Implement `VisualizePredictionStep(BaseStep)` in new
-      `src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py`. Make 6.1-6.8 green.
+      `src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py`. Make 6.1-6.8a green.
 
 ## 7. `CrossPlatformPipeline` task wiring (test-first)
 
@@ -204,36 +284,49 @@
       comfortably above the mean permutation-null median across the same seeds.
 - [ ] 9.3 Write failing test `test_permutation_test_noise_r2_falls_within_its_own_null_band`: on the
       pure-noise fixture (task 1.1), mean observed R² falls within mean-null-median ± 1σ.
-- [ ] 9.4 **Empirically determine** (via a real computation, run and recorded during
-      implementation — not assumed from the roadmap's "≈25%" estimate) the pure-noise fixture's
-      actual mean null top-quartile-recovery value. Write failing test
-      `test_permutation_test_top_quartile_recovery_signal_vs_noise`: signal fixture's observed
-      recovery ≥ 80%; noise fixture's observed recovery is comfortably separated from the
-      signal's, near the empirically-determined null value (not a blindly-pinned 25%).
+- [ ] 9.4a **Spike, not a test** — compute (via a real run, recorded here and in design.md's
+      Decision 11 note): the pure-noise fixture's actual mean null top-quartile-recovery value.
+      Cross-check against the theoretical chance-level baseline `2q / n` (found during
+      `/review-openspec` round 1: at `n=19, q=5`, `2q/n ≈ 52.6%`, not the roadmap's originally-
+      estimated "≈25%" — the roadmap's number was never verified against the actual `top-q`-in-
+      `top-2q` window definition). This step produces a number to write a real assertion against
+      in 9.4b; it is not itself a red/green TDD step (a value that doesn't exist yet cannot be
+      asserted against).
+- [ ] 9.4b Write failing test `test_permutation_test_top_quartile_recovery_signal_vs_noise`, using
+      9.4a's now-known empirical value: signal fixture's observed recovery ≥ 80%; noise fixture's
+      observed recovery is comfortably separated from the signal's, close to the empirically-
+      determined null value (not a blindly-pinned 25% or an untested theoretical `2q/n`).
 - [ ] 9.5 Write failing test `test_visualize_prediction_step_figure_provenance`: run the step
       twice (different input CSV content between runs, e.g. a perturbed fixture), assert the two
       resulting `07_prediction_figure.png` files differ (via content hash), and that a given run's
       figure's mtime is at or after its input CSVs' mtimes.
-- [ ] 9.6 Implement whatever `permutation_test()`/fixture adjustments are needed to make 9.1-9.5
-      pass, recording the actual empirically-determined values from 9.4 in this file and in
-      `design.md`'s Decision 11 note (per this program's "verify, don't assume" convention).
+- [ ] 9.6 Implement whatever `permutation_test()`/fixture adjustments are needed to make 9.1-9.3
+      and 9.4b-9.5 pass, recording the actual empirically-determined values from 9.4a in this file
+      and in `design.md`'s Decision 11 note (per this program's "verify, don't assume" convention).
 
-## 10. Dependency + `theory.md` addendum
+## 10. `theory.md` addendum
 
-- [ ] 10.1 Add `joblib` to `pyproject.toml`'s direct dependencies (Decision 5), pinned to the
-      version already resolved transitively via `scikit-learn` in this environment's lockfile.
-- [ ] 10.2 Add a permutation-null pseudo-code section to
+> `joblib` dependency addition moved to Section 5a (must precede Section 6, which imports it).
+
+- [ ] 10.1 Add a permutation-null pseudo-code section to
       `c:\vaults\sleap-roots\wheat-edpie-paper\cross-platform-prediction\theory.md` (external
       vault), matching its existing LOGO-CV/per-fold-PCA pseudo-code style, including the
       per-target (not per-permutation) `joblib.Parallel` lesson from this tier's benchmark
       (Decision 4) as a documented erratum/addendum for any future tier that loops
-      `logo_cv_predict`.
+      `logo_cv_predict`. **This file lives in a separate external repository/git history from
+      `sleap-roots-analyze`** — it is committed separately, in the vault's own repo, and will NOT
+      appear in this repo's PR diff; a reviewer of the sleap-roots-analyze PR should not expect to
+      see this change there.
 
 ## 11. Manual real-data validation gate (non-CI, pre-merge, sign-off required)
 
 > Mirrors Tier 3/3.5's Section 8 exactly — see design.md Section 5 for full rationale. Not
 > complete until Elizabeth has reviewed the findings and explicitly signed off; a green CI run is
-> necessary but not sufficient.
+> necessary but not sufficient. **Timing**: per Tier 3.5's actual precedent (PR #199's real commit
+> history — validation commits landed *between* two rounds of PR-review fix commits, not
+> exclusively before the PR opened), this section runs on the already-open PR branch, after the
+> first 5-subagent self-review pass (task 13.7's pre-PR-open round) and before the second,
+> CI-triggered review pass — not necessarily a strict pre-PR-open gate.
 
 - [ ] 11.1 Reuse Tier 3.5's Section 8 real BLUP tables and 4 directed-pair `CrossPlatformConfig`
       YAMLs (`pipeline_runs/section8_manual_validation_20260716/`) if still valid; rebuild via the
@@ -253,19 +346,38 @@
       inference reinforces or changes that caveat's conclusion.
 - [ ] 11.6 Visually inspect all 4 `07_prediction_figure.png` outputs for legibility and correctness.
 - [ ] 11.7 Present findings to Elizabeth; record her explicit sign-off here before this task (and
-      Section 12's `/pre-merge-check`) is considered complete.
+      Section 13's `/pre-merge-check`) is considered complete.
 
 ## 12. Docs
 
 - [ ] 12.1 Add a `docs/CHANGELOG.md` `[Unreleased]` `### Added` entry.
 - [ ] 12.2 Extend `docs/CROSS_PLATFORM_ANALYSIS.md`'s existing `## Cross-Platform Genotype-Effect
       Prediction` section (Tier 3.5 already extended it once) with a new `###` subsection covering
-      `permutation_test()`, `VisualizePredictionStep`, the new `PredictionConfig` fields, and a
-      concrete YAML example with `visualize: true`.
-- [ ] 12.3 No `docs/API.md` entry — `PermutationResult`/`CrossPlatformPermutationResult` follow
-      the same `__all__`-driven pattern as their siblings and DO get an entry there (unlike
-      Configs/Steps, per Tier 3.5 task 9.1's finding); confirm and add if the existing
-      `CrossPlatformPredictionResult`/`TargetPrediction` entries set that precedent.
+      `permutation_test()` **and `top_quartile_recovery()`** (found during `/review-openspec`
+      round 1: the latter was missing from this task's original list), `VisualizePredictionStep`,
+      the new `PredictionConfig` fields, and a concrete YAML example with `visualize: true`. State
+      usage (what/how) only — cross-reference `design.md`'s Decisions for benchmark/rationale
+      detail (the 105.5min→27.4min parallelization benchmark, the figure-scope rationale) rather
+      than restating it (DRY). Also:
+      - **Correct the existing section's stale closing sentence** (found during round 1: it
+        currently reads "The permutation null and its figures (Tier 4) remain a separate, later
+        change" — stale now that this change *is* Tier 4).
+      - **Document the new output-file naming convention** (`07_permutation_<method>.json`,
+        `07_prediction_figure.png`) in an "Output:" paragraph, mirroring the existing section's own
+        precedent for Tier 3.5's `06_prediction_<method>.json` — currently this naming exists only
+        in `proposal.md`/`design.md`, neither of which is shipped documentation.
+      - **Add a one-line note to the `### Current Limitations` subsection** that
+        `CrossPlatformSummaryGenerator` does not yet surface permutation/visualization output
+        either (follow-up #197's scope has grown with this tier's new outputs, not fixed here).
+- [ ] 12.3 **No `docs/API.md` entry.** Verified directly (found during `/review-openspec` round 1
+      that the original task's premise was backwards): `LOGOCVResult`/`CrossPlatformPredictionResult`/
+      `TargetPrediction` are all in `__all__`, but **none** has an `API.md` entry — the
+      `cross_platform_prediction` module section documents only its two functions
+      (`fit_pca_on_fold`, `logo_cv_predict`); `__all__` membership does not predict `API.md`
+      inclusion for these dataclasses. `PermutationResult`/`CrossPlatformPermutationResult` follow
+      that same (undocumented-dataclass) precedent — no `API.md` change needed. `permutation_test`/
+      `top_quartile_recovery` DO get entries in the `cross_platform_prediction` module section,
+      alongside the existing two functions.
 
 ## 13. Validation
 

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -103,9 +103,17 @@
       case where using the *original* `y` as truth (instead of that permutation's shuffled `y`)
       would produce a detectably different recovery value — assert the shuffled-`y`-as-truth
       behavior (Decision 2 in design.md).
-- [ ] 2.11 Write failing test `test_permutation_test_p_value_formula`: for a hand-constructed
-      `null` array and `observed` value, assert `p_value_r2` (etc.) equals
-      `(count(v >= observed) + 1) / (n_permutations + 1)` exactly.
+- [ ] 2.11 Write failing test `test_permutation_test_p_value_formula_r2_and_rho`: for a
+      hand-constructed `null` array and `observed` value, assert `p_value_r2` **and**
+      `p_value_spearman_rho` each equal `(count(v >= observed) + 1) / (n_permutations + 1)` exactly
+      (right-tail — higher is better for both metrics).
+- [ ] 2.11a Write failing test `test_permutation_test_p_value_formula_rmse`: for a
+      hand-constructed `null` array and `observed` value, assert `p_value_rmse` equals
+      `(count(v <= observed) + 1) / (n_permutations + 1)` exactly — the **opposite**-tail formula
+      from 2.11 (lower RMSE is better), a separate task rather than folded into 2.11's "(etc.)" to
+      prevent an implementer from generalizing the wrong (right-tail) formula to RMSE by pattern-
+      matching alone (found during `/review-openspec` round 4: 2.11's original "(etc.)" wording,
+      if taken literally, contradicts the corrected RMSE formula and 9.2a's own assertion).
 - [ ] 2.12 Write failing test `test_permutation_test_rejects_non_positive_n_permutations`:
       `n_permutations=0` and `n_permutations=-1` both raise `ValueError`, before any
       `logo_cv_predict` call (spy to confirm zero calls made).
@@ -127,6 +135,14 @@
       expected to affect many permutations within one target, not a rare one-off, so failing fast
       saves little wall-clock time while complicating which-permutations-ran accounting), not a
       downstream `to_json()` crash with no indication of which permutation caused it.
+- [ ] 2.13b Write failing test `test_permutation_test_rejects_non_finite_observed_values_before_permutations_run`:
+      a constant `y` (legal per `logo_cv_predict`'s own "Constant y does not raise" contract,
+      reachable by a direct Python-API caller with no upstream pipeline guard — found during
+      `/review-openspec` round 4: the non-finite guard from 2.13a only ever covered null values,
+      never the observed call) — assert `ValueError` naming the offending observed metric, raised
+      immediately after the observed-value `logo_cv_predict` call and before any permutation is
+      drawn (spy to confirm zero shuffled calls made), not after wastefully completing the full
+      permutation loop on data already known to be unusable.
 - [ ] 2.14 Implement `permutation_test(X, y, genotypes, reduction_method="pls_latent",
       representative_names=None, n_permutations=1000, random_state=42)` in
       `cross_platform_prediction.py`, building its RNG via
@@ -134,8 +150,9 @@
       directly, which requires a `BitGenerator` instance and rejects a bare `int` — `default_rng`
       accepts `int`/`SeedSequence`/`Generator` uniformly, which is what makes 2.8's parametrized
       `SeedSequence` case and Section 7's per-target `SeedSequence` children both work with no
-      int-extraction step). Returns a `PermutationResult` (Section 3), including the non-finite-
-      null scan from 2.13a. Make 2.5-2.13a green.
+      int-extraction step). Returns a `PermutationResult` (Section 3), including the observed-value
+      non-finite check from 2.13b (runs first) and the non-finite null scan from 2.13a (runs after
+      all permutations complete). Make 2.5-2.13b green.
 
 ## 3. `PermutationResult`/`CrossPlatformPermutationResult` (test-first)
 
@@ -229,11 +246,14 @@
       figure-content module instead, which does not import `joblib` — corrected during round 3).
       Adding the dependency after that import would exist is backwards.
 
-## 6. Figure content: `visualize_prediction.py` module (test-first)
+## 6. Figure content: `src/sleap_roots_analyze/visualize_prediction.py` module (test-first)
 
 > **Moved ahead of the step that consumes it** (found during `/review-openspec` round 2: the
 > step's own tests mock/call `create_prediction_figure`, which didn't exist yet when this section
-> was numbered after the step — a real sequencing bug, not just a stylistic reordering).
+> was numbered after the step — a real sequencing bug, not just a stylistic reordering). Tests
+> land in `tests/test_visualize_prediction.py` — distinct from Section 7's
+> `tests/test_step_visualize_prediction.py`, per proposal.md's naming-collision note (the two new
+> source files share the basename `visualize_prediction.py` in different subpackages).
 
 - [ ] 6.1 Write failing test `test_create_prediction_figure_scatter_panel_uses_pc1_target_only`:
       given multiple targets' data, the obs-vs-pred scatter panel's plotted points correspond only
@@ -256,13 +276,15 @@
       `cross_experiment_analysis.py`'s plotting-function convention (pure functions returning a
       `matplotlib.Figure`, no file I/O). Make 6.1-6.4a green.
 
-## 7. `VisualizePredictionStep` (test-first)
+## 7. `src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py` — `VisualizePredictionStep` (test-first)
 
 > Restructured during `/review-openspec` round 2: round 1's "3 test-group commits, 1 implementation
 > commit at the end" pattern doesn't achieve real atomicity — each test-only commit would leave
 > `uv run pytest` red until the final implementation commit lands (verified against Tier 3.5's own
 > real commit history, which never split tests from implementation this way). Restructured into 3
-> genuine red→green pairs, each landing its own working implementation increment.
+> genuine red→green pairs, each landing its own working implementation increment. Tests land in
+> `tests/test_step_visualize_prediction.py` — distinct from Section 6's
+> `tests/test_visualize_prediction.py` (see that section's own note).
 
 **7a. Wiring and predictor-matrix reuse (red→green pair 1)**
 
@@ -274,8 +296,12 @@
 > parent-process mock is invisible (the worker calls the real, unmocked function, or a spy
 > implemented as a non-picklable `Mock` raises `PicklingError`) — either way the test would stop
 > testing what it claims, or break outright, the moment real parallelization is exercised. This
-> applies to 7a.1, 7a.3, 7a.4, and 7b.4 below; 7b.1/7b.2 avoid the issue by inspecting the
-> `joblib.Parallel`/`delayed` construction itself rather than mocking `permutation_test`.
+> applies to 7a.1, 7a.3, 7a.4, 7b.4, **and 7c.5/7c.6** (added during `/review-openspec` round 4 —
+> the original note missed these two, which also need to monkeypatch `logo_cv_predict`/
+> `permutation_test` to inject a non-finite/failing result) below; 7b.1/7b.2 avoid the issue by
+> inspecting the `joblib.Parallel`/`delayed` construction itself rather than mocking
+> `permutation_test`; 7b.5, 7b.7, and 7c's other tests call the real, unmocked functions and are
+> likewise unaffected.
 
 - [ ] 7a.1 Write failing test `test_visualize_prediction_step_reuses_task6_predictor_matrices`
       (`permutation_n_jobs=1`, see note above): spy on any BLUP-loading/genotype-mean-aggregation
@@ -376,17 +402,22 @@
       Section 6) confirm it was called with only the primary `reduction_method`'s results, not
       `comparison_methods`'.
 - [ ] 7c.5 Write failing test
-      `test_visualize_prediction_step_rejects_non_finite_permutation_result_with_named_error`:
-      when `permutation_test` (or its underlying `logo_cv_predict` calls) would produce a
-      non-finite null value for one target/method, the step surfaces `ValueError` naming the
-      target/method/permutation-index (propagated from `permutation_test`'s own guard, task
-      2.13a), before attempting to write any `07_permutation_<method>.json`.
+      `test_visualize_prediction_step_rejects_non_finite_permutation_result_with_named_error`
+      (`permutation_n_jobs=1`, per the mocking-across-process-boundary note at the top of Section
+      7a — found during `/review-openspec` round 4 that this note originally scoped itself to
+      7a.1/7a.3/7a.4/7b.4 only and missed this test, which needs the identical pinning since
+      injecting the non-finite result requires monkeypatching `logo_cv_predict`/`permutation_test`
+      the same way task 2.13a does): when `permutation_test` (or its underlying `logo_cv_predict`
+      calls) would produce a non-finite null value for one target/method, the step surfaces
+      `ValueError` naming the target/method/permutation-index (propagated from `permutation_test`'s
+      own guard, task 2.13a), before attempting to write any `07_permutation_<method>.json`.
 - [ ] 7c.6 Write failing test
-      `test_visualize_prediction_step_writes_no_partial_json_files_when_any_combination_fails`:
-      one `(target, method)` combination fails (per 7c.5) while every other combination for the
-      pair would have individually succeeded — assert **zero** `07_permutation_<method>.json`
-      files exist after the exception propagates, including for methods whose own combinations all
-      succeeded (all-or-nothing per pair, not a partial write).
+      `test_visualize_prediction_step_writes_no_partial_json_files_when_any_combination_fails`
+      (`permutation_n_jobs=1`, same reason as 7c.5): one `(target, method)` combination fails (per
+      7c.5) while every other combination for the pair would have individually succeeded — assert
+      **zero** `07_permutation_<method>.json` files exist after the exception propagates, including
+      for methods whose own combinations all succeeded (all-or-nothing per pair, not a partial
+      write).
 - [ ] 7c.7 Extend `VisualizePredictionStep` to save one `CrossPlatformPermutationResult` JSON per
       method (only after every combination for the pair has succeeded — 7c.6's all-or-nothing
       contract) and call `create_prediction_figure()` (Section 6) with the primary method's
@@ -416,13 +447,16 @@
 > cost minutes and collectively threaten the shared 30-minute CI job budget across 3 OSes. Only
 > 9.1 stated this explicitly in an earlier draft; 9.2/9.3/9.4b now do too.
 >
-> **Estimated (not yet measured) total added CI time (found during `/review-openspec` round 3):**
-> ~8 minutes serial, at ~20ms/`logo_cv_predict` call, `n_permutations=200`, across 9.1 (40 fixtures
-> × 201 calls) + 9.2 + 9.3 + 9.4b (20-seed fixture, ×201 calls each). This is an estimate, not a
-> measurement — task 9.6 MUST record the actual measured wall time for Section 9's test suite (per
-> OS, since Windows runners are typically slower for process/import-heavy work) and, if it
-> meaningfully threatens the shared 30-minute budget once Sections 2-8's other new tests and 7b.5's
-> real multi-process `loky` test are also counted, reduce `n_permutations` further and/or the
+> **Estimated (not yet measured) total added CI time (found during `/review-openspec` round 3,
+> arithmetic corrected round 4 to include 9.1a/9.2a):** ~9 minutes serial, at ~20ms/
+> `logo_cv_predict` call, `n_permutations=200`, across 9.1 (40 fixtures × 201 calls) + 9.1a (same
+> 40 fixtures, ×201 calls, for `p_value_rmse`) + 9.2 + 9.2a (same signal fixture, no extra
+> `permutation_test` calls — reads an already-computed `p_value_rmse`) + 9.3 + 9.4b (20-seed
+> fixture, ×201 calls each). This is an estimate, not a measurement — task 9.6 MUST record the
+> actual measured wall time for Section 9's test suite (per OS, since Windows runners are
+> typically slower for process/import-heavy work) and, if it meaningfully threatens the shared
+> 30-minute budget once Sections 2-8's other new tests and 7b.5's real multi-process `loky` test
+> are also counted, reduce `n_permutations` further and/or the
 > fixture count, rather than assuming the estimate above holds.
 
 - [ ] 9.1 Write failing test `test_permutation_test_p_values_are_uniform_under_null` (K-S
@@ -431,11 +465,16 @@
       default), collect the resulting `p_value_r2`s, K-S-test against `Uniform(0,1)`, assert
       `p > 0.05`.
 - [ ] 9.1a Write failing test `test_permutation_test_p_value_rmse_is_uniform_under_null`: the same
-      K-S calibration procedure as 9.1, but for `p_value_rmse` — a separate, explicit check that
-      the RMSE-specific left-tail p-value formula (per the Permutation Test requirement's
-      per-metric-direction scenario) is itself correctly calibrated, not just correctly directed
-      (found during `/review-openspec` round 3: no oracle anywhere previously checked
-      `p_value_rmse`'s calibration or direction — only `p_value_r2` was covered by 9.1).
+      K-S calibration procedure as 9.1, but for `p_value_rmse` (found during `/review-openspec`
+      round 3: no oracle anywhere previously checked `p_value_rmse`'s calibration at all — only
+      `p_value_r2` was covered by 9.1). **This test verifies Type-I-error calibration only, not
+      direction** (found during `/review-openspec` round 4: under a pure-noise null, the observed
+      value's rank among the `N` null draws is uniform regardless of which tail the p-value formula
+      uses — both the correct left-tail and an incorrectly-reverted right-tail RMSE formula pass
+      this K-S test identically, since pure noise has no asymmetry for either formula to get wrong).
+      **Task 9.2a below, not this task, is what actually guards against the RMSE direction
+      regression** (a genuinely low-RMSE *signal* result reads as significant only under the
+      correct left-tail formula) — do not treat 9.1a passing as evidence the direction is correct.
 - [ ] 9.2 Write failing test `test_permutation_test_signal_r2_exceeds_its_own_null_median`: on the
       N=20-seed planted-signal fixture (task 1.1), with `n_permutations=200` (explicit, CI-fast),
       the mean observed R² across seeds is comfortably above the mean permutation-null median
@@ -471,8 +510,14 @@
 - [ ] 9.6 Implement whatever `permutation_test()`/fixture adjustments are needed to make 9.1, 9.1a,
       9.2, 9.2a, 9.3, and 9.4b-9.5 pass, recording the actual empirically-determined values from
       9.4a in this file and in `design.md`'s Decision 11 note (per this program's "verify, don't
-      assume" convention), and measuring and recording Section 9's actual total wall time per OS
-      (per the CI-timeout note above) here.
+      assume" convention). Also measure and record Section 9's actual total wall time per OS
+      (found during `/review-openspec` round 4: the original wording of this task named an outcome
+      with no concrete mechanism) — concretely: read the `tests` CI job's own `pytest --durations`
+      output (already part of this repo's standard `uv run pytest` invocation, no new tooling
+      needed) for `tests/test_cross_platform_prediction.py::TestPermutationOracles` (or wherever
+      Section 9's tests land) on each of the 3 CI matrix OSes, once this section's tests are green
+      on an open PR; record the 3 per-OS numbers here and compare against the ~8-minute serial
+      estimate above (per the CI-timeout note's own "estimate, not measurement" framing).
 
 ## 10. `theory.md` addendum
 
@@ -540,8 +585,11 @@
         targets, verified against real EDPIE data — see Section 11's findings for the actual
         measured number").
       - The `2q/n` chance-level baseline for top-quartile recovery (e.g. "chance-level recovery is
-        `2q/n`, not 25% — ≈52.6% at n=19, q=5" — found during round 2 that this math previously
-        existed only in the OpenSpec proposal, not any shipped doc a user would actually see).
+        `2q/n`, not 25% — varying ≈44-55% across this program's real n=15-24 scale, e.g. ≈52.6% at
+        n=19, q=5" — found during round 2 that this math previously existed only in the OpenSpec
+        proposal, not any shipped doc a user would actually see; range widened during round 4 from
+        an earlier single-point "≈52.6%" example that risked reading as a fixed constant rather
+        than an n-dependent range).
       Also:
       - **Correct the existing section's stale closing sentence** (found during round 1: it
         currently reads "The permutation null and its figures (Tier 4) remain a separate, later
@@ -552,16 +600,25 @@
       - **Extend the existing `### Current Limitations` subsection's #197 bullet in place** (found
         during round 2: a separate new bullet would read as a near-duplicate) to also note that
         `CrossPlatformSummaryGenerator` doesn't surface permutation/visualization output either.
-- [ ] 12.3 **No `docs/API.md` entry.** Verified directly (found during `/review-openspec` round 1
-      that the original task's premise was backwards): `LOGOCVResult`/`CrossPlatformPredictionResult`/
-      `TargetPrediction` are all in `__all__`, but **none** has an `API.md` entry — the
-      `cross_platform_prediction` module section documents only its two functions
-      (`fit_pca_on_fold`, `logo_cv_predict`); `__all__` membership does not predict `API.md`
-      inclusion for these dataclasses. `PermutationResult`/`CrossPlatformPermutationResult` follow
-      that same (undocumented-dataclass) precedent — no `API.md` change needed. `permutation_test`/
+- [ ] 12.3 **No `docs/API.md` entry** for `PermutationResult`/`CrossPlatformPermutationResult`.
+      Verified directly (found during `/review-openspec` round 1 that the original task's premise
+      was backwards): `LOGOCVResult`/`CrossPlatformPredictionResult`/`TargetPrediction` are all in
+      `__all__`, but **none** has an `API.md` entry — the `cross_platform_prediction` module
+      section documents only its two functions (`fit_pca_on_fold`, `logo_cv_predict`); `__all__`
+      membership does not predict `API.md` inclusion for these dataclasses. `permutation_test`/
       `top_quartile_recovery` DO get entries in the `cross_platform_prediction` module section,
       matching the existing `fit_pca_on_fold`/`logo_cv_predict` entries' heading/signature/prose
-      format exactly.
+      format exactly. **Both `permutation_test`'s own docstring and its `API.md` entry MUST state**
+      (found during `/review-openspec` round 4: these are genuine Python-API footguns, subtle
+      enough that each took multiple internal review rounds to catch, and neither the docstring nor
+      any shipped doc mentioned them — the OpenSpec proposal itself moves to
+      `openspec/changes/archive/...` on archival and won't be visible to a future caller):
+      - `p_value_r2` and `p_value_spearman_rho` are right-tailed (higher is better); `p_value_rmse`
+        is **left-tailed**, the opposite convention (lower is better) — do not read a low
+        `p_value_rmse` as indicating a bad fit.
+      - `random_state` accepts `int`/`SeedSequence` reproducibly (same input always reproduces the
+        same null draws), but a passed-in `numpy.random.Generator` instance is stateful — reusing
+        the *same* `Generator` instance across two calls will **not** reproduce identical results.
 
 ## 13. Validation
 

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -33,11 +33,14 @@
 
 ## 1. Fixtures (test-first)
 
-- [ ] 1.1 Reuse Tier 3's N=20-seed-averaged planted-signal fixture (`n_genotypes=19, n_traits=3,
+- [x] 1.1 Reuse Tier 3's N=20-seed-averaged planted-signal fixture (`n_genotypes=19, n_traits=3,
       signal_strength=0.8`, seeds `1..20`) and its pure-noise counterpart, per Tier 3 Decision 6 —
       do not re-derive from `theory.md`'s single-seed recipe. Confirm these fixtures (or a thin
       wrapper reusing their generator function) are importable from this tier's test module.
-- [ ] 1.2 Add a small set of independent pure-noise fixtures (real, non-degenerate `X`; `y`
+      **Confirmed:** `cross_platform_planted_signal_fixture`/`cross_platform_pure_noise_fixture`
+      (`tests/fixtures.py`) are registered via `conftest.py`'s `from tests.fixtures import *` —
+      importable as ordinary pytest fixtures with no change needed.
+- [x] 1.2 Add a small set of independent pure-noise fixtures (real, non-degenerate `X`; `y`
       independently drawn, no planted relationship) for the K-S permutation-calibration oracle —
       **exactly 40** independent realizations (pinned to one exact number, not "~30-50", per
       `/review-openspec` round 3's request for exact, measurable quantities), each with a **fixed,
@@ -46,31 +49,38 @@
       other fixtures' scale). Pinning both to literals makes task 9.1's K-S test a deterministic
       golden check rather than a live stochastic
       draw with an intrinsic ~5%+ false-failure rate across 3 OSes × every PR.
-- [ ] 1.3 Add a small 2-platform synthetic BLUP fixture pair with `prediction.visualize: true`
+      **Implemented:** `cross_platform_permutation_calibration_fixture` (`tests/fixtures.py`),
+      seed offset +30000 (seeds 1..40), same (19, 3) shape as the primary fixtures.
+- [x] 1.3 Add a small 2-platform synthetic BLUP fixture pair with `prediction.visualize: true`
       wired into a harness YAML (extending Tier 3.5's own harness fixture at
       `tests/fixtures/harness/cross_platform/`, or a sibling file) — used for wiring-correctness
       tests in Sections 6-8, not for statistical oracle assertions (mirrors Tier 3.5 task 1.1/1.2's
       "wiring correctness, not statistical claim" framing).
+      **Implemented:** `cross_platform_prediction_wiring_visualize.yaml`, extending Tier 3.5's
+      `cross_platform_prediction_wiring.yaml` with `visualize: true, n_permutations: 20,
+      permutation_random_state: 42, permutation_n_jobs: 1` (wiring-test default; individual tests
+      override `n_jobs` on the loaded, non-frozen `PredictionConfig` object when real
+      `joblib.Parallel` dispatch is needed).
 
 ## 2. `permutation_test()`/`top_quartile_recovery()` (test-first)
 
-- [ ] 2.1 Write failing test `test_top_quartile_recovery_perfect_prediction_recovers_all`: a
+- [x] 2.1 Write failing test `test_top_quartile_recovery_perfect_prediction_recovers_all`: a
       strictly monotonic `y_pred` (e.g. `y_pred == y_true`) gives `top_quartile_recovery == 1.0`.
-- [ ] 2.2 Write failing test `test_top_quartile_recovery_uses_top_2q_predicted_set`: construct a
+- [x] 2.2 Write failing test `test_top_quartile_recovery_uses_top_2q_predicted_set`: construct a
       case where the true top-`Q` genotypes are NOT in the predicted top-`Q` but ARE in the
       predicted top-`2Q` — assert full recovery (proves the `2Q` window, not `Q`, is used).
-- [ ] 2.3 Write failing test `test_top_quartile_recovery_default_q_is_quarter_of_n`: with
+- [x] 2.3 Write failing test `test_top_quartile_recovery_default_q_is_quarter_of_n`: with
       `len(y_true) == 19` and `q` omitted, assert the effective `q` used equals `round(19 / 4)`
       (inspect via a case constructed so a wrong `q` produces a different recovery fraction).
-- [ ] 2.3a Write failing test `test_top_quartile_recovery_small_n_gives_at_least_one_and_not_over_n`:
+- [x] 2.3a Write failing test `test_top_quartile_recovery_small_n_gives_at_least_one_and_not_over_n`:
       at `len(y_true)=3` (this program's smallest real scale), assert the effective *default* `q`
       used is `>= 1` and `2 * q <= len(y_true)` (guards against a vacuous `q=0` or an out-of-range
       window).
-- [ ] 2.3b Write failing test `test_top_quartile_recovery_rejects_explicit_invalid_q`: a caller-
+- [x] 2.3b Write failing test `test_top_quartile_recovery_rejects_explicit_invalid_q`: a caller-
       supplied `q=0`, a negative `q`, or a `q` with `2 * q > len(y_true)` raises `ValueError` naming
       the invalid `q` and `len(y_true)` — a stricter contract than 2.3a's *default*-`q` case, which
       the function itself computes and guarantees valid.
-- [ ] 2.4 Implement `top_quartile_recovery(y_true, y_pred, q=None)` in
+- [x] 2.4 Implement `top_quartile_recovery(y_true, y_pred, q=None)` in
       `cross_platform_prediction.py`. Make 2.1-2.3b green.
 
 > **Commit boundary**: 2.1-2.4 (`top_quartile_recovery`, no dependency on `permutation_test`) is a
@@ -632,8 +642,8 @@
       NOT yet the case after round 2 here, which found 2 new BLOCKING + several IMPORTANT; a
       further round is warranted before this is a natural stopping point). Reconcile literally
       into `design.md`.
-- [ ] 13.5 Wait for Elizabeth's explicit approval of the fully-reconciled proposal before starting
-      implementation (Sections 1-10).
+- [x] 13.5 Wait for Elizabeth's explicit approval of the fully-reconciled proposal before starting
+      implementation (Sections 1-10). **Approved 2026-07-17.**
 - [ ] 13.6 Section 11's manual real-data validation gate, complete with sign-off.
 - [ ] 13.7 Post-implementation code review: `/pre-merge-check` including a 5-subagent `/review-pr`
       self-review pass before the PR opens, and a second fresh pass once CI runs on the open PR

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -730,4 +730,31 @@
       `PermutationTestResult` missing from package-root exports; a one-directional naming-collision
       docstring cross-reference; a pooling-validity comment. Declined: write-to-temp-then-rename
       for the JSON write loop (low-probability failure mode, outside the documented contract).
-      Full re-run: 193 passed, 0 failed. Second pass pending the open PR's CI run.
+      Full re-run: 193 passed, 0 failed.
+
+      **CI-timeout fix (found after the pre-PR pass, before the second pass could run):**
+      `Tests (ubuntu)`/`Tests (windows)` hit the 30-minute job timeout —
+      `TestPermutationOracles` recomputed `permutation_test()` redundantly per test method.
+      Fixed via 3 module-scoped fixtures sharing one computation across the class's 6 tests, plus
+      `n_permutations` 200→100 for the CI-only oracle fixtures. Verified: ubuntu 16m51s (pass),
+      mac 14m9s (pass), windows 28m36s (pass, but a thin ~5% margin against the 30-minute budget).
+
+      **Second pass done (PR #201, open PR mode):** 0 BLOCKING across all 5 lenses again. Fixed 4
+      converged IMPORTANT findings: (1) restricted `TestPermutationOracles` to Linux-only CI via
+      `pytestmark = pytest.mark.skipif(sys.platform != "linux", ...)` on the class (mirroring
+      `test_numerical_stability.py`'s single-OS pattern, but for a CI-*budget* reason — no
+      OS-dependent code path exists in `permutation_test()` — not a cross-OS numerical-drift one);
+      this removes the Windows-margin risk outright rather than trimming it further. (2) Removed
+      the now-dead `cross_platform_permutation_calibration_fixture` in `tests/fixtures.py`
+      (unreferenced since the module-scoped fixtures above call `_make_pure_noise_realization`
+      directly). (3) Wrapped `create_prediction_figure`'s panel-building in `try/except` (closes
+      the figure before re-raising) and `VisualizePredictionStep.execute()`'s `savefig` in
+      `try/finally` — both close a figure-leak path reachable only when a panel-building/save call
+      raises (e.g. the missing-`"PC1"` `ValueError`), previously unreachable via the wired pipeline
+      but reachable via direct calls; added 3 new tests in `tests/test_visualize_prediction.py`
+      asserting no figure leaks on all 3 `ValueError` paths. (4) Added a test in
+      `tests/test_step_visualize_prediction.py` exercising `VisualizePredictionStep().execute(...,
+      prev_result=None)` and asserting the existing mypy-motivated `ValueError` guard fires with a
+      sensible message. Re-verified locally: 101 passed, 6 skipped (the 6 being
+      `TestPermutationOracles`, confirmed skipped on this non-Linux dev machine) in the 3 directly
+      affected files; full-suite re-run before push.

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -540,7 +540,7 @@
 
 > `joblib` dependency addition lives in Section 5a (must precede Section 7b, which imports it).
 
-- [ ] 10.1 Add a permutation-null pseudo-code section to
+- [x] 10.1 Add a permutation-null pseudo-code section to
       `c:\vaults\sleap-roots\wheat-edpie-paper\cross-platform-prediction\theory.md` (external
       vault), matching its existing LOGO-CV/per-fold-PCA pseudo-code style, including the
       per-target (not per-permutation) `joblib.Parallel` lesson from this tier's benchmark
@@ -551,6 +551,11 @@
       see this change there. No pointer to this addendum exists anywhere in this repo (confirmed
       during `/review-openspec` round 2: it would be discoverable only via archived OpenSpec
       history or vault access) — accepted as a known, non-blocking gap, not fixed in this tier.
+      **Done:** committed separately in the vault's own repo (commit `4535d35`, "docs: add
+      permutation-null pseudo-code addendum") -- new theory.md Section 6 (shuffle-and-refit
+      pseudo-code, the RMSE tail-direction footgun, the per-target parallelization lesson, the
+      2q/n chance-level baseline) plus a Tier 4 subsection added to the renumbered Section 7
+      reviewer checklist. Not part of this repo's diff, as expected.
 
 ## 11. Manual real-data validation gate (non-CI, pre-merge, sign-off required)
 

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -533,8 +533,27 @@
       on an open PR; record the 3 per-OS numbers here and compare against the ~8-minute serial
       estimate above (per the CI-timeout note's own "estimate, not measurement" framing).
       **Local measurement (dev machine, Windows, serial):** 9m28s for
-      `TestPermutationOracles`'s 6 tests. Consistent with the ~9-minute estimate. Per-OS CI numbers
-      still pending -- to be recorded once this section is green on the open PR (13.7).
+      `TestPermutationOracles`'s 6 tests. Consistent with the ~9-minute estimate.
+
+      **CI measurement (PR #201, first push) -- this estimate held locally but NOT on CI runners.**
+      `Tests (ubuntu, Python 3.11)` and `Tests (windows, Python 3.11)` both hit the job's
+      `timeout-minutes: 30` and were canceled; `test_cross_platform_prediction.py` alone (which
+      houses `TestPermutationOracles`) had run for **20m19s** at cancellation (01:02:21-01:22:40),
+      consuming two-thirds of the entire job budget by itself. Root cause: the *tests*, not
+      `permutation_test()` itself, redundantly recomputed the same fixture's `permutation_test()`
+      results once per sibling oracle test that shared it (the calibration fixture recomputed for
+      both 9.1/9.1a; the signal fixture recomputed for 9.2/9.2a/half of 9.4b; the noise fixture for
+      9.3/half of 9.4b) -- roughly 36,000 total `logo_cv_predict` calls -- combined with CI runners
+      measuring ~2x slower than this dev machine for this workload. **Fixed:** introduced
+      module-scoped pytest fixtures (`_calibration_permutation_results`,
+      `_signal_permutation_results`, `_noise_permutation_results`) computing each fixture's
+      `permutation_test()` results exactly once per test module, shared across every oracle test
+      that uses it, and reduced the CI oracle `n_permutations` from 200 to 100 (the empirically-
+      measured values recorded above and in design.md's Decision 11 note were measured at
+      n_permutations=200 and are unaffected -- only the CI regression check's own N changed).
+      Combined effect: ~36,000 -> ~8,000 `logo_cv_predict` calls (~4.4x). Re-measured locally:
+      `TestPermutationOracles` 9m28s -> **2m23s**; the full `test_cross_platform_prediction.py`
+      file 2m26s. Awaiting confirmation this fits the CI budget on the next push.
 
 ## 10. `theory.md` addendum
 

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -229,11 +229,11 @@
 
 ## 5. `PredictCrossPlatformStep` additive extension (test-first)
 
-- [ ] 5.1 Write failing test `test_predict_step_exposes_predictor_matrices_in_step_result_data`:
+- [x] 5.1 Write failing test `test_predict_step_exposes_predictor_matrices_in_step_result_data`:
       after a normal run, `StepResult.data["predictor_matrices"]` holds `source_clean`/
       `target_clean` (DataFrames matching the step's own internal computation) and
       `source_representative_names`/`target_representatives`.
-- [ ] 5.2 Write failing test
+- [x] 5.2 Write failing test
       `test_predict_step_existing_data_metadata_files_unchanged_by_predictor_matrices_addition`: a
       full backward-compat regression test — every existing key in `StepResult.data`/`metadata`
       and every path in `files_generated` is byte-for-byte/value-for-value identical to this step's
@@ -241,7 +241,7 @@
       Explicitly assert `set(result.data.keys()) - {"predictor_matrices"}` equals the exact
       pre-Tier-4 key set (method names only) — not just that pre-existing keys are unchanged, but
       that `"predictor_matrices"` is the *only* addition, catching any accidental extra key leakage.
-- [ ] 5.3 Extend `PredictCrossPlatformStep.execute()` in `predict_cross_platform.py` to populate
+- [x] 5.3 Extend `PredictCrossPlatformStep.execute()` in `predict_cross_platform.py` to populate
       `predictor_matrices`. Make 5.1-5.2 green.
 
 ## 5a. `joblib` dependency (must land before Section 7b)

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -87,7 +87,7 @@
 > natural standalone commit; 2.5 onward (`permutation_test`, which calls `top_quartile_recovery`)
 > is a second.
 
-- [ ] 2.5 Write failing test `test_permutation_test_observed_matches_direct_logo_cv_predict_call`:
+- [x] 2.5 Write failing test `test_permutation_test_observed_matches_direct_logo_cv_predict_call`:
       `permutation_test(X, y, genotypes, method).observed_r2` (etc.) exactly matches an
       independent `logo_cv_predict(X, y, genotypes, method)` call's `r2` (etc.) on the same inputs;
       `observed_top_quartile_recovery` exactly equals
@@ -95,47 +95,47 @@
       separately-shuffled or stale value (this metric has no `LOGOCVResult`/`TargetPrediction`
       analog to cross-check against, unlike the other three, so this test is its only wiring
       oracle).
-- [ ] 2.6 Write failing test `test_permutation_test_null_distributions_have_length_n_permutations`:
+- [x] 2.6 Write failing test `test_permutation_test_null_distributions_have_length_n_permutations`:
       `null_r2`/`null_rmse`/`null_spearman_rho`/`null_top_quartile_recovery` each have length `N`
       for `n_permutations=N`.
-- [ ] 2.7 Write failing test `test_permutation_test_shuffles_y_not_x_or_genotypes`: spy on
+- [x] 2.7 Write failing test `test_permutation_test_shuffles_y_not_x_or_genotypes`: spy on
       `logo_cv_predict` (or inspect its call arguments) to confirm each permutation iteration's `X`
       and `genotypes` arguments are unchanged from the original inputs, only `y` differs.
-- [ ] 2.8 Write failing test `test_permutation_test_deterministic_given_same_random_state`: two
+- [x] 2.8 Write failing test `test_permutation_test_deterministic_given_same_random_state`: two
       calls in the same process, with identical arguments (including `random_state`), produce
       bit-identical null arrays. Also parametrize over `random_state` being a plain `int` and a
       `numpy.random.SeedSequence` instance — both must work, since `VisualizePredictionStep`
       (Section 7) passes `SeedSequence` children, not raw ints.
-- [ ] 2.9 Write failing test `test_permutation_test_different_random_state_differs`: two calls
+- [x] 2.9 Write failing test `test_permutation_test_different_random_state_differs`: two calls
       differing only in `random_state` produce non-identical `null_r2` arrays.
-- [ ] 2.10 Write failing test
+- [x] 2.10 Write failing test
       `test_permutation_test_null_top_quartile_recovery_uses_shuffled_y_as_truth`: construct a
       case where using the *original* `y` as truth (instead of that permutation's shuffled `y`)
       would produce a detectably different recovery value — assert the shuffled-`y`-as-truth
       behavior (Decision 2 in design.md).
-- [ ] 2.11 Write failing test `test_permutation_test_p_value_formula_r2_and_rho`: for a
+- [x] 2.11 Write failing test `test_permutation_test_p_value_formula_r2_and_rho`: for a
       hand-constructed `null` array and `observed` value, assert `p_value_r2` **and**
       `p_value_spearman_rho` each equal `(count(v >= observed) + 1) / (n_permutations + 1)` exactly
       (right-tail — higher is better for both metrics).
-- [ ] 2.11a Write failing test `test_permutation_test_p_value_formula_rmse`: for a
+- [x] 2.11a Write failing test `test_permutation_test_p_value_formula_rmse`: for a
       hand-constructed `null` array and `observed` value, assert `p_value_rmse` equals
       `(count(v <= observed) + 1) / (n_permutations + 1)` exactly — the **opposite**-tail formula
       from 2.11 (lower RMSE is better), a separate task rather than folded into 2.11's "(etc.)" to
       prevent an implementer from generalizing the wrong (right-tail) formula to RMSE by pattern-
       matching alone (found during `/review-openspec` round 4: 2.11's original "(etc.)" wording,
       if taken literally, contradicts the corrected RMSE formula and 9.2a's own assertion).
-- [ ] 2.12 Write failing test `test_permutation_test_rejects_non_positive_n_permutations`:
+- [x] 2.12 Write failing test `test_permutation_test_rejects_non_positive_n_permutations`:
       `n_permutations=0` and `n_permutations=-1` both raise `ValueError`, before any
       `logo_cv_predict` call (spy to confirm zero calls made).
-- [ ] 2.12a Write failing test `test_permutation_test_accepts_n_permutations_equal_1`:
+- [x] 2.12a Write failing test `test_permutation_test_accepts_n_permutations_equal_1`:
       `n_permutations=1` does not raise; `null_r2`/etc. each have length exactly `1`; the resulting
       p-value formula degenerates correctly to `(count + 1) / 2` (either `0.5` or `1.0`) — a
       boundary distinct from the general `n_permutations<=0` rejection in 2.12.
-- [ ] 2.13 Write failing test `test_permutation_test_surfaces_logo_cv_predict_validation_errors`:
+- [x] 2.13 Write failing test `test_permutation_test_surfaces_logo_cv_predict_validation_errors`:
       an invalid `reduction_method` (or mismatched-length `X`/`y`/`genotypes`, or duplicate
       `genotypes`) raises the same `ValueError` `logo_cv_predict` itself would raise, from the
       observed-value call, before any permutation runs.
-- [ ] 2.13a Write failing test `test_permutation_test_rejects_non_finite_null_values_with_named_error`:
+- [x] 2.13a Write failing test `test_permutation_test_rejects_non_finite_null_values_with_named_error`:
       construct a permutation iteration whose LOGO-CV fold structure produces a non-finite
       `spearman_rho` (e.g. inject via a monkeypatched `logo_cv_predict` returning a degenerate
       result for one specific permutation index, independent of whether that permutation's
@@ -145,7 +145,7 @@
       expected to affect many permutations within one target, not a rare one-off, so failing fast
       saves little wall-clock time while complicating which-permutations-ran accounting), not a
       downstream `to_json()` crash with no indication of which permutation caused it.
-- [ ] 2.13b Write failing test `test_permutation_test_rejects_non_finite_observed_values_before_permutations_run`:
+- [x] 2.13b Write failing test `test_permutation_test_rejects_non_finite_observed_values_before_permutations_run`:
       a constant `y` (legal per `logo_cv_predict`'s own "Constant y does not raise" contract,
       reachable by a direct Python-API caller with no upstream pipeline guard — found during
       `/review-openspec` round 4: the non-finite guard from 2.13a only ever covered null values,
@@ -153,7 +153,7 @@
       immediately after the observed-value `logo_cv_predict` call and before any permutation is
       drawn (spy to confirm zero shuffled calls made), not after wastefully completing the full
       permutation loop on data already known to be unusable.
-- [ ] 2.14 Implement `permutation_test(X, y, genotypes, reduction_method="pls_latent",
+- [x] 2.14 Implement `permutation_test(X, y, genotypes, reduction_method="pls_latent",
       representative_names=None, n_permutations=1000, random_state=42)` in
       `cross_platform_prediction.py`, building its RNG via
       `numpy.random.default_rng(random_state)` (not `numpy.random.Generator(random_state)`
@@ -166,20 +166,20 @@
 
 ## 3. `PermutationResult`/`CrossPlatformPermutationResult` (test-first)
 
-- [ ] 3.1 Write failing test `test_permutation_result_round_trips_through_json_as_native_types`:
+- [x] 3.1 Write failing test `test_permutation_result_round_trips_through_json_as_native_types`:
       `json.dumps(dataclasses.asdict(result))` succeeds; parsed-back numeric fields (including
       every element of every null-distribution list) are Python `float`, not `np.float64`.
-- [ ] 3.2 Write failing test `test_permutation_result_null_lists_have_length_n_permutations`.
-- [ ] 3.3 Write failing test
+- [x] 3.2 Write failing test `test_permutation_result_null_lists_have_length_n_permutations`.
+- [x] 3.3 Write failing test
       `test_cross_platform_prediction_result_has_no_permutation_result_field`: inspect
       `dataclasses.fields(CrossPlatformPredictionResult)` and `TargetPrediction`, assert neither
       references `PermutationResult`/`CrossPlatformPermutationResult` (Decision 3 — types stay
       structurally independent).
-- [ ] 3.3a Write failing test `test_permutation_result_has_no_sklearn_or_numpy_object`:
+- [x] 3.3a Write failing test `test_permutation_result_has_no_sklearn_or_numpy_object`:
       `dataclasses.asdict(result)` contains no sklearn `Pipeline`/`PLSRegression`/`Ridge`/`PCA`/
       `StandardScaler` object and no raw `numpy.ndarray` — every null-distribution field is a
       plain Python `list` of `float`.
-- [ ] 3.4 Implement `PermutationResult`/`CrossPlatformPermutationResult` in `result_types.py`,
+- [x] 3.4 Implement `PermutationResult`/`CrossPlatformPermutationResult` in `result_types.py`,
       mirroring `TargetPrediction`/`CrossPlatformPredictionResult`'s `to_dict()`/`to_json()`
       pattern exactly. Make 3.1-3.3a green.
 
@@ -187,17 +187,17 @@
 > `permutation_test` and can land before Section 2 finishes; 3.5-3.8 (the adapter, which calls
 > `permutation_test` in its own test) must land after Section 2 is green.
 
-- [ ] 3.5 Write failing test
+- [x] 3.5 Write failing test
       `test_cross_platform_permutation_result_adapter_maps_fields_from_real_output`: build a
       `CrossPlatformPermutationResult` from real `permutation_test()` outputs for multiple targets,
       assert every field matches exactly.
-- [ ] 3.6 Implement the `from_permutation_test_results`-style adapter (naming to match
+- [x] 3.6 Implement the `from_permutation_test_results`-style adapter (naming to match
       `CrossPlatformPredictionResult.from_logo_cv_results`'s convention). Make 3.5 green.
-- [ ] 3.7 Write failing test
+- [x] 3.7 Write failing test
       `test_permutation_result_types_importable_from_package_root`:
       `from sleap_roots_analyze import CrossPlatformPermutationResult, PermutationResult`
       succeeds; both names in `__all__`, no duplicates.
-- [ ] 3.8 Add both names to `__init__.py`'s import block and `__all__` (grouped by comment header,
+- [x] 3.8 Add both names to `__init__.py`'s import block and `__all__` (grouped by comment header,
       matching the existing `pc_correlations`/cross-platform-prediction grouping convention). Make
       3.7 green.
 

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -396,22 +396,22 @@
 
 **7c. JSON/figure output (red→green pair 3)**
 
-- [ ] 7c.1 Write failing test `test_visualize_prediction_step_saves_one_json_per_method`: `K + 1`
+- [x] 7c.1 Write failing test `test_visualize_prediction_step_saves_one_json_per_method`: `K + 1`
       `07_permutation_<method>.json` files for `reduction_method` + `K` `comparison_methods`.
-- [ ] 7c.2 Write failing test
+- [x] 7c.2 Write failing test
       `test_visualize_prediction_step_saves_one_json_when_comparison_methods_empty`: with `K=0`,
       exactly 1 `07_permutation_<method>.json` file is saved, not `0` (a distinct check from
       7c.1's general formula, guarding the `K=0` edge specifically).
-- [ ] 7c.3 Write failing test
+- [x] 7c.3 Write failing test
       `test_visualize_prediction_step_permutation_observed_matches_task6_prediction_exactly`: for
       each target/method, the permutation JSON's `observed_r2`/`observed_rmse`/
       `observed_spearman_rho` exactly matches task 6's `06_prediction_<method>.json`'s `r2`/
       `rmse`/`spearman_rho` for the same target.
-- [ ] 7c.4 Write failing test `test_visualize_prediction_step_saves_one_figure_using_primary_method_only`:
+- [x] 7c.4 Write failing test `test_visualize_prediction_step_saves_one_figure_using_primary_method_only`:
       exactly one `07_prediction_figure.png`, and (via a spy/mock on `create_prediction_figure`,
       Section 6) confirm it was called with only the primary `reduction_method`'s results, not
       `comparison_methods`'.
-- [ ] 7c.5 Write failing test
+- [x] 7c.5 Write failing test
       `test_visualize_prediction_step_rejects_non_finite_permutation_result_with_named_error`
       (`permutation_n_jobs=1`, per the mocking-across-process-boundary note at the top of Section
       7a — found during `/review-openspec` round 4 that this note originally scoped itself to
@@ -421,14 +421,14 @@
       calls) would produce a non-finite null value for one target/method, the step surfaces
       `ValueError` naming the target/method/permutation-index (propagated from `permutation_test`'s
       own guard, task 2.13a), before attempting to write any `07_permutation_<method>.json`.
-- [ ] 7c.6 Write failing test
+- [x] 7c.6 Write failing test
       `test_visualize_prediction_step_writes_no_partial_json_files_when_any_combination_fails`
       (`permutation_n_jobs=1`, same reason as 7c.5): one `(target, method)` combination fails (per
       7c.5) while every other combination for the pair would have individually succeeded — assert
       **zero** `07_permutation_<method>.json` files exist after the exception propagates, including
       for methods whose own combinations all succeeded (all-or-nothing per pair, not a partial
       write).
-- [ ] 7c.7 Extend `VisualizePredictionStep` to save one `CrossPlatformPermutationResult` JSON per
+- [x] 7c.7 Extend `VisualizePredictionStep` to save one `CrossPlatformPermutationResult` JSON per
       method (only after every combination for the pair has succeeded — 7c.6's all-or-nothing
       contract) and call `create_prediction_figure()` (Section 6) with the primary method's
       results only, saving `07_prediction_figure.png` with `dpi=300, bbox_inches="tight"` matching

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -436,18 +436,18 @@
 
 ## 8. `CrossPlatformPipeline` task wiring (test-first)
 
-- [ ] 8.1 Write failing test `test_cross_platform_pipeline_appends_visualize_prediction_task_when_visualize_enabled`:
+- [x] 8.1 Write failing test `test_cross_platform_pipeline_appends_visualize_prediction_task_when_visualize_enabled`:
       `create_tasks()` includes a 7th task, `depends_on=["06_predict_cross_platform"]`, when
       `config.prediction.visualize=True`.
-- [ ] 8.2 Write failing test `test_cross_platform_pipeline_omits_visualize_prediction_task_when_disabled`:
+- [x] 8.2 Write failing test `test_cross_platform_pipeline_omits_visualize_prediction_task_when_disabled`:
       `create_tasks()` returns exactly 6 tasks when `config.prediction.visualize=False` (the
       default) — including when `config.prediction.enabled=True` (prediction alone, no
       visualization).
-- [ ] 8.3 Add `_run_visualize_prediction` runner method + the conditional `Task(...)` entry to
+- [x] 8.3 Add `_run_visualize_prediction` runner method + the conditional `Task(...)` entry to
       `CrossPlatformPipeline.create_tasks()`. Make 8.1-8.2 green.
-- [ ] 8.4 Write failing test `test_cli_cross_platform_dry_run_lists_visualize_prediction_step_when_enabled`
+- [x] 8.4 Write failing test `test_cli_cross_platform_dry_run_lists_visualize_prediction_step_when_enabled`
       and `test_cli_cross_platform_dry_run_omits_it_when_disabled` (mirroring Tier 3.5 tasks 7.1-7.2).
-- [ ] 8.5 Update `cli.py`'s dry-run steps list (conditional 7th entry) and docstring. Make 8.4 green.
+- [x] 8.5 Update `cli.py`'s dry-run steps list (conditional 7th entry) and docstring. Make 8.4 green.
 
 ## 9. Oracle tests (test-first, per design.md Decision 11)
 

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -39,10 +39,12 @@
       wrapper reusing their generator function) are importable from this tier's test module.
 - [ ] 1.2 Add a small set of independent pure-noise fixtures (real, non-degenerate `X`; `y`
       independently drawn, no planted relationship) for the K-S permutation-calibration oracle —
-      ~30-50 independent realizations, each with a **fixed, committed literal seed** (not
-      regenerated per test run) and a **fixed, committed literal `permutation_test` `random_state`**
-      for the oracle itself, `n_genotypes=19` (matches the other fixtures' scale). Pinning both to
-      literals makes task 9.1's K-S test a deterministic golden check rather than a live stochastic
+      **exactly 40** independent realizations (pinned to one exact number, not "~30-50", per
+      `/review-openspec` round 3's request for exact, measurable quantities), each with a **fixed,
+      committed literal seed** (not regenerated per test run) and a **fixed, committed literal
+      `permutation_test` `random_state`** for the oracle itself, `n_genotypes=19` (matches the
+      other fixtures' scale). Pinning both to literals makes task 9.1's K-S test a deterministic
+      golden check rather than a live stochastic
       draw with an intrinsic ~5%+ false-failure rate across 3 OSes × every PR.
 - [ ] 1.3 Add a small 2-platform synthetic BLUP fixture pair with `prediction.visualize: true`
       wired into a harness YAML (extending Tier 3.5's own harness fixture at
@@ -215,13 +217,17 @@
 - [ ] 5.3 Extend `PredictCrossPlatformStep.execute()` in `predict_cross_platform.py` to populate
       `predictor_matrices`. Make 5.1-5.2 green.
 
-## 5a. `joblib` dependency (must land before Section 6)
+## 5a. `joblib` dependency (must land before Section 7b)
 
 - [ ] 5a.1 Add `joblib` to `pyproject.toml`'s direct dependencies (design.md Decision 5), pinned to
-      the version already resolved transitively via `scikit-learn` in this environment's lockfile
-      — moved ahead of Section 6, which imports `joblib.Parallel` directly at module level; adding
-      the dependency after that import would exist is backwards (found during `/review-openspec`
-      round 1).
+      the version already resolved transitively via `scikit-learn` in this environment's lockfile,
+      and regenerate `uv.lock` accordingly (found during `/review-openspec` round 3: the original
+      task didn't mention the lockfile needs regenerating alongside the `pyproject.toml` edit) —
+      ordered ahead of Section 7b, which imports `joblib.Parallel` directly at module level (this
+      task was originally worded around "Section 6," which meant `VisualizePredictionStep` before
+      round 2's Section 6/7 restructuring moved the step to Section 7 and made Section 6 the
+      figure-content module instead, which does not import `joblib` — corrected during round 3).
+      Adding the dependency after that import would exist is backwards.
 
 ## 6. Figure content: `visualize_prediction.py` module (test-first)
 
@@ -239,10 +245,16 @@
       the two bars' heights equal the mean observed and mean null top-quartile-recovery across all
       targets.
 - [ ] 6.4 Write failing test `test_create_prediction_figure_returns_a_figure_with_three_axes`.
+- [ ] 6.4a Write failing test `test_create_prediction_figure_handles_single_target`: given only one
+      target's data (e.g. the PC1-only degenerate case Section 7 also handles — found during
+      `/review-openspec` round 3: task 7c.7 will call this function for that same fixture, and
+      nothing previously verified the violin/bar-chart panels degrade gracefully to `N=1` target
+      rather than erroring on a single-element distribution), assert the figure is still built
+      successfully with all 3 panels present, not a crash.
 - [ ] 6.5 Implement `create_prediction_figure(...)` (and any supporting per-panel helper functions)
       in new `src/sleap_roots_analyze/visualize_prediction.py`, following
       `cross_experiment_analysis.py`'s plotting-function convention (pure functions returning a
-      `matplotlib.Figure`, no file I/O). Make 6.1-6.4 green.
+      `matplotlib.Figure`, no file I/O). Make 6.1-6.4a green.
 
 ## 7. `VisualizePredictionStep` (test-first)
 
@@ -254,22 +266,39 @@
 
 **7a. Wiring and predictor-matrix reuse (red→green pair 1)**
 
-- [ ] 7a.1 Write failing test `test_visualize_prediction_step_reuses_task6_predictor_matrices`: spy
-      on any BLUP-loading/genotype-mean-aggregation function to confirm zero calls when
-      `predictor_matrices` is supplied via `kwargs["06_predict_cross_platform"]`.
+> **Mocking-across-process-boundary note (found during `/review-openspec` round 3):** every test
+> below that mocks/spies on `permutation_test` or a BLUP-loading/aggregation function MUST fix
+> `config.prediction.permutation_n_jobs=1` in its fixture. `joblib.Parallel(n_jobs=1)` runs
+> sequentially in-process (never touching the `loky` backend), so a `unittest.mock.patch` in the
+> test process stays valid; at `n_jobs>1`, `loky` dispatches to separate worker processes where a
+> parent-process mock is invisible (the worker calls the real, unmocked function, or a spy
+> implemented as a non-picklable `Mock` raises `PicklingError`) — either way the test would stop
+> testing what it claims, or break outright, the moment real parallelization is exercised. This
+> applies to 7a.1, 7a.3, 7a.4, and 7b.4 below; 7b.1/7b.2 avoid the issue by inspecting the
+> `joblib.Parallel`/`delayed` construction itself rather than mocking `permutation_test`.
+
+- [ ] 7a.1 Write failing test `test_visualize_prediction_step_reuses_task6_predictor_matrices`
+      (`permutation_n_jobs=1`, see note above): spy on any BLUP-loading/genotype-mean-aggregation
+      function to confirm zero calls when `predictor_matrices` is supplied via
+      `kwargs["06_predict_cross_platform"]`.
 - [ ] 7a.2 Write failing test `test_visualize_prediction_step_handles_pc1_only_targets`: with zero
       representative-trait targets (only `target_name="PC1"` present, e.g. a fixture where
       `select_cluster_representatives` returned empty — Tier 3.5's own documented degenerate case),
       the step's target/method enumeration produces exactly `N=1` unit per method, not a crash.
+      This test only exercises the pre-`joblib` serial path built in 7a.5 — task 7b.7 below
+      re-verifies this same PC1-only fixture through the real `joblib.Parallel` dispatch added in
+      7b.6, since the "Step still runs with only the PC1 target" scenario explicitly requires the
+      degenerate case to work when *dispatched through `joblib.Parallel`*, not merely when called
+      serially.
 - [ ] 7a.3 Write failing test
-      `test_visualize_prediction_step_calls_permutation_test_once_per_target_per_method`: for `N`
-      targets × `M` methods (`reduction_method` + `comparison_methods`), `permutation_test` is
-      called exactly `N * M` times (serial call, `n_jobs=1`, for this red→green pair — parallel
-      dispatch is Section 7b's concern).
+      `test_visualize_prediction_step_calls_permutation_test_once_per_target_per_method`
+      (`permutation_n_jobs=1`, see note above): for `N` targets × `M` methods (`reduction_method` +
+      `comparison_methods`), `permutation_test` is called exactly `N * M` times.
 - [ ] 7a.4 Write failing test
-      `test_visualize_prediction_step_calls_permutation_test_n_times_when_comparison_methods_empty`:
-      with `comparison_methods=[]` (`K=0`), `permutation_test` is called exactly `N` times (`N`
-      targets × 1 method) — an explicit `K=0` case, not just the general `N * M` formula in 7a.3.
+      `test_visualize_prediction_step_calls_permutation_test_n_times_when_comparison_methods_empty`
+      (`permutation_n_jobs=1`, see note above): with `comparison_methods=[]` (`K=0`),
+      `permutation_test` is called exactly `N` times (`N` targets × 1 method) — an explicit `K=0`
+      case, not just the general `N * M` formula in 7a.3.
 - [ ] 7a.5 Implement a minimal `VisualizePredictionStep(BaseStep)` in new
       `src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py`: reads `predictor_matrices`
       and task 6's results, enumerates `(target_name, method)` combinations in the canonical order
@@ -296,10 +325,11 @@
       distinct seeds, the `i`-th child assigned to the `i`-th combination in that order — no two
       combinations receive the same seed, and re-running with the same `permutation_random_state`
       and the same combinations reproduces the same derived seeds.
-- [ ] 7b.4 Write failing test `test_visualize_prediction_step_permutation_test_receives_derived_seed`:
-      spy on `permutation_test` to confirm each call's `random_state` argument is that
-      combination's derived `SeedSequence` child from 7b.3 (passed through unchanged — no
-      int-extraction step, per `default_rng`'s uniform acceptance of `SeedSequence`), not the raw
+- [ ] 7b.4 Write failing test `test_visualize_prediction_step_permutation_test_receives_derived_seed`
+      (`permutation_n_jobs=1`, see the note at the top of Section 7a): spy on `permutation_test` to
+      confirm each call's `random_state` argument is that combination's derived `SeedSequence`
+      child from 7b.3 (passed through unchanged — no int-extraction step, per `default_rng`'s
+      uniform acceptance of `SeedSequence`), not the raw
       `config.prediction.permutation_random_state`.
 - [ ] 7b.5 Write failing test
       `test_visualize_prediction_step_parallel_vs_serial_results_agree_within_tolerance`: on a
@@ -310,10 +340,23 @@
       every element of every null distribution — **not bit-identical** (loky worker processes may
       resolve a different default BLAS thread count than the main process, a documented source of
       ULP-level floating-point differences per `docs/reproducibility.md`'s established cross-BLAS
-      tolerance convention, independent of this step's own correctness).
+      tolerance convention, independent of this step's own correctness). This test calls the real
+      `permutation_test` (no mocking) at both `n_jobs` settings, so it is unaffected by the
+      mocking-across-process-boundary note above.
 - [ ] 7b.6 Extend `VisualizePredictionStep` to dispatch the 7a.5 enumeration through
       `joblib.Parallel(n_jobs=config.prediction.permutation_n_jobs, backend="loky")`, deriving
       per-combination seeds via `SeedSequence.spawn(N)` (7b.3). Make 7b.1-7b.5 green.
+- [ ] 7b.7 Write failing test `test_visualize_prediction_step_handles_pc1_only_targets_via_joblib`:
+      re-run 7a.2's PC1-only (zero representative-trait) fixture at `permutation_n_jobs=4` (real
+      multi-process dispatch, no mocking), asserting the step still runs successfully through the
+      full `joblib.Parallel` dispatch with `N=1` total unit per method, producing a valid
+      `CrossPlatformPermutationResult` — not a crash. Required per the `cross-platform-analysis`
+      spec's "Step still runs with only the PC1 target when zero representative traits are
+      selected" scenario, which explicitly requires this to work when dispatched through
+      `joblib.Parallel`, not merely when called serially (found during `/review-openspec` round 3:
+      7a.2 alone only tests the pre-`joblib` serial path built in 7a.5, never re-verified after
+      real parallelization is wired in by 7b.6). Make green (should already pass once 7b.6 lands;
+      this is a regression/completeness check, not new production code).
 
 **7c. JSON/figure output (red→green pair 3)**
 
@@ -369,19 +412,41 @@
 
 > **CI-timeout note (found during `/review-openspec` round 2):** every oracle test below MUST
 > state an explicit, small `n_permutations` for CI — at the production default (`1000`) across
-> the N=20-seed fixture (9.2/9.3) or 30-50-fixture set (9.1), several of these would individually
+> the N=20-seed fixture (9.2/9.3) or the 40-fixture set (9.1), several of these would individually
 > cost minutes and collectively threaten the shared 30-minute CI job budget across 3 OSes. Only
 > 9.1 stated this explicitly in an earlier draft; 9.2/9.3/9.4b now do too.
+>
+> **Estimated (not yet measured) total added CI time (found during `/review-openspec` round 3):**
+> ~8 minutes serial, at ~20ms/`logo_cv_predict` call, `n_permutations=200`, across 9.1 (40 fixtures
+> × 201 calls) + 9.2 + 9.3 + 9.4b (20-seed fixture, ×201 calls each). This is an estimate, not a
+> measurement — task 9.6 MUST record the actual measured wall time for Section 9's test suite (per
+> OS, since Windows runners are typically slower for process/import-heavy work) and, if it
+> meaningfully threatens the shared 30-minute budget once Sections 2-8's other new tests and 7b.5's
+> real multi-process `loky` test are also counted, reduce `n_permutations` further and/or the
+> fixture count, rather than assuming the estimate above holds.
 
 - [ ] 9.1 Write failing test `test_permutation_test_p_values_are_uniform_under_null` (K-S
-      calibration oracle): run `permutation_test()` on ~30-50 independent pure-noise fixtures
-      (task 1.2) with `n_permutations=200` (explicit, CI-fast — distinct from the
-      `n_permutations=1000` production default), collect the resulting `p_value_r2`s, K-S-test
-      against `Uniform(0,1)`, assert `p > 0.05`.
+      calibration oracle): run `permutation_test()` on all 40 pure-noise fixtures (task 1.2) with
+      `n_permutations=200` (explicit, CI-fast — distinct from the `n_permutations=1000` production
+      default), collect the resulting `p_value_r2`s, K-S-test against `Uniform(0,1)`, assert
+      `p > 0.05`.
+- [ ] 9.1a Write failing test `test_permutation_test_p_value_rmse_is_uniform_under_null`: the same
+      K-S calibration procedure as 9.1, but for `p_value_rmse` — a separate, explicit check that
+      the RMSE-specific left-tail p-value formula (per the Permutation Test requirement's
+      per-metric-direction scenario) is itself correctly calibrated, not just correctly directed
+      (found during `/review-openspec` round 3: no oracle anywhere previously checked
+      `p_value_rmse`'s calibration or direction — only `p_value_r2` was covered by 9.1).
 - [ ] 9.2 Write failing test `test_permutation_test_signal_r2_exceeds_its_own_null_median`: on the
       N=20-seed planted-signal fixture (task 1.1), with `n_permutations=200` (explicit, CI-fast),
       the mean observed R² across seeds is comfortably above the mean permutation-null median
       across the same seeds.
+- [ ] 9.2a Write failing test `test_permutation_test_signal_p_value_rmse_reads_as_significant`: on
+      the same planted-signal fixture, assert `p_value_rmse` is small (comfortably below `0.5`),
+      proving the RMSE-specific left-tail formula is actually in effect for a genuinely good
+      (low-RMSE) result — direct regression test for the "A good (low-RMSE) result does not read
+      as non-significant" scenario, guarding against the exact directional-inversion bug found
+      during `/review-openspec` round 3 (the naive R²/ρ-style right-tail formula would instead
+      produce `p_value_rmse ≈ 1.0` here, reading as non-significant).
 - [ ] 9.3 Write failing test `test_permutation_test_noise_r2_falls_within_its_own_null_band`: on the
       pure-noise fixture (task 1.1), with `n_permutations=200` (explicit, CI-fast), mean observed
       R² falls within mean-null-median ± 1σ.
@@ -403,13 +468,15 @@
       twice (different input CSV content between runs, e.g. a perturbed fixture), assert the two
       resulting `07_prediction_figure.png` files differ (via content hash), and that a given run's
       figure's mtime is at or after its input CSVs' mtimes.
-- [ ] 9.6 Implement whatever `permutation_test()`/fixture adjustments are needed to make 9.1-9.3
-      and 9.4b-9.5 pass, recording the actual empirically-determined values from 9.4a in this file
-      and in `design.md`'s Decision 11 note (per this program's "verify, don't assume" convention).
+- [ ] 9.6 Implement whatever `permutation_test()`/fixture adjustments are needed to make 9.1, 9.1a,
+      9.2, 9.2a, 9.3, and 9.4b-9.5 pass, recording the actual empirically-determined values from
+      9.4a in this file and in `design.md`'s Decision 11 note (per this program's "verify, don't
+      assume" convention), and measuring and recording Section 9's actual total wall time per OS
+      (per the CI-timeout note above) here.
 
 ## 10. `theory.md` addendum
 
-> `joblib` dependency addition lives in Section 5a (must precede Section 6, which imports it).
+> `joblib` dependency addition lives in Section 5a (must precede Section 7b, which imports it).
 
 - [ ] 10.1 Add a permutation-null pseudo-code section to
       `c:\vaults\sleap-roots\wheat-edpie-paper\cross-platform-prediction\theory.md` (external

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -469,12 +469,12 @@
 > are also counted, reduce `n_permutations` further and/or the
 > fixture count, rather than assuming the estimate above holds.
 
-- [ ] 9.1 Write failing test `test_permutation_test_p_values_are_uniform_under_null` (K-S
+- [x] 9.1 Write failing test `test_permutation_test_p_values_are_uniform_under_null` (K-S
       calibration oracle): run `permutation_test()` on all 40 pure-noise fixtures (task 1.2) with
       `n_permutations=200` (explicit, CI-fast — distinct from the `n_permutations=1000` production
       default), collect the resulting `p_value_r2`s, K-S-test against `Uniform(0,1)`, assert
       `p > 0.05`.
-- [ ] 9.1a Write failing test `test_permutation_test_p_value_rmse_is_uniform_under_null`: the same
+- [x] 9.1a Write failing test `test_permutation_test_p_value_rmse_is_uniform_under_null`: the same
       K-S calibration procedure as 9.1, but for `p_value_rmse` (found during `/review-openspec`
       round 3: no oracle anywhere previously checked `p_value_rmse`'s calibration at all — only
       `p_value_r2` was covered by 9.1). **This test verifies Type-I-error calibration only, not
@@ -485,21 +485,21 @@
       **Task 9.2a below, not this task, is what actually guards against the RMSE direction
       regression** (a genuinely low-RMSE *signal* result reads as significant only under the
       correct left-tail formula) — do not treat 9.1a passing as evidence the direction is correct.
-- [ ] 9.2 Write failing test `test_permutation_test_signal_r2_exceeds_its_own_null_median`: on the
+- [x] 9.2 Write failing test `test_permutation_test_signal_r2_exceeds_its_own_null_median`: on the
       N=20-seed planted-signal fixture (task 1.1), with `n_permutations=200` (explicit, CI-fast),
       the mean observed R² across seeds is comfortably above the mean permutation-null median
       across the same seeds.
-- [ ] 9.2a Write failing test `test_permutation_test_signal_p_value_rmse_reads_as_significant`: on
+- [x] 9.2a Write failing test `test_permutation_test_signal_p_value_rmse_reads_as_significant`: on
       the same planted-signal fixture, assert `p_value_rmse` is small (comfortably below `0.5`),
       proving the RMSE-specific left-tail formula is actually in effect for a genuinely good
       (low-RMSE) result — direct regression test for the "A good (low-RMSE) result does not read
       as non-significant" scenario, guarding against the exact directional-inversion bug found
       during `/review-openspec` round 3 (the naive R²/ρ-style right-tail formula would instead
       produce `p_value_rmse ≈ 1.0` here, reading as non-significant).
-- [ ] 9.3 Write failing test `test_permutation_test_noise_r2_falls_within_its_own_null_band`: on the
+- [x] 9.3 Write failing test `test_permutation_test_noise_r2_falls_within_its_own_null_band`: on the
       pure-noise fixture (task 1.1), with `n_permutations=200` (explicit, CI-fast), mean observed
       R² falls within mean-null-median ± 1σ.
-- [ ] 9.4a **Spike, not a test** — compute (via a real run, recorded here and in design.md's
+- [x] 9.4a **Spike, not a test** — compute (via a real run, recorded here and in design.md's
       Decision 11 note): the pure-noise fixture's actual mean null top-quartile-recovery value at
       `n_permutations=200`. Cross-check against the theoretical chance-level baseline `2q / n`
       (found during `/review-openspec` round 1: at `n=19, q=5`, `2q/n ≈ 52.6%`, not the roadmap's
@@ -508,16 +508,20 @@
       via the hypergeometric mean). This step produces a number to write a real assertion against
       in 9.4b; it is not itself a red/green TDD step (a value that doesn't exist yet cannot be
       asserted against).
-- [ ] 9.4b Write failing test `test_permutation_test_top_quartile_recovery_signal_vs_noise`, using
+      **Measured:** ≈44.3% (pooled mean, 20 seeds × 200 permutations = 4000 draws,
+      `reduction_method="pls_latent"`) — close to but measurably below the `2q/n ≈ 52.6%`
+      theoretical baseline (expected: the theoretical value assumes a uniformly random `y_pred`,
+      the empirical null instead reflects real LOGO-CV-fit predictions). See design.md Decision 11.
+- [x] 9.4b Write failing test `test_permutation_test_top_quartile_recovery_signal_vs_noise`, using
       9.4a's now-known empirical value (`n_permutations=200`, explicit, CI-fast): signal fixture's
       observed recovery ≥ 80%; noise fixture's observed recovery is comfortably separated from the
       signal's, close to the empirically-determined null value (not a blindly-pinned 25% or an
       untested theoretical `2q/n`).
-- [ ] 9.5 Write failing test `test_visualize_prediction_step_figure_provenance`: run the step
+- [x] 9.5 Write failing test `test_visualize_prediction_step_figure_provenance`: run the step
       twice (different input CSV content between runs, e.g. a perturbed fixture), assert the two
       resulting `07_prediction_figure.png` files differ (via content hash), and that a given run's
       figure's mtime is at or after its input CSVs' mtimes.
-- [ ] 9.6 Implement whatever `permutation_test()`/fixture adjustments are needed to make 9.1, 9.1a,
+- [x] 9.6 Implement whatever `permutation_test()`/fixture adjustments are needed to make 9.1, 9.1a,
       9.2, 9.2a, 9.3, and 9.4b-9.5 pass, recording the actual empirically-determined values from
       9.4a in this file and in `design.md`'s Decision 11 note (per this program's "verify, don't
       assume" convention). Also measure and record Section 9's actual total wall time per OS
@@ -528,6 +532,9 @@
       Section 9's tests land) on each of the 3 CI matrix OSes, once this section's tests are green
       on an open PR; record the 3 per-OS numbers here and compare against the ~8-minute serial
       estimate above (per the CI-timeout note's own "estimate, not measurement" framing).
+      **Local measurement (dev machine, Windows, serial):** 9m28s for
+      `TestPermutationOracles`'s 6 tests. Consistent with the ~9-minute estimate. Per-OS CI numbers
+      still pending -- to be recorded once this section is green on the open PR (13.7).
 
 ## 10. `theory.md` addendum
 

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -3,6 +3,33 @@
 > `CrossPlatformPermutationResult` type, additive `PredictCrossPlatformStep` extension, config
 > field placement, figure scope) is in `design.md`'s Decisions section and the brainstormed design
 > at `docs/superpowers/specs/2026-07-16-prediction-permutation-and-figure-design.md`.
+>
+> **`/review-openspec` round 1 reconciled into this file** (full findings in design.md's
+> "Adversarial Review Reconciliation (round 1)" section): a dropped-scenario bug in the MODIFIED
+> "Predict Cross-Platform..." requirement, a missing non-finite-null guard, the `2q/n` top-
+> quartile-recovery math (not the roadmap's unverified "≈25%"), a backwards `docs/API.md` task
+> premise, a missed stale-sentence doc fix, per-target/method seed independence via
+> `SeedSequence.spawn`, `assert_allclose` (not bit-identical) for parallel-vs-serial, the `joblib`
+> dependency task moved before the section that imports it, and several smaller test/doc gaps.
+>
+> **`/review-openspec` round 2 (fresh, no memory of round 1) reconciled into this file** (full
+> findings in design.md's "Adversarial Review Reconciliation (round 2)" section): two new BLOCKING
+> issues — the `numpy.random.Generator(random_state)` API call in round 1's own fix was invalid
+> (that constructor rejects a bare `int`; fixed to `numpy.random.default_rng(random_state)`, which
+> accepts `int`/`SeedSequence`/`Generator` uniformly, resolving the `SeedSequence.spawn()` →
+> `permutation_test(random_state=...)` handoff round 1 left unspecified), and Section 6 (now 7)
+> depended on `create_prediction_figure()` (Section 8, now 6) without that section being sequenced
+> first — fixed by moving the figure-content module ahead of the step and restructuring the step's
+> implementation into 3 genuine red→green increments instead of "8 tests, then 1 commit at the
+> end." Also fixed: an intrinsic CI-timeout risk in the oracle tests (missing explicit reduced
+> `n_permutations`), a factually-wrong claim about Tier 3.5's manual-validation timing (corrected
+> against real commit timestamps), missing config validation for the 2 previously-untested
+> `PredictionConfig` fields, unspecified seed-enumeration order, unspecified partial-failure/atomic-
+> write semantics, an unstated fail-fast-vs-complete rationale, a documentation anti-pattern
+> (cross-referencing `design.md`, which moves to `openspec/changes/archive/...` on archival) fixed
+> by stating key numbers directly in shipped docs instead, and several missing edge-case
+> scenarios/tests (explicit invalid `q`, PC1-only targets, `comparison_methods=[]`, an
+> `observed_top_quartile_recovery` wiring check).
 
 ## 1. Fixtures (test-first)
 
@@ -34,10 +61,15 @@
       `len(y_true) == 19` and `q` omitted, assert the effective `q` used equals `round(19 / 4)`
       (inspect via a case constructed so a wrong `q` produces a different recovery fraction).
 - [ ] 2.3a Write failing test `test_top_quartile_recovery_small_n_gives_at_least_one_and_not_over_n`:
-      at `len(y_true)=3` (this program's smallest real scale), assert the effective `q` used is
-      `>= 1` and `2 * q <= len(y_true)` (guards against a vacuous `q=0` or an out-of-range window).
+      at `len(y_true)=3` (this program's smallest real scale), assert the effective *default* `q`
+      used is `>= 1` and `2 * q <= len(y_true)` (guards against a vacuous `q=0` or an out-of-range
+      window).
+- [ ] 2.3b Write failing test `test_top_quartile_recovery_rejects_explicit_invalid_q`: a caller-
+      supplied `q=0`, a negative `q`, or a `q` with `2 * q > len(y_true)` raises `ValueError` naming
+      the invalid `q` and `len(y_true)` — a stricter contract than 2.3a's *default*-`q` case, which
+      the function itself computes and guarantees valid.
 - [ ] 2.4 Implement `top_quartile_recovery(y_true, y_pred, q=None)` in
-      `cross_platform_prediction.py`. Make 2.1-2.3a green.
+      `cross_platform_prediction.py`. Make 2.1-2.3b green.
 
 > **Commit boundary**: 2.1-2.4 (`top_quartile_recovery`, no dependency on `permutation_test`) is a
 > natural standalone commit; 2.5 onward (`permutation_test`, which calls `top_quartile_recovery`)
@@ -45,7 +77,12 @@
 
 - [ ] 2.5 Write failing test `test_permutation_test_observed_matches_direct_logo_cv_predict_call`:
       `permutation_test(X, y, genotypes, method).observed_r2` (etc.) exactly matches an
-      independent `logo_cv_predict(X, y, genotypes, method)` call's `r2` (etc.) on the same inputs.
+      independent `logo_cv_predict(X, y, genotypes, method)` call's `r2` (etc.) on the same inputs;
+      `observed_top_quartile_recovery` exactly equals
+      `top_quartile_recovery(y, that_call.y_pred)` — the same observed call's predictions, not a
+      separately-shuffled or stale value (this metric has no `LOGOCVResult`/`TargetPrediction`
+      analog to cross-check against, unlike the other three, so this test is its only wiring
+      oracle).
 - [ ] 2.6 Write failing test `test_permutation_test_null_distributions_have_length_n_permutations`:
       `null_r2`/`null_rmse`/`null_spearman_rho`/`null_top_quartile_recovery` each have length `N`
       for `n_permutations=N`.
@@ -53,7 +90,10 @@
       `logo_cv_predict` (or inspect its call arguments) to confirm each permutation iteration's `X`
       and `genotypes` arguments are unchanged from the original inputs, only `y` differs.
 - [ ] 2.8 Write failing test `test_permutation_test_deterministic_given_same_random_state`: two
-      calls with identical arguments (including `random_state`) produce bit-identical null arrays.
+      calls in the same process, with identical arguments (including `random_state`), produce
+      bit-identical null arrays. Also parametrize over `random_state` being a plain `int` and a
+      `numpy.random.SeedSequence` instance — both must work, since `VisualizePredictionStep`
+      (Section 7) passes `SeedSequence` children, not raw ints.
 - [ ] 2.9 Write failing test `test_permutation_test_different_random_state_differs`: two calls
       differing only in `random_state` produce non-identical `null_r2` arrays.
 - [ ] 2.10 Write failing test
@@ -80,13 +120,20 @@
       `spearman_rho` (e.g. inject via a monkeypatched `logo_cv_predict` returning a degenerate
       result for one specific permutation index, independent of whether that permutation's
       shuffled `y` was itself constant) — assert `ValueError` naming both the offending metric and
-      the permutation index, not a downstream `to_json()` crash with no indication of which
-      permutation caused it (per the cross-platform-prediction spec's "Non-finite null values are
-      rejected" scenario).
+      the permutation index, raised only after all `n_permutations` calls complete (fail-fast on
+      the first occurrence was considered and rejected: a genuinely non-finite-producing bug is
+      expected to affect many permutations within one target, not a rare one-off, so failing fast
+      saves little wall-clock time while complicating which-permutations-ran accounting), not a
+      downstream `to_json()` crash with no indication of which permutation caused it.
 - [ ] 2.14 Implement `permutation_test(X, y, genotypes, reduction_method="pls_latent",
       representative_names=None, n_permutations=1000, random_state=42)` in
-      `cross_platform_prediction.py`, returning a `PermutationResult` (Section 3), including the
-      non-finite-null scan from 2.13a. Make 2.5-2.13a green.
+      `cross_platform_prediction.py`, building its RNG via
+      `numpy.random.default_rng(random_state)` (not `numpy.random.Generator(random_state)`
+      directly, which requires a `BitGenerator` instance and rejects a bare `int` — `default_rng`
+      accepts `int`/`SeedSequence`/`Generator` uniformly, which is what makes 2.8's parametrized
+      `SeedSequence` case and Section 7's per-target `SeedSequence` children both work with no
+      int-extraction step). Returns a `PermutationResult` (Section 3), including the non-finite-
+      null scan from 2.13a. Make 2.5-2.13a green.
 
 ## 3. `PermutationResult`/`CrossPlatformPermutationResult` (test-first)
 
@@ -134,13 +181,22 @@
 - [ ] 4.2 Write failing test `test_cross_platform_config_rejects_visualize_true_with_enabled_false`:
       `CrossPlatformConfig(..., prediction=PredictionConfig(enabled=False, visualize=True))`
       raises `ValueError` at construction time.
-- [ ] 4.3 Write failing test `test_prediction_config_n_permutations_validation_skipped_when_visualize_false`:
-      `enabled=True, visualize=False, n_permutations=0` does not raise.
+- [ ] 4.3 Write failing test `test_prediction_config_permutation_fields_validation_skipped_when_visualize_false`:
+      `enabled=True, visualize=False` with `n_permutations=0`, `permutation_n_jobs=0`, and
+      `permutation_random_state=-1` (all simultaneously invalid) does not raise — none of the 3
+      permutation-related fields are validated unless `visualize=True`.
 - [ ] 4.4 Write failing test `test_prediction_config_rejects_non_positive_n_permutations_when_visualize_true`:
       `enabled=True, visualize=True, n_permutations=0` (and `-1`) raises `ValueError`.
+- [ ] 4.4a Write failing test `test_prediction_config_rejects_non_positive_permutation_n_jobs_when_visualize_true`:
+      `enabled=True, visualize=True, permutation_n_jobs=0` (and `-1`) raises `ValueError` naming
+      the field, not `joblib.Parallel`'s own raw error surfacing later inside
+      `VisualizePredictionStep`.
+- [ ] 4.4b Write failing test `test_prediction_config_rejects_invalid_permutation_random_state_when_visualize_true`:
+      `enabled=True, visualize=True, permutation_random_state=-1` (and a non-`int` value) raises
+      `ValueError` naming the field, not `numpy.random.SeedSequence`'s own raw error.
 - [ ] 4.5 Extend `PredictionConfig`/`CrossPlatformConfig.__post_init__` in
-      `pipeline/config/components.py` with the 4 new fields and the 4.2/4.4 validations. Make
-      4.1-4.4 green.
+      `pipeline/config/components.py` with the 4 new fields and the 4.2/4.4/4.4a/4.4b validations.
+      Make 4.1-4.4b green.
 
 ## 5. `PredictCrossPlatformStep` additive extension (test-first)
 
@@ -167,135 +223,182 @@
       the dependency after that import would exist is backwards (found during `/review-openspec`
       round 1).
 
-## 6. `VisualizePredictionStep` (test-first)
+## 6. Figure content: `visualize_prediction.py` module (test-first)
 
-> Split into three commits (found during `/review-openspec` round 1: one implementation task for
-> 8 tests was too coarse-grained relative to this program's established per-commit granularity):
-> 6.1-6.2 (wiring/reuse), 6.3-6.5a (joblib parallelization — the riskiest, most novel piece, worth
-> isolated review), 6.6-6.8a (JSON/figure I/O).
+> **Moved ahead of the step that consumes it** (found during `/review-openspec` round 2: the
+> step's own tests mock/call `create_prediction_figure`, which didn't exist yet when this section
+> was numbered after the step — a real sequencing bug, not just a stylistic reordering).
 
-- [ ] 6.1 Write failing test `test_visualize_prediction_step_reuses_task6_predictor_matrices`: spy
+- [ ] 6.1 Write failing test `test_create_prediction_figure_scatter_panel_uses_pc1_target_only`:
+      given multiple targets' data, the obs-vs-pred scatter panel's plotted points correspond only
+      to the `PC1` target's `y_true`/`y_pred`.
+- [ ] 6.2 Write failing test `test_create_prediction_figure_violin_panel_pools_all_targets_nulls`:
+      the violin/strip panel's null data is the concatenation of every target's `null_r2`, and its
+      observed-points data is every target's `observed_r2` (one point per target).
+- [ ] 6.3 Write failing test `test_create_prediction_figure_bar_chart_shows_observed_vs_null_mean`:
+      the two bars' heights equal the mean observed and mean null top-quartile-recovery across all
+      targets.
+- [ ] 6.4 Write failing test `test_create_prediction_figure_returns_a_figure_with_three_axes`.
+- [ ] 6.5 Implement `create_prediction_figure(...)` (and any supporting per-panel helper functions)
+      in new `src/sleap_roots_analyze/visualize_prediction.py`, following
+      `cross_experiment_analysis.py`'s plotting-function convention (pure functions returning a
+      `matplotlib.Figure`, no file I/O). Make 6.1-6.4 green.
+
+## 7. `VisualizePredictionStep` (test-first)
+
+> Restructured during `/review-openspec` round 2: round 1's "3 test-group commits, 1 implementation
+> commit at the end" pattern doesn't achieve real atomicity — each test-only commit would leave
+> `uv run pytest` red until the final implementation commit lands (verified against Tier 3.5's own
+> real commit history, which never split tests from implementation this way). Restructured into 3
+> genuine red→green pairs, each landing its own working implementation increment.
+
+**7a. Wiring and predictor-matrix reuse (red→green pair 1)**
+
+- [ ] 7a.1 Write failing test `test_visualize_prediction_step_reuses_task6_predictor_matrices`: spy
       on any BLUP-loading/genotype-mean-aggregation function to confirm zero calls when
       `predictor_matrices` is supplied via `kwargs["06_predict_cross_platform"]`.
-- [ ] 6.1a Write failing test `test_visualize_prediction_step_handles_pc1_only_targets`: with zero
+- [ ] 7a.2 Write failing test `test_visualize_prediction_step_handles_pc1_only_targets`: with zero
       representative-trait targets (only `target_name="PC1"` present, e.g. a fixture where
       `select_cluster_representatives` returned empty — Tier 3.5's own documented degenerate case),
-      the step runs successfully through the full `joblib.Parallel` dispatch with `N=1` total
-      `(target, method)` unit, producing a valid `CrossPlatformPermutationResult`, not a crash.
-- [ ] 6.2 Write failing test
+      the step's target/method enumeration produces exactly `N=1` unit per method, not a crash.
+- [ ] 7a.3 Write failing test
       `test_visualize_prediction_step_calls_permutation_test_once_per_target_per_method`: for `N`
       targets × `M` methods (`reduction_method` + `comparison_methods`), `permutation_test` is
-      called exactly `N * M` times.
-- [ ] 6.2a Write failing test
+      called exactly `N * M` times (serial call, `n_jobs=1`, for this red→green pair — parallel
+      dispatch is Section 7b's concern).
+- [ ] 7a.4 Write failing test
       `test_visualize_prediction_step_calls_permutation_test_n_times_when_comparison_methods_empty`:
       with `comparison_methods=[]` (`K=0`), `permutation_test` is called exactly `N` times (`N`
-      targets × 1 method) — an explicit `K=0` case, not just the general `N * M` formula in 6.2.
-- [ ] 6.3 Write failing test
+      targets × 1 method) — an explicit `K=0` case, not just the general `N * M` formula in 7a.3.
+- [ ] 7a.5 Implement a minimal `VisualizePredictionStep(BaseStep)` in new
+      `src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py`: reads `predictor_matrices`
+      and task 6's results, enumerates `(target_name, method)` combinations in the canonical order
+      (methods first, `[reduction_method] + comparison_methods`; then `target_names` in task 6's
+      `CrossPlatformPredictionResult.predictions` order — representative traits, then `"PC1"`
+      last), and calls `permutation_test()` serially (no `joblib` yet) for each. Make 7a.1-7a.4
+      green.
+
+**7b. `joblib` parallelization across targets (red→green pair 2 — the riskiest, most novel piece)**
+
+- [ ] 7b.1 Write failing test
       `test_visualize_prediction_step_parallelizes_across_target_method_units_not_within_one`:
       inspect the `joblib.Parallel`/`delayed` call structure (or the list of dispatched callables)
       to confirm one `delayed(...)` unit per `(target, method)` combination, not per permutation
       iteration.
-- [ ] 6.4 Write failing test
+- [ ] 7b.2 Write failing test
       `test_visualize_prediction_step_joblib_n_jobs_and_backend_match_config`:
       `joblib.Parallel` is constructed with `n_jobs=config.prediction.permutation_n_jobs,
       backend="loky"` (per the cross-platform-analysis spec's explicit backend choice).
-- [ ] 6.4a Write failing test
+- [ ] 7b.3 Write failing test
       `test_visualize_prediction_step_derives_independent_seed_per_target_method`: for `N`
-      `(target, method)` combinations, assert `numpy.random.SeedSequence(
-      config.prediction.permutation_random_state).spawn(N)` is used to derive `N` distinct seeds,
-      one passed to each `permutation_test()` call — no two combinations receive the same seed,
-      and re-running with the same `permutation_random_state` reproduces the same derived seeds
-      (per design.md Decision 4's finding that reusing one seed across all targets would
-      correlate, not independently sample, the pooled-null figure panel's null draws).
-- [ ] 6.5 Write failing test
+      `(target, method)` combinations enumerated in the canonical order (7a.5), assert
+      `numpy.random.SeedSequence(config.prediction.permutation_random_state).spawn(N)` derives `N`
+      distinct seeds, the `i`-th child assigned to the `i`-th combination in that order — no two
+      combinations receive the same seed, and re-running with the same `permutation_random_state`
+      and the same combinations reproduces the same derived seeds.
+- [ ] 7b.4 Write failing test `test_visualize_prediction_step_permutation_test_receives_derived_seed`:
+      spy on `permutation_test` to confirm each call's `random_state` argument is that
+      combination's derived `SeedSequence` child from 7b.3 (passed through unchanged — no
+      int-extraction step, per `default_rng`'s uniform acceptance of `SeedSequence`), not the raw
+      `config.prediction.permutation_random_state`.
+- [ ] 7b.5 Write failing test
       `test_visualize_prediction_step_parallel_vs_serial_results_agree_within_tolerance`: on a
-      small fixture, `permutation_n_jobs=1` and `permutation_n_jobs=4` produce
-      `CrossPlatformPermutationResult`s that agree via `numpy.testing.assert_allclose(...,
-      rtol=1e-6, atol=1e-9)` — **not bit-identical** (loky worker processes may resolve a
-      different default BLAS thread count than the main process, a documented source of
-      ULP-level floating-point differences per `docs/reproducibility.md`'s established
-      cross-BLAS tolerance convention, independent of this step's own correctness).
-- [ ] 6.5a Write failing test `test_visualize_prediction_step_permutation_test_receives_derived_seed`:
-      spy on `permutation_test` to confirm each call's `random_state` argument matches that
-      combination's derived seed from 6.4a, not the raw `config.prediction.permutation_random_state`
-      passed through unchanged.
-- [ ] 6.6 Write failing test `test_visualize_prediction_step_saves_one_json_per_method`: `K + 1`
+      small fixture with an explicitly small, stated `n_permutations` (e.g. 50, to bound the
+      elementwise-comparison surface and keep this test CI-fast), `permutation_n_jobs=1` and
+      `permutation_n_jobs=4` produce `CrossPlatformPermutationResult`s that agree via
+      `numpy.testing.assert_allclose(..., rtol=1e-6, atol=1e-9)` for every numeric field, including
+      every element of every null distribution — **not bit-identical** (loky worker processes may
+      resolve a different default BLAS thread count than the main process, a documented source of
+      ULP-level floating-point differences per `docs/reproducibility.md`'s established cross-BLAS
+      tolerance convention, independent of this step's own correctness).
+- [ ] 7b.6 Extend `VisualizePredictionStep` to dispatch the 7a.5 enumeration through
+      `joblib.Parallel(n_jobs=config.prediction.permutation_n_jobs, backend="loky")`, deriving
+      per-combination seeds via `SeedSequence.spawn(N)` (7b.3). Make 7b.1-7b.5 green.
+
+**7c. JSON/figure output (red→green pair 3)**
+
+- [ ] 7c.1 Write failing test `test_visualize_prediction_step_saves_one_json_per_method`: `K + 1`
       `07_permutation_<method>.json` files for `reduction_method` + `K` `comparison_methods`.
-- [ ] 6.7 Write failing test
+- [ ] 7c.2 Write failing test
+      `test_visualize_prediction_step_saves_one_json_when_comparison_methods_empty`: with `K=0`,
+      exactly 1 `07_permutation_<method>.json` file is saved, not `0` (a distinct check from
+      7c.1's general formula, guarding the `K=0` edge specifically).
+- [ ] 7c.3 Write failing test
       `test_visualize_prediction_step_permutation_observed_matches_task6_prediction_exactly`: for
       each target/method, the permutation JSON's `observed_r2`/`observed_rmse`/
       `observed_spearman_rho` exactly matches task 6's `06_prediction_<method>.json`'s `r2`/
       `rmse`/`spearman_rho` for the same target.
-- [ ] 6.8 Write failing test `test_visualize_prediction_step_saves_one_figure_using_primary_method_only`:
-      exactly one `07_prediction_figure.png`, and (via a spy/mock on the figure-building function)
-      confirm it was called with only the primary `reduction_method`'s results, not
+- [ ] 7c.4 Write failing test `test_visualize_prediction_step_saves_one_figure_using_primary_method_only`:
+      exactly one `07_prediction_figure.png`, and (via a spy/mock on `create_prediction_figure`,
+      Section 6) confirm it was called with only the primary `reduction_method`'s results, not
       `comparison_methods`'.
-- [ ] 6.8a Write failing test
+- [ ] 7c.5 Write failing test
       `test_visualize_prediction_step_rejects_non_finite_permutation_result_with_named_error`:
       when `permutation_test` (or its underlying `logo_cv_predict` calls) would produce a
       non-finite null value for one target/method, the step surfaces `ValueError` naming the
       target/method/permutation-index (propagated from `permutation_test`'s own guard, task
       2.13a), before attempting to write any `07_permutation_<method>.json`.
-- [ ] 6.9 Implement `VisualizePredictionStep(BaseStep)` in new
-      `src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py`. Make 6.1-6.8a green.
+- [ ] 7c.6 Write failing test
+      `test_visualize_prediction_step_writes_no_partial_json_files_when_any_combination_fails`:
+      one `(target, method)` combination fails (per 7c.5) while every other combination for the
+      pair would have individually succeeded — assert **zero** `07_permutation_<method>.json`
+      files exist after the exception propagates, including for methods whose own combinations all
+      succeeded (all-or-nothing per pair, not a partial write).
+- [ ] 7c.7 Extend `VisualizePredictionStep` to save one `CrossPlatformPermutationResult` JSON per
+      method (only after every combination for the pair has succeeded — 7c.6's all-or-nothing
+      contract) and call `create_prediction_figure()` (Section 6) with the primary method's
+      results only, saving `07_prediction_figure.png` with `dpi=300, bbox_inches="tight"` matching
+      `visualize_cross_platform.py`'s convention. Make 7c.1-7c.6 green.
 
-## 7. `CrossPlatformPipeline` task wiring (test-first)
+## 8. `CrossPlatformPipeline` task wiring (test-first)
 
-- [ ] 7.1 Write failing test `test_cross_platform_pipeline_appends_visualize_prediction_task_when_visualize_enabled`:
+- [ ] 8.1 Write failing test `test_cross_platform_pipeline_appends_visualize_prediction_task_when_visualize_enabled`:
       `create_tasks()` includes a 7th task, `depends_on=["06_predict_cross_platform"]`, when
       `config.prediction.visualize=True`.
-- [ ] 7.2 Write failing test `test_cross_platform_pipeline_omits_visualize_prediction_task_when_disabled`:
+- [ ] 8.2 Write failing test `test_cross_platform_pipeline_omits_visualize_prediction_task_when_disabled`:
       `create_tasks()` returns exactly 6 tasks when `config.prediction.visualize=False` (the
       default) — including when `config.prediction.enabled=True` (prediction alone, no
       visualization).
-- [ ] 7.3 Add `_run_visualize_prediction` runner method + the conditional `Task(...)` entry to
-      `CrossPlatformPipeline.create_tasks()`. Make 7.1-7.2 green.
-- [ ] 7.4 Write failing test `test_cli_cross_platform_dry_run_lists_visualize_prediction_step_when_enabled`
+- [ ] 8.3 Add `_run_visualize_prediction` runner method + the conditional `Task(...)` entry to
+      `CrossPlatformPipeline.create_tasks()`. Make 8.1-8.2 green.
+- [ ] 8.4 Write failing test `test_cli_cross_platform_dry_run_lists_visualize_prediction_step_when_enabled`
       and `test_cli_cross_platform_dry_run_omits_it_when_disabled` (mirroring Tier 3.5 tasks 7.1-7.2).
-- [ ] 7.5 Update `cli.py`'s dry-run steps list (conditional 7th entry) and docstring. Make 7.4 green.
-
-## 8. Figure content: `visualize_prediction.py` module (test-first)
-
-- [ ] 8.1 Write failing test `test_create_prediction_figure_scatter_panel_uses_pc1_target_only`:
-      given multiple targets' data, the obs-vs-pred scatter panel's plotted points correspond only
-      to the `PC1` target's `y_true`/`y_pred`.
-- [ ] 8.2 Write failing test `test_create_prediction_figure_violin_panel_pools_all_targets_nulls`:
-      the violin/strip panel's null data is the concatenation of every target's `null_r2`, and its
-      observed-points data is every target's `observed_r2` (one point per target).
-- [ ] 8.3 Write failing test `test_create_prediction_figure_bar_chart_shows_observed_vs_null_mean`:
-      the two bars' heights equal the mean observed and mean null top-quartile-recovery across all
-      targets.
-- [ ] 8.4 Write failing test `test_create_prediction_figure_returns_a_figure_with_three_axes`.
-- [ ] 8.5 Implement `create_prediction_figure(...)` (and any supporting per-panel helper functions)
-      in new `src/sleap_roots_analyze/visualize_prediction.py`, following
-      `cross_experiment_analysis.py`'s plotting-function convention (pure functions returning a
-      `matplotlib.Figure`, no file I/O). Make 8.1-8.4 green.
-- [ ] 8.6 Wire `create_prediction_figure()` into `VisualizePredictionStep` (Section 6), saving with
-      `dpi=300, bbox_inches="tight"` matching `visualize_cross_platform.py`'s convention.
+- [ ] 8.5 Update `cli.py`'s dry-run steps list (conditional 7th entry) and docstring. Make 8.4 green.
 
 ## 9. Oracle tests (test-first, per design.md Decision 11)
 
+> **CI-timeout note (found during `/review-openspec` round 2):** every oracle test below MUST
+> state an explicit, small `n_permutations` for CI — at the production default (`1000`) across
+> the N=20-seed fixture (9.2/9.3) or 30-50-fixture set (9.1), several of these would individually
+> cost minutes and collectively threaten the shared 30-minute CI job budget across 3 OSes. Only
+> 9.1 stated this explicitly in an earlier draft; 9.2/9.3/9.4b now do too.
+
 - [ ] 9.1 Write failing test `test_permutation_test_p_values_are_uniform_under_null` (K-S
       calibration oracle): run `permutation_test()` on ~30-50 independent pure-noise fixtures
-      (task 1.2) with a reduced `n_permutations` (e.g. 200, CI-fast), collect the resulting
-      `p_value_r2`s, K-S-test against `Uniform(0,1)`, assert `p > 0.05`.
+      (task 1.2) with `n_permutations=200` (explicit, CI-fast — distinct from the
+      `n_permutations=1000` production default), collect the resulting `p_value_r2`s, K-S-test
+      against `Uniform(0,1)`, assert `p > 0.05`.
 - [ ] 9.2 Write failing test `test_permutation_test_signal_r2_exceeds_its_own_null_median`: on the
-      N=20-seed planted-signal fixture (task 1.1), the mean observed R² across seeds is
-      comfortably above the mean permutation-null median across the same seeds.
+      N=20-seed planted-signal fixture (task 1.1), with `n_permutations=200` (explicit, CI-fast),
+      the mean observed R² across seeds is comfortably above the mean permutation-null median
+      across the same seeds.
 - [ ] 9.3 Write failing test `test_permutation_test_noise_r2_falls_within_its_own_null_band`: on the
-      pure-noise fixture (task 1.1), mean observed R² falls within mean-null-median ± 1σ.
+      pure-noise fixture (task 1.1), with `n_permutations=200` (explicit, CI-fast), mean observed
+      R² falls within mean-null-median ± 1σ.
 - [ ] 9.4a **Spike, not a test** — compute (via a real run, recorded here and in design.md's
-      Decision 11 note): the pure-noise fixture's actual mean null top-quartile-recovery value.
-      Cross-check against the theoretical chance-level baseline `2q / n` (found during
-      `/review-openspec` round 1: at `n=19, q=5`, `2q/n ≈ 52.6%`, not the roadmap's originally-
-      estimated "≈25%" — the roadmap's number was never verified against the actual `top-q`-in-
-      `top-2q` window definition). This step produces a number to write a real assertion against
+      Decision 11 note): the pure-noise fixture's actual mean null top-quartile-recovery value at
+      `n_permutations=200`. Cross-check against the theoretical chance-level baseline `2q / n`
+      (found during `/review-openspec` round 1: at `n=19, q=5`, `2q/n ≈ 52.6%`, not the roadmap's
+      originally-estimated "≈25%" — the roadmap's number was never verified against the actual
+      `top-q`-in-`top-2q` window definition; independently re-derived and confirmed during round 2
+      via the hypergeometric mean). This step produces a number to write a real assertion against
       in 9.4b; it is not itself a red/green TDD step (a value that doesn't exist yet cannot be
       asserted against).
 - [ ] 9.4b Write failing test `test_permutation_test_top_quartile_recovery_signal_vs_noise`, using
-      9.4a's now-known empirical value: signal fixture's observed recovery ≥ 80%; noise fixture's
-      observed recovery is comfortably separated from the signal's, close to the empirically-
-      determined null value (not a blindly-pinned 25% or an untested theoretical `2q/n`).
+      9.4a's now-known empirical value (`n_permutations=200`, explicit, CI-fast): signal fixture's
+      observed recovery ≥ 80%; noise fixture's observed recovery is comfortably separated from the
+      signal's, close to the empirically-determined null value (not a blindly-pinned 25% or an
+      untested theoretical `2q/n`).
 - [ ] 9.5 Write failing test `test_visualize_prediction_step_figure_provenance`: run the step
       twice (different input CSV content between runs, e.g. a perturbed fixture), assert the two
       resulting `07_prediction_figure.png` files differ (via content hash), and that a given run's
@@ -306,7 +409,7 @@
 
 ## 10. `theory.md` addendum
 
-> `joblib` dependency addition moved to Section 5a (must precede Section 6, which imports it).
+> `joblib` dependency addition lives in Section 5a (must precede Section 6, which imports it).
 
 - [ ] 10.1 Add a permutation-null pseudo-code section to
       `c:\vaults\sleap-roots\wheat-edpie-paper\cross-platform-prediction\theory.md` (external
@@ -316,17 +419,20 @@
       `logo_cv_predict`. **This file lives in a separate external repository/git history from
       `sleap-roots-analyze`** — it is committed separately, in the vault's own repo, and will NOT
       appear in this repo's PR diff; a reviewer of the sleap-roots-analyze PR should not expect to
-      see this change there.
+      see this change there. No pointer to this addendum exists anywhere in this repo (confirmed
+      during `/review-openspec` round 2: it would be discoverable only via archived OpenSpec
+      history or vault access) — accepted as a known, non-blocking gap, not fixed in this tier.
 
 ## 11. Manual real-data validation gate (non-CI, pre-merge, sign-off required)
 
 > Mirrors Tier 3/3.5's Section 8 exactly — see design.md Section 5 for full rationale. Not
 > complete until Elizabeth has reviewed the findings and explicitly signed off; a green CI run is
-> necessary but not sufficient. **Timing**: per Tier 3.5's actual precedent (PR #199's real commit
-> history — validation commits landed *between* two rounds of PR-review fix commits, not
-> exclusively before the PR opened), this section runs on the already-open PR branch, after the
-> first 5-subagent self-review pass (task 13.7's pre-PR-open round) and before the second,
-> CI-triggered review pass — not necessarily a strict pre-PR-open gate.
+> necessary but not sufficient. **Timing, corrected during `/review-openspec` round 2** (round 1's
+> claim that validation ran "between two rounds of review" was checked against Tier 3.5's actual
+> commit timestamps and found factually wrong): Tier 3.5's real history shows validation landing
+> **after both** 5-subagent review rounds, with a further CI-driven fix landing even after
+> Elizabeth's sign-off. This section is therefore a late-stage gate that can trail every review
+> round in `/pre-merge-check` (task 13.7), not a step reliably sandwiched between two of them.
 
 - [ ] 11.1 Reuse Tier 3.5's Section 8 real BLUP tables and 4 directed-pair `CrossPlatformConfig`
       YAMLs (`pipeline_runs/section8_manual_validation_20260716/`) if still valid; rebuild via the
@@ -353,22 +459,32 @@
 - [ ] 12.1 Add a `docs/CHANGELOG.md` `[Unreleased]` `### Added` entry.
 - [ ] 12.2 Extend `docs/CROSS_PLATFORM_ANALYSIS.md`'s existing `## Cross-Platform Genotype-Effect
       Prediction` section (Tier 3.5 already extended it once) with a new `###` subsection covering
-      `permutation_test()` **and `top_quartile_recovery()`** (found during `/review-openspec`
-      round 1: the latter was missing from this task's original list), `VisualizePredictionStep`,
-      the new `PredictionConfig` fields, and a concrete YAML example with `visualize: true`. State
-      usage (what/how) only — cross-reference `design.md`'s Decisions for benchmark/rationale
-      detail (the 105.5min→27.4min parallelization benchmark, the figure-scope rationale) rather
-      than restating it (DRY). Also:
+      `permutation_test()` and `top_quartile_recovery()`, `VisualizePredictionStep`, and **all 4**
+      new `PredictionConfig` fields (`visualize`, `n_permutations`, `permutation_random_state`,
+      `permutation_n_jobs` — found during `/review-openspec` round 2 that an earlier draft of this
+      task risked an incomplete YAML example naming only `visualize: true`) shown together in one
+      concrete YAML example under the existing `prediction:` block. State usage (what/how) only,
+      but **do not cross-reference `design.md` for key numbers** (found during round 2: `design.md`
+      moves to `openspec/changes/archive/<change-id>/design.md` on archival, so a shipped-doc
+      pointer to it goes stale/dangling the moment this change archives — a documentation
+      anti-pattern, not a DRY win). Instead, state directly in this new subsection:
+      - The one-line parallelization headline (e.g. "full per-representative-trait permutation
+        nulls take ~27 minutes worst-case across all 4 pairs via `joblib.Parallel` across
+        targets, verified against real EDPIE data — see Section 11's findings for the actual
+        measured number").
+      - The `2q/n` chance-level baseline for top-quartile recovery (e.g. "chance-level recovery is
+        `2q/n`, not 25% — ≈52.6% at n=19, q=5" — found during round 2 that this math previously
+        existed only in the OpenSpec proposal, not any shipped doc a user would actually see).
+      Also:
       - **Correct the existing section's stale closing sentence** (found during round 1: it
         currently reads "The permutation null and its figures (Tier 4) remain a separate, later
         change" — stale now that this change *is* Tier 4).
       - **Document the new output-file naming convention** (`07_permutation_<method>.json`,
         `07_prediction_figure.png`) in an "Output:" paragraph, mirroring the existing section's own
-        precedent for Tier 3.5's `06_prediction_<method>.json` — currently this naming exists only
-        in `proposal.md`/`design.md`, neither of which is shipped documentation.
-      - **Add a one-line note to the `### Current Limitations` subsection** that
-        `CrossPlatformSummaryGenerator` does not yet surface permutation/visualization output
-        either (follow-up #197's scope has grown with this tier's new outputs, not fixed here).
+        precedent for Tier 3.5's `06_prediction_<method>.json`.
+      - **Extend the existing `### Current Limitations` subsection's #197 bullet in place** (found
+        during round 2: a separate new bullet would read as a near-duplicate) to also note that
+        `CrossPlatformSummaryGenerator` doesn't surface permutation/visualization output either.
 - [ ] 12.3 **No `docs/API.md` entry.** Verified directly (found during `/review-openspec` round 1
       that the original task's premise was backwards): `LOGOCVResult`/`CrossPlatformPredictionResult`/
       `TargetPrediction` are all in `__all__`, but **none** has an `API.md` entry — the
@@ -377,18 +493,21 @@
       inclusion for these dataclasses. `PermutationResult`/`CrossPlatformPermutationResult` follow
       that same (undocumented-dataclass) precedent — no `API.md` change needed. `permutation_test`/
       `top_quartile_recovery` DO get entries in the `cross_platform_prediction` module section,
-      alongside the existing two functions.
+      matching the existing `fit_pca_on_fold`/`logo_cv_predict` entries' heading/signature/prose
+      format exactly.
 
 ## 13. Validation
 
 - [ ] 13.1 `openspec validate add-prediction-permutation-and-figure --strict` — resolve every
       reported issue.
 - [ ] 13.2 `/lint` (black + ruff) on all changed files.
-- [ ] 13.3 Full `uv run pytest --cov --cov-branch` — no regressions, all new tests (Sections 2-9)
-      green.
+- [ ] 13.3 Full `uv run pytest --cov --cov-branch` — no regressions, all new tests (Sections
+      2-9) green.
 - [ ] 13.4 `/review-openspec` — adversarial proposal review, budget for multiple independent
-      rounds (this program's established pattern: 3-5 BLOCKING findings round 1, diminishing each
-      round). Reconcile literally into `design.md`.
+      rounds (this program's established pattern: BLOCKING findings diminishing round over round —
+      NOT yet the case after round 2 here, which found 2 new BLOCKING + several IMPORTANT; a
+      further round is warranted before this is a natural stopping point). Reconcile literally
+      into `design.md`.
 - [ ] 13.5 Wait for Elizabeth's explicit approval of the fully-reconciled proposal before starting
       implementation (Sections 1-10).
 - [ ] 13.6 Section 11's manual real-data validation gate, complete with sign-off.

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -345,29 +345,29 @@
 
 **7b. `joblib` parallelization across targets (red→green pair 2 — the riskiest, most novel piece)**
 
-- [ ] 7b.1 Write failing test
+- [x] 7b.1 Write failing test
       `test_visualize_prediction_step_parallelizes_across_target_method_units_not_within_one`:
       inspect the `joblib.Parallel`/`delayed` call structure (or the list of dispatched callables)
       to confirm one `delayed(...)` unit per `(target, method)` combination, not per permutation
       iteration.
-- [ ] 7b.2 Write failing test
+- [x] 7b.2 Write failing test
       `test_visualize_prediction_step_joblib_n_jobs_and_backend_match_config`:
       `joblib.Parallel` is constructed with `n_jobs=config.prediction.permutation_n_jobs,
       backend="loky"` (per the cross-platform-analysis spec's explicit backend choice).
-- [ ] 7b.3 Write failing test
+- [x] 7b.3 Write failing test
       `test_visualize_prediction_step_derives_independent_seed_per_target_method`: for `N`
       `(target, method)` combinations enumerated in the canonical order (7a.5), assert
       `numpy.random.SeedSequence(config.prediction.permutation_random_state).spawn(N)` derives `N`
       distinct seeds, the `i`-th child assigned to the `i`-th combination in that order — no two
       combinations receive the same seed, and re-running with the same `permutation_random_state`
       and the same combinations reproduces the same derived seeds.
-- [ ] 7b.4 Write failing test `test_visualize_prediction_step_permutation_test_receives_derived_seed`
+- [x] 7b.4 Write failing test `test_visualize_prediction_step_permutation_test_receives_derived_seed`
       (`permutation_n_jobs=1`, see the note at the top of Section 7a): spy on `permutation_test` to
       confirm each call's `random_state` argument is that combination's derived `SeedSequence`
       child from 7b.3 (passed through unchanged — no int-extraction step, per `default_rng`'s
       uniform acceptance of `SeedSequence`), not the raw
       `config.prediction.permutation_random_state`.
-- [ ] 7b.5 Write failing test
+- [x] 7b.5 Write failing test
       `test_visualize_prediction_step_parallel_vs_serial_results_agree_within_tolerance`: on a
       small fixture with an explicitly small, stated `n_permutations` (e.g. 50, to bound the
       elementwise-comparison surface and keep this test CI-fast), `permutation_n_jobs=1` and
@@ -379,10 +379,10 @@
       tolerance convention, independent of this step's own correctness). This test calls the real
       `permutation_test` (no mocking) at both `n_jobs` settings, so it is unaffected by the
       mocking-across-process-boundary note above.
-- [ ] 7b.6 Extend `VisualizePredictionStep` to dispatch the 7a.5 enumeration through
+- [x] 7b.6 Extend `VisualizePredictionStep` to dispatch the 7a.5 enumeration through
       `joblib.Parallel(n_jobs=config.prediction.permutation_n_jobs, backend="loky")`, deriving
       per-combination seeds via `SeedSequence.spawn(N)` (7b.3). Make 7b.1-7b.5 green.
-- [ ] 7b.7 Write failing test `test_visualize_prediction_step_handles_pc1_only_targets_via_joblib`:
+- [x] 7b.7 Write failing test `test_visualize_prediction_step_handles_pc1_only_targets_via_joblib`:
       re-run 7a.2's PC1-only (zero representative-trait) fixture at `permutation_n_jobs=4` (real
       multi-process dispatch, no mocking), asserting the step still runs successfully through the
       full `joblib.Parallel` dispatch with `N=1` total unit per method, producing a valid

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -265,23 +265,23 @@
 > `tests/test_step_visualize_prediction.py`, per proposal.md's naming-collision note (the two new
 > source files share the basename `visualize_prediction.py` in different subpackages).
 
-- [ ] 6.1 Write failing test `test_create_prediction_figure_scatter_panel_uses_pc1_target_only`:
+- [x] 6.1 Write failing test `test_create_prediction_figure_scatter_panel_uses_pc1_target_only`:
       given multiple targets' data, the obs-vs-pred scatter panel's plotted points correspond only
       to the `PC1` target's `y_true`/`y_pred`.
-- [ ] 6.2 Write failing test `test_create_prediction_figure_violin_panel_pools_all_targets_nulls`:
+- [x] 6.2 Write failing test `test_create_prediction_figure_violin_panel_pools_all_targets_nulls`:
       the violin/strip panel's null data is the concatenation of every target's `null_r2`, and its
       observed-points data is every target's `observed_r2` (one point per target).
-- [ ] 6.3 Write failing test `test_create_prediction_figure_bar_chart_shows_observed_vs_null_mean`:
+- [x] 6.3 Write failing test `test_create_prediction_figure_bar_chart_shows_observed_vs_null_mean`:
       the two bars' heights equal the mean observed and mean null top-quartile-recovery across all
       targets.
-- [ ] 6.4 Write failing test `test_create_prediction_figure_returns_a_figure_with_three_axes`.
-- [ ] 6.4a Write failing test `test_create_prediction_figure_handles_single_target`: given only one
+- [x] 6.4 Write failing test `test_create_prediction_figure_returns_a_figure_with_three_axes`.
+- [x] 6.4a Write failing test `test_create_prediction_figure_handles_single_target`: given only one
       target's data (e.g. the PC1-only degenerate case Section 7 also handles — found during
       `/review-openspec` round 3: task 7c.7 will call this function for that same fixture, and
       nothing previously verified the violin/bar-chart panels degrade gracefully to `N=1` target
       rather than erroring on a single-element distribution), assert the figure is still built
       successfully with all 3 panels present, not a crash.
-- [ ] 6.5 Implement `create_prediction_figure(...)` (and any supporting per-panel helper functions)
+- [x] 6.5 Implement `create_prediction_figure(...)` (and any supporting per-panel helper functions)
       in new `src/sleap_roots_analyze/visualize_prediction.py`, following
       `cross_experiment_analysis.py`'s plotting-function convention (pure functions returning a
       `matplotlib.Figure`, no file I/O). Make 6.1-6.4a green.

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -678,19 +678,29 @@
 
 ## 13. Validation
 
-- [ ] 13.1 `openspec validate add-prediction-permutation-and-figure --strict` — resolve every
-      reported issue.
-- [ ] 13.2 `/lint` (black + ruff) on all changed files.
-- [ ] 13.3 Full `uv run pytest --cov --cov-branch` — no regressions, all new tests (Sections
-      2-9) green.
-- [ ] 13.4 `/review-openspec` — adversarial proposal review, budget for multiple independent
+- [x] 13.1 `openspec validate add-prediction-permutation-and-figure --strict` — resolve every
+      reported issue. **Passes.**
+- [x] 13.2 `/lint` (black + ruff) on all changed files. **Clean** (verified against this branch's
+      actual changed-file list, not the full repo — a full-repo scan surfaces 33 pre-existing
+      docstring-convention errors on `main`, unrelated to this branch, in files this branch never
+      touches).
+- [x] 13.3 Full `uv run pytest --cov --cov-branch` — no regressions, all new tests (Sections
+      2-9) green. **Ran full suite (3748s): 1 failed, 2823 passed, 31 skipped.** The 1 failure
+      (`test_sweep_covers_all_stochastic_functions`) was a real, correctly-caught gap:
+      `permutation_test`'s new `random_state` parameter made it a newly-discoverable stochastic
+      function with no reproducibility-sweep case. Fixed (registered in
+      `tests/reproducibility_cases.py` + `EXPECTED_QUALNAMES`); re-verified green, plus a full
+      re-run of every Tier 3/3.5/4 + reproducibility + public-API test file together (298 passed,
+      18 skipped, 0 failed).
+- [x] 13.4 `/review-openspec` — adversarial proposal review, budget for multiple independent
       rounds (this program's established pattern: BLOCKING findings diminishing round over round —
       NOT yet the case after round 2 here, which found 2 new BLOCKING + several IMPORTANT; a
       further round is warranted before this is a natural stopping point). Reconcile literally
-      into `design.md`.
+      into `design.md`. **Done — 4 rounds, round 4 found 0 new BLOCKING.**
 - [x] 13.5 Wait for Elizabeth's explicit approval of the fully-reconciled proposal before starting
       implementation (Sections 1-10). **Approved 2026-07-17.**
-- [ ] 13.6 Section 11's manual real-data validation gate, complete with sign-off.
+- [x] 13.6 Section 11's manual real-data validation gate, complete with sign-off. **Signed off
+      2026-07-17.**
 - [ ] 13.7 Post-implementation code review: `/pre-merge-check` including a 5-subagent `/review-pr`
       self-review pass before the PR opens, and a second fresh pass once CI runs on the open PR
       (mirroring Tier 3/3.5's precedent — both passes have caught real bugs every tier so far).

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -701,6 +701,14 @@
       implementation (Sections 1-10). **Approved 2026-07-17.**
 - [x] 13.6 Section 11's manual real-data validation gate, complete with sign-off. **Signed off
       2026-07-17.**
-- [ ] 13.7 Post-implementation code review: `/pre-merge-check` including a 5-subagent `/review-pr`
+- [x] 13.7 Post-implementation code review: `/pre-merge-check` including a 5-subagent `/review-pr`
       self-review pass before the PR opens, and a second fresh pass once CI runs on the open PR
       (mirroring Tier 3/3.5's precedent — both passes have caught real bugs every tier so far).
+      **Pre-PR pass done:** 0 BLOCKING across all 5 lenses. Fixed: a real, confirmed
+      `plt.close(fig)` leak in `VisualizePredictionStep` (broke this codebase's established
+      per-figure-step convention); inconsistent int/bool validation across the 3 permutation
+      config fields; `top_quartile_recovery`'s default `q` silently wrong (not raising) at `n=1`;
+      `PermutationTestResult` missing from package-root exports; a one-directional naming-collision
+      docstring cross-reference; a pooling-validity comment. Declined: write-to-temp-then-rename
+      for the JSON write loop (low-probability failure mode, outside the documented contract).
+      Full re-run: 193 passed, 0 failed. Second pass pending the open PR's CI run.

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -313,11 +313,11 @@
 > `permutation_test`; 7b.5, 7b.7, and 7c's other tests call the real, unmocked functions and are
 > likewise unaffected.
 
-- [ ] 7a.1 Write failing test `test_visualize_prediction_step_reuses_task6_predictor_matrices`
+- [x] 7a.1 Write failing test `test_visualize_prediction_step_reuses_task6_predictor_matrices`
       (`permutation_n_jobs=1`, see note above): spy on any BLUP-loading/genotype-mean-aggregation
       function to confirm zero calls when `predictor_matrices` is supplied via
       `kwargs["06_predict_cross_platform"]`.
-- [ ] 7a.2 Write failing test `test_visualize_prediction_step_handles_pc1_only_targets`: with zero
+- [x] 7a.2 Write failing test `test_visualize_prediction_step_handles_pc1_only_targets`: with zero
       representative-trait targets (only `target_name="PC1"` present, e.g. a fixture where
       `select_cluster_representatives` returned empty — Tier 3.5's own documented degenerate case),
       the step's target/method enumeration produces exactly `N=1` unit per method, not a crash.
@@ -326,16 +326,16 @@
       7b.6, since the "Step still runs with only the PC1 target" scenario explicitly requires the
       degenerate case to work when *dispatched through `joblib.Parallel`*, not merely when called
       serially.
-- [ ] 7a.3 Write failing test
+- [x] 7a.3 Write failing test
       `test_visualize_prediction_step_calls_permutation_test_once_per_target_per_method`
       (`permutation_n_jobs=1`, see note above): for `N` targets × `M` methods (`reduction_method` +
       `comparison_methods`), `permutation_test` is called exactly `N * M` times.
-- [ ] 7a.4 Write failing test
+- [x] 7a.4 Write failing test
       `test_visualize_prediction_step_calls_permutation_test_n_times_when_comparison_methods_empty`
       (`permutation_n_jobs=1`, see note above): with `comparison_methods=[]` (`K=0`),
       `permutation_test` is called exactly `N` times (`N` targets × 1 method) — an explicit `K=0`
       case, not just the general `N * M` formula in 7a.3.
-- [ ] 7a.5 Implement a minimal `VisualizePredictionStep(BaseStep)` in new
+- [x] 7a.5 Implement a minimal `VisualizePredictionStep(BaseStep)` in new
       `src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py`: reads `predictor_matrices`
       and task 6's results, enumerates `(target_name, method)` combinations in the canonical order
       (methods first, `[reduction_method] + comparison_methods`; then `target_names` in task 6's

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -203,27 +203,27 @@
 
 ## 4. `PredictionConfig` new fields + `CrossPlatformConfig` cross-check (test-first)
 
-- [ ] 4.1 Write failing test `test_prediction_config_visualize_defaults_to_false_and_no_op`:
+- [x] 4.1 Write failing test `test_prediction_config_visualize_defaults_to_false_and_no_op`:
       `PredictionConfig()` has `visualize=False`, `n_permutations=1000`,
       `permutation_random_state=42`, `permutation_n_jobs=8`; construction with these defaults does
       not raise.
-- [ ] 4.2 Write failing test `test_cross_platform_config_rejects_visualize_true_with_enabled_false`:
+- [x] 4.2 Write failing test `test_cross_platform_config_rejects_visualize_true_with_enabled_false`:
       `CrossPlatformConfig(..., prediction=PredictionConfig(enabled=False, visualize=True))`
       raises `ValueError` at construction time.
-- [ ] 4.3 Write failing test `test_prediction_config_permutation_fields_validation_skipped_when_visualize_false`:
+- [x] 4.3 Write failing test `test_prediction_config_permutation_fields_validation_skipped_when_visualize_false`:
       `enabled=True, visualize=False` with `n_permutations=0`, `permutation_n_jobs=0`, and
       `permutation_random_state=-1` (all simultaneously invalid) does not raise — none of the 3
       permutation-related fields are validated unless `visualize=True`.
-- [ ] 4.4 Write failing test `test_prediction_config_rejects_non_positive_n_permutations_when_visualize_true`:
+- [x] 4.4 Write failing test `test_prediction_config_rejects_non_positive_n_permutations_when_visualize_true`:
       `enabled=True, visualize=True, n_permutations=0` (and `-1`) raises `ValueError`.
-- [ ] 4.4a Write failing test `test_prediction_config_rejects_non_positive_permutation_n_jobs_when_visualize_true`:
+- [x] 4.4a Write failing test `test_prediction_config_rejects_non_positive_permutation_n_jobs_when_visualize_true`:
       `enabled=True, visualize=True, permutation_n_jobs=0` (and `-1`) raises `ValueError` naming
       the field, not `joblib.Parallel`'s own raw error surfacing later inside
       `VisualizePredictionStep`.
-- [ ] 4.4b Write failing test `test_prediction_config_rejects_invalid_permutation_random_state_when_visualize_true`:
+- [x] 4.4b Write failing test `test_prediction_config_rejects_invalid_permutation_random_state_when_visualize_true`:
       `enabled=True, visualize=True, permutation_random_state=-1` (and a non-`int` value) raises
       `ValueError` naming the field, not `numpy.random.SeedSequence`'s own raw error.
-- [ ] 4.5 Extend `PredictionConfig`/`CrossPlatformConfig.__post_init__` in
+- [x] 4.5 Extend `PredictionConfig`/`CrossPlatformConfig.__post_init__` in
       `pipeline/config/components.py` with the 4 new fields and the 4.2/4.4/4.4a/4.4b validations.
       Make 4.1-4.4b green.
 

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -618,9 +618,9 @@
       genotype-level points in all 4; violin/strip panel shows a visible real-vs-null spread
       (widest, as expected, for the ~129-target worst-case pair); bar chart's two bars are
       distinguishable in all 4. No legibility issues found.
-- [ ] 11.7 Present findings to Elizabeth; record her explicit sign-off here before this task (and
+- [x] 11.7 Present findings to Elizabeth; record her explicit sign-off here before this task (and
       Section 13's `/pre-merge-check`) is considered complete.
-      **Findings presented 2026-07-17 (see conversation) — awaiting Elizabeth's explicit sign-off.**
+      **Findings presented 2026-07-17; Elizabeth signed off the same day (see conversation).**
 
 ## 12. Docs
 

--- a/openspec/changes/add-prediction-permutation-and-figure/tasks.md
+++ b/openspec/changes/add-prediction-permutation-and-figure/tasks.md
@@ -568,25 +568,59 @@
 > Elizabeth's sign-off. This section is therefore a late-stage gate that can trail every review
 > round in `/pre-merge-check` (task 13.7), not a step reliably sandwiched between two of them.
 
-- [ ] 11.1 Reuse Tier 3.5's Section 8 real BLUP tables and 4 directed-pair `CrossPlatformConfig`
+- [x] 11.1 Reuse Tier 3.5's Section 8 real BLUP tables and 4 directed-pair `CrossPlatformConfig`
       YAMLs (`pipeline_runs/section8_manual_validation_20260716/`) if still valid; rebuild via the
       same non-committed script pattern if the underlying QC vintage has moved. Extend each YAML's
       `prediction:` block with `visualize: true`, `n_permutations: 1000`, `permutation_n_jobs: 8`.
-- [ ] 11.2 Run all 4 directed pairs through the full 7-task pipeline, including
+      **Done:** all 4 original YAMLs' data/BLUP paths verified to still resolve on disk (no
+      rebuild needed); 4 new `*_visualize.yaml` sibling copies created (originals left untouched)
+      with `visualize: true, n_permutations: 1000, permutation_random_state: 42,
+      permutation_n_jobs: 8` appended to each `prediction:` block.
+- [x] 11.2 Run all 4 directed pairs through the full 7-task pipeline, including
       `Turface19→Cylinder` (worst-case pair, ~129 representative traits).
-- [ ] 11.3 Re-measure and record real wall time, per pair and total — superseding the synthetic-
+      **Done:** all 4 pairs ran successfully to completion (7/7 tasks each), output in
+      `pipeline_runs/section8_manual_validation_20260716/results_tier4_visualize/`.
+- [x] 11.3 Re-measure and record real wall time, per pair and total — superseding the synthetic-
       fixture-derived 27.4-minute estimate (design.md Decision 4/Risks). If any pair or the total
       exceeds 30 minutes, apply a documented fallback (design.md Risks) before proceeding to 11.7.
-- [ ] 11.4 Sanity-check permutation-based p-values against Tier 3.5's Section 8.2/8.3 nominally-
+      **Measured (this dev machine, 16-core, `n_jobs=8`):**
+      | Pair | Total wall time | Step 7 (visualize prediction) alone |
+      |---|---|---|
+      | Turface150→Turface19 | 1m32s | 74s |
+      | Cylinder→Field | 4m18s | 196s |
+      | Turface19→Field | 2m49s | 147s |
+      | Turface19→Cylinder (worst case) | **12m58s** | **720s (12m00s)** |
+      | **Total (all 4, sequential)** | **~21.6 min** | — |
+      All comfortably under the 30-minute gate — the worst-case pair alone came in at less than
+      half the synthetic-fixture-extrapolated 27.4-minute estimate. No fallback needed.
+- [x] 11.4 Sanity-check permutation-based p-values against Tier 3.5's Section 8.2/8.3 nominally-
       significant findings (e.g. Cylinder→Field `Root Count 20cm`, asymptotic R²=0.25/ρ=+0.49/
       p=0.033; Turface19→Cylinder `Seminal Angles Proximal Max Max`, asymptotic R²=0.38/ρ=+0.62/
       p=0.004) — record whether these still look significant under the permutation-based p-value.
-- [ ] 11.5 Cross-check against Tier 3.5's Section 8.5 multiple-testing/power caveat (raw p<0.05
+      **Done:** both hits reproduce exactly under the `representatives` method (not `pls_latent`,
+      this tier's primary method — Tier 3.5's own reported figures came from the comparison
+      method). Both remain significant under permutation-based inference, matching or slightly
+      improving on the asymptotic figures: Root Count 20cm asymptotic p=0.033 → permutation
+      p_r2=0.017, p_rho=0.022; Seminal Angles Proximal Max Max asymptotic p=0.0044 → permutation
+      p_r2=0.004, p_rho=0.005.
+- [x] 11.5 Cross-check against Tier 3.5's Section 8.5 multiple-testing/power caveat (raw p<0.05
       count 63/354, FDR-corrected count 9/354, all 9 negative ρ) — record whether permutation-based
       inference reinforces or changes that caveat's conclusion.
-- [ ] 11.6 Visually inspect all 4 `07_prediction_figure.png` outputs for legibility and correctness.
+      **Done:** permutation-based prediction p-values (`p_value_r2`, same 354-row denominator: 4
+      pairs × 2 methods × per-pair target count) are markedly more conservative than the
+      correlation step's asymptotic p-values — raw p<0.05 count **9/354 (2.5%)**, vs. Tier 3.5's
+      63/354 (17.8%); **0/354 survive FDR-BH correction**, vs. Tier 3.5's own 9/354 survivors (all
+      negative ρ). This **reinforces** (more strongly, not just confirms) Tier 3.5's Section 8.5
+      conclusion: individual nominally-significant hits should not be read as confirmed
+      cross-platform predictability at this genotype sample size.
+- [x] 11.6 Visually inspect all 4 `07_prediction_figure.png` outputs for legibility and correctness.
+      **Done:** all 4 inspected directly. Readable axis labels/titles; PC1 scatter shows
+      genotype-level points in all 4; violin/strip panel shows a visible real-vs-null spread
+      (widest, as expected, for the ~129-target worst-case pair); bar chart's two bars are
+      distinguishable in all 4. No legibility issues found.
 - [ ] 11.7 Present findings to Elizabeth; record her explicit sign-off here before this task (and
       Section 13's `/pre-merge-check`) is considered complete.
+      **Findings presented 2026-07-17 (see conversation) — awaiting Elizabeth's explicit sign-off.**
 
 ## 12. Docs
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
 dependencies = [
     "adjustText>=1.3.0",
     "click>=8.0.0",
+    "joblib>=1.5.2",
     "matplotlib>=3.10.6",
     "networkx>=3.5",
     "numpy>=2.3.2",

--- a/src/sleap_roots_analyze/__init__.py
+++ b/src/sleap_roots_analyze/__init__.py
@@ -216,6 +216,7 @@ from sleap_roots_analyze.cross_platform_prediction import (
     permutation_test,
     top_quartile_recovery,
     LOGOCVResult,
+    PermutationTestResult,
 )
 from sleap_roots_analyze.result_types import (
     CrossPlatformPredictionResult,
@@ -387,6 +388,7 @@ __all__ = [
     # Cross-platform prediction permutation null + figures (Tier 4, #200)
     "permutation_test",
     "top_quartile_recovery",
+    "PermutationTestResult",
     "CrossPlatformPermutationResult",
     "PermutationResult",
 ]

--- a/src/sleap_roots_analyze/__init__.py
+++ b/src/sleap_roots_analyze/__init__.py
@@ -213,11 +213,15 @@ from sleap_roots_analyze.pc_correlations import (
 from sleap_roots_analyze.cross_platform_prediction import (
     fit_pca_on_fold,
     logo_cv_predict,
+    permutation_test,
+    top_quartile_recovery,
     LOGOCVResult,
 )
 from sleap_roots_analyze.result_types import (
     CrossPlatformPredictionResult,
     TargetPrediction,
+    CrossPlatformPermutationResult,
+    PermutationResult,
 )
 
 __all__ = [
@@ -380,4 +384,9 @@ __all__ = [
     "LOGOCVResult",
     "CrossPlatformPredictionResult",
     "TargetPrediction",
+    # Cross-platform prediction permutation null + figures (Tier 4, #200)
+    "permutation_test",
+    "top_quartile_recovery",
+    "CrossPlatformPermutationResult",
+    "PermutationResult",
 ]

--- a/src/sleap_roots_analyze/cli.py
+++ b/src/sleap_roots_analyze/cli.py
@@ -526,6 +526,9 @@ def cross_platform(
     - Optionally, predict cross-platform genotype values via LOGO-CV, as a
       6th step, when the config's `prediction.enabled` is true (no new flag
       -- set it in the config's `prediction:` block)
+    - Optionally, compute a permutation-null significance test and a
+      3-panel prediction figure, as a 7th step, when the config's
+      `prediction.visualize` is true (requires `prediction.enabled` too)
 
     This pipeline is designed to compare traits across different experimental
     platforms or conditions to identify which traits capture similar biological
@@ -589,6 +592,15 @@ def cross_platform(
                         "6",
                         "PredictCrossPlatform",
                         "Predict cross-platform genotype values via LOGO-CV",
+                    )
+                )
+
+            if cfg.prediction.visualize:
+                steps.append(
+                    (
+                        "7",
+                        "VisualizePrediction",
+                        "Permutation-null significance test + prediction figure",
                     )
                 )
 

--- a/src/sleap_roots_analyze/cross_platform_prediction.py
+++ b/src/sleap_roots_analyze/cross_platform_prediction.py
@@ -14,9 +14,10 @@ CV-hygiene contract this module implements against.
 
 from __future__ import annotations
 
+import math
 from collections import Counter
 from dataclasses import dataclass
-from typing import Optional, Sequence
+from typing import Optional, Sequence, Union
 
 import numpy as np
 import pandas as pd
@@ -346,3 +347,197 @@ def top_quartile_recovery(
     top_q_true = set(np.argsort(-y_true, kind="stable")[:q])
     top_2q_pred = set(np.argsort(-y_pred, kind="stable")[: 2 * q])
     return len(top_q_true & top_2q_pred) / q
+
+
+@dataclass
+class PermutationTestResult:
+    """Permutation-null significance test result for one prediction target.
+
+    Returned by :func:`permutation_test`. Deliberately does not carry a
+    ``target_name`` field -- this type mirrors :class:`LOGOCVResult`'s role
+    as the analytical module's own "raw" result, with no knowledge of which
+    named target it was computed for (that context is attached only by
+    ``result_types.CrossPlatformPermutationResult.from_permutation_test_results``,
+    exactly as ``TargetPrediction`` attaches ``target_name`` to a plain
+    ``LOGOCVResult``).
+
+    Attributes:
+        observed_r2: Aggregate R^2 from one ``logo_cv_predict()`` call on the
+            real (unshuffled) ``y``.
+        observed_rmse: Aggregate RMSE from the same observed call.
+        observed_spearman_rho: Aggregate Spearman rho from the same observed
+            call.
+        observed_top_quartile_recovery: :func:`top_quartile_recovery`
+            computed from the same observed call's predictions.
+        null_r2: R^2 for each of ``n_permutations`` shuffled-``y`` calls.
+        null_rmse: RMSE for each shuffled-``y`` call.
+        null_spearman_rho: Spearman rho for each shuffled-``y`` call.
+        null_top_quartile_recovery: :func:`top_quartile_recovery` for each
+            shuffled-``y`` call, using that permutation's own shuffled ``y``
+            as ground truth (not the original, unshuffled ``y``).
+        p_value_r2: One-sided p-value, right-tailed (higher R^2 is better).
+        p_value_rmse: One-sided p-value, **left-tailed** (lower RMSE is
+            better -- the opposite convention from R^2/rho). Do not read a
+            low ``p_value_rmse`` as indicating a bad fit.
+        p_value_spearman_rho: One-sided p-value, right-tailed, same
+            direction as ``p_value_r2``.
+        n_permutations: Number of permutations run (length of every
+            ``null_*`` array).
+    """
+
+    observed_r2: float
+    observed_rmse: float
+    observed_spearman_rho: float
+    observed_top_quartile_recovery: float
+    null_r2: np.ndarray
+    null_rmse: np.ndarray
+    null_spearman_rho: np.ndarray
+    null_top_quartile_recovery: np.ndarray
+    p_value_r2: float
+    p_value_rmse: float
+    p_value_spearman_rho: float
+    n_permutations: int
+
+
+def permutation_test(
+    X: pd.DataFrame,
+    y: np.ndarray,
+    genotypes: Sequence[str],
+    reduction_method: str = "pls_latent",
+    representative_names: Optional[Sequence[str]] = None,
+    n_permutations: int = 1000,
+    random_state: Union[int, np.random.SeedSequence, np.random.Generator] = 42,
+) -> PermutationTestResult:
+    """Permutation-null significance test for a cross-platform LOGO-CV prediction.
+
+    Self-contained: first calls :func:`logo_cv_predict` once on the real
+    (unshuffled) ``y`` to populate the observed R^2/RMSE/Spearman rho/
+    top-quartile-recovery, then draws ``n_permutations`` independent
+    shuffles of ``y`` relative to ``genotypes`` (``X`` and ``genotypes`` are
+    never shuffled) and calls :func:`logo_cv_predict` once per shuffle to
+    build the null distributions and one-sided p-values.
+
+    Args:
+        X: Predictor matrix, forwarded unchanged to every ``logo_cv_predict``
+            call -- see that function's own contract.
+        y: Target values, one per genotype. The real, unshuffled labeling;
+            each permutation iteration shuffles a copy of this array.
+        genotypes: Genotype labels, forwarded unchanged to every
+            ``logo_cv_predict`` call.
+        reduction_method: Forwarded to every ``logo_cv_predict`` call.
+        representative_names: Forwarded to every ``logo_cv_predict`` call.
+        n_permutations: Number of shuffled-``y`` calls to run. Must be
+            positive.
+        random_state: Seed for the permutation draws, built into an RNG via
+            ``numpy.random.default_rng`` (not ``numpy.random.Generator``
+            directly, which requires a ``BitGenerator`` instance and rejects
+            a bare ``int``). Accepts ``int``/``numpy.random.SeedSequence``
+            reproducibly (the same input always reproduces the same null
+            draws). A passed-in ``numpy.random.Generator`` instance is
+            stateful -- reusing the *same* ``Generator`` instance across two
+            calls will **not** reproduce identical results, since its
+            internal state has advanced between calls.
+
+    Returns:
+        A :class:`PermutationTestResult` with the observed values, full null
+        distributions, and one-sided p-values.
+
+    Raises:
+        ValueError: If ``n_permutations`` is not positive (checked before
+            any ``logo_cv_predict`` call); if the observed-value
+            ``logo_cv_predict`` call itself raises (e.g. an invalid
+            ``reduction_method`` or mismatched-length inputs) -- surfaced
+            unchanged, before any permutation is drawn; if a constant
+            (zero-variance) ``y`` produces a non-finite observed
+            ``spearman_rho``/``top_quartile_recovery`` (legal per
+            ``logo_cv_predict``'s own contract, but unusable here) -- raised
+            immediately after the observed call, before any permutation is
+            drawn; if any permutation produces a non-finite null value --
+            raised only after all ``n_permutations`` calls complete (a
+            genuinely non-finite-producing bug is expected to affect many
+            permutations within one target, not a rare one-off, so failing
+            fast saves little wall-clock time while complicating
+            which-permutations-ran accounting), naming both the offending
+            metric(s) and permutation index(es).
+    """
+    if n_permutations <= 0:
+        raise ValueError(f"n_permutations must be positive, got {n_permutations}")
+
+    observed = logo_cv_predict(X, y, genotypes, reduction_method, representative_names)
+    observed_top_quartile_recovery = top_quartile_recovery(
+        observed.y_true, observed.y_pred
+    )
+
+    observed_metrics = {
+        "r2": observed.r2,
+        "rmse": observed.rmse,
+        "spearman_rho": observed.spearman_rho,
+        "top_quartile_recovery": observed_top_quartile_recovery,
+    }
+    non_finite_observed = sorted(
+        name for name, value in observed_metrics.items() if not math.isfinite(value)
+    )
+    if non_finite_observed:
+        raise ValueError(
+            f"Observed value(s) for metric(s) {non_finite_observed} are "
+            "non-finite (e.g. a constant y produces a non-finite "
+            "spearman_rho) -- refusing to run n_permutations shuffled calls "
+            "on data already known to be unusable"
+        )
+
+    rng = np.random.default_rng(random_state)
+    y_arr = np.asarray(y, dtype=float)
+
+    null_r2 = np.empty(n_permutations)
+    null_rmse = np.empty(n_permutations)
+    null_spearman_rho = np.empty(n_permutations)
+    null_top_quartile_recovery = np.empty(n_permutations)
+
+    for i in range(n_permutations):
+        y_shuffled = rng.permutation(y_arr)
+        shuffled_result = logo_cv_predict(
+            X, y_shuffled, genotypes, reduction_method, representative_names
+        )
+        null_r2[i] = shuffled_result.r2
+        null_rmse[i] = shuffled_result.rmse
+        null_spearman_rho[i] = shuffled_result.spearman_rho
+        null_top_quartile_recovery[i] = top_quartile_recovery(
+            y_shuffled, shuffled_result.y_pred
+        )
+
+    non_finite_entries = [
+        (name, int(idx))
+        for name, arr in (
+            ("r2", null_r2),
+            ("rmse", null_rmse),
+            ("spearman_rho", null_spearman_rho),
+            ("top_quartile_recovery", null_top_quartile_recovery),
+        )
+        for idx in np.where(~np.isfinite(arr))[0]
+    ]
+    if non_finite_entries:
+        raise ValueError(
+            f"Non-finite null value(s) found (metric, permutation index): "
+            f"{non_finite_entries}"
+        )
+
+    p_value_r2 = (np.sum(null_r2 >= observed.r2) + 1) / (n_permutations + 1)
+    p_value_rmse = (np.sum(null_rmse <= observed.rmse) + 1) / (n_permutations + 1)
+    p_value_spearman_rho = (np.sum(null_spearman_rho >= observed.spearman_rho) + 1) / (
+        n_permutations + 1
+    )
+
+    return PermutationTestResult(
+        observed_r2=observed.r2,
+        observed_rmse=observed.rmse,
+        observed_spearman_rho=observed.spearman_rho,
+        observed_top_quartile_recovery=observed_top_quartile_recovery,
+        null_r2=null_r2,
+        null_rmse=null_rmse,
+        null_spearman_rho=null_spearman_rho,
+        null_top_quartile_recovery=null_top_quartile_recovery,
+        p_value_r2=float(p_value_r2),
+        p_value_rmse=float(p_value_rmse),
+        p_value_spearman_rho=float(p_value_spearman_rho),
+        n_permutations=n_permutations,
+    )

--- a/src/sleap_roots_analyze/cross_platform_prediction.py
+++ b/src/sleap_roots_analyze/cross_platform_prediction.py
@@ -293,3 +293,56 @@ def logo_cv_predict(
         spearman_rho=float(spearman_rho),
         spearman_p=float(spearman_p),
     )
+
+
+def top_quartile_recovery(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    q: Optional[int] = None,
+) -> float:
+    """Fraction of the true top-``q`` genotypes recovered in the predicted top-``2q``.
+
+    Tier 4 (#200) metric: ranks genotypes by ``y_true`` and by ``y_pred``
+    independently, then measures what fraction of the true top-``q`` set
+    (by ``y_true``) also appears in the *predicted* top-``2q`` set (by
+    ``y_pred``) -- a wider predicted window than the true one, since a
+    ranking-based recovery metric at n~=19 is too noisy to expect exact
+    top-``q``-for-top-``q`` agreement.
+
+    Chance-level (random ``y_pred``) expected recovery is ``2*q/n`` by
+    linearity of expectation, not a fixed "25%" -- see design.md Decision 11
+    for the derivation. Used both for the observed value (real ``y``, real
+    LOGO-CV predictions) and, once per permutation inside
+    :func:`permutation_test`, for the null distribution.
+
+    Args:
+        y_true: Observed target values, one per genotype.
+        y_pred: Predicted target values, same order as ``y_true``.
+        q: Size of the true top-quartile set. Defaults to
+            ``max(1, round(len(y_true) / 4))`` -- clamped to at least 1 so a
+            small ``n`` never produces a vacuous, zero-size window. An
+            explicitly-supplied ``q`` is validated strictly (must be
+            positive and satisfy ``2 * q <= len(y_true)``); the computed
+            default is never invalid at this program's real n>=3 scale.
+
+    Returns:
+        The fraction (in ``[0, 1]``) of the true top-``q`` genotypes present
+        in the predicted top-``2q`` genotypes.
+
+    Raises:
+        ValueError: If an explicitly-supplied ``q`` is not positive, or if
+            ``2 * q`` exceeds ``len(y_true)``.
+    """
+    y_true = np.asarray(y_true, dtype=float)
+    y_pred = np.asarray(y_pred, dtype=float)
+    n = len(y_true)
+    if q is None:
+        q = max(1, round(n / 4))
+    elif q <= 0 or 2 * q > n:
+        raise ValueError(
+            f"q must be a positive integer with 2*q <= len(y_true) ({n}), " f"got q={q}"
+        )
+
+    top_q_true = set(np.argsort(-y_true, kind="stable")[:q])
+    top_2q_pred = set(np.argsort(-y_pred, kind="stable")[: 2 * q])
+    return len(top_q_true & top_2q_pred) / q

--- a/src/sleap_roots_analyze/cross_platform_prediction.py
+++ b/src/sleap_roots_analyze/cross_platform_prediction.py
@@ -324,7 +324,9 @@ def top_quartile_recovery(
             small ``n`` never produces a vacuous, zero-size window. An
             explicitly-supplied ``q`` is validated strictly (must be
             positive and satisfy ``2 * q <= len(y_true)``); the computed
-            default is never invalid at this program's real n>=3 scale.
+            default is never invalid at this program's real n>=3 scale (or
+            any ``n>=2``) but is only well-defined for ``n>=2`` -- see
+            ``Raises`` below.
 
     Returns:
         The fraction (in ``[0, 1]``) of the true top-``q`` genotypes present
@@ -332,12 +334,20 @@ def top_quartile_recovery(
 
     Raises:
         ValueError: If an explicitly-supplied ``q`` is not positive, or if
-            ``2 * q`` exceeds ``len(y_true)``.
+            ``2 * q`` exceeds ``len(y_true)``; or if ``len(y_true) < 2``
+            (below this, even the default ``q`` would violate
+            ``2 * q <= len(y_true)``).
     """
     y_true = np.asarray(y_true, dtype=float)
     y_pred = np.asarray(y_pred, dtype=float)
     n = len(y_true)
     if q is None:
+        if n < 2:
+            raise ValueError(
+                f"len(y_true)={n} is too small for a default q: even q=1 "
+                "would violate 2*q <= len(y_true); provide an explicit "
+                "valid q (impossible below n=2) or use a larger input"
+            )
         q = max(1, round(n / 4))
     elif q <= 0 or 2 * q > n:
         raise ValueError(

--- a/src/sleap_roots_analyze/pipeline/config/components.py
+++ b/src/sleap_roots_analyze/pipeline/config/components.py
@@ -885,6 +885,27 @@ class PredictionConfig:
             enabled=True and predictor_source="blup".
         target_blup_path: Path to the target platform's BLUP-adjusted-means
             CSV. Same requirement as source_blup_path.
+        visualize: Whether to run VisualizePredictionStep (Tier 4, #200) --
+            an optional 7th pipeline task that computes a permutation-null
+            significance test per target/method and saves a composite
+            figure. Default False so every existing CrossPlatformConfig YAML
+            is unaffected. Only ever meaningful when enabled=True (a
+            visualize=True + enabled=False combination is rejected by
+            CrossPlatformConfig.__post_init__, which alone can see both
+            fields, since PredictionConfig's own __post_init__ short-circuits
+            entirely when enabled=False).
+        n_permutations: Number of shuffled-y calls per permutation_test()
+            call. Validated (must be positive) only when visualize=True.
+        permutation_random_state: Seed for the permutation draws (an
+            independent child is derived per target/method via
+            numpy.random.SeedSequence(...).spawn(N), not this raw value
+            reused identically). Validated (must be a non-negative int)
+            only when visualize=True.
+        permutation_n_jobs: Number of joblib.Parallel workers, parallelizing
+            across independent (target, method) units -- not across
+            individual permutation calls, which measured slower than serial
+            (design.md Decision 4). Validated (must be positive) only when
+            visualize=True.
     """
 
     enabled: bool = False
@@ -896,6 +917,10 @@ class PredictionConfig:
     blup_refit_per_fold: bool = False
     source_blup_path: Optional[str] = None
     target_blup_path: Optional[str] = None
+    visualize: bool = False
+    n_permutations: int = 1000
+    permutation_random_state: int = 42
+    permutation_n_jobs: int = 8
 
     def __post_init__(self) -> None:
         """Validate configuration parameters (full no-op when disabled)."""
@@ -958,6 +983,33 @@ class PredictionConfig:
                         f"{path_attr} must resolve to an existing file when "
                         f"predictor_source='blup', got {path_value!r}"
                     )
+
+        # The 3 permutation-related fields below are only ever consumed by
+        # VisualizePredictionStep -- validated only when visualize=True, so
+        # an enabled=True/visualize=False run (prediction alone, no
+        # permutation/figures) never rejects values it will never use.
+        if self.visualize:
+            if self.n_permutations <= 0:
+                raise ValueError(
+                    f"n_permutations must be positive when visualize=True, "
+                    f"got {self.n_permutations}"
+                )
+            if not isinstance(self.permutation_n_jobs, int) or (
+                self.permutation_n_jobs <= 0
+            ):
+                raise ValueError(
+                    f"permutation_n_jobs must be a positive int when "
+                    f"visualize=True, got {self.permutation_n_jobs!r}"
+                )
+            if (
+                not isinstance(self.permutation_random_state, int)
+                or isinstance(self.permutation_random_state, bool)
+                or self.permutation_random_state < 0
+            ):
+                raise ValueError(
+                    f"permutation_random_state must be a non-negative int "
+                    f"when visualize=True, got {self.permutation_random_state!r}"
+                )
 
 
 @dataclass(frozen=True)
@@ -1186,6 +1238,20 @@ class CrossPlatformConfig:
                     f"must match correlation_method '{self.correlation_method}' "
                     f"(expected '{expected_p_col}')"
                 )
+
+        # visualize=True only ever makes sense when enabled=True --
+        # VisualizePredictionStep reads PredictCrossPlatformStep's (task 6's)
+        # output, which never runs when enabled=False. This lives here, not
+        # in PredictionConfig.__post_init__, because that method's own
+        # `if not self.enabled: return` short-circuit (Decision 4) would
+        # otherwise skip this check entirely for exactly the combination it
+        # needs to reject (Tier 4, #200, design.md Decision 7).
+        if self.prediction.visualize and not self.prediction.enabled:
+            raise ValueError(
+                "prediction.visualize=True requires prediction.enabled=True "
+                "-- VisualizePredictionStep reads PredictCrossPlatformStep's "
+                "output, which never runs when enabled=False"
+            )
 
         # Cross-check prediction.platform_pairs against this config's own
         # exp1_name/exp2_name (Decision 3) -- PredictionConfig alone has no

--- a/src/sleap_roots_analyze/pipeline/config/components.py
+++ b/src/sleap_roots_analyze/pipeline/config/components.py
@@ -989,13 +989,19 @@ class PredictionConfig:
         # an enabled=True/visualize=False run (prediction alone, no
         # permutation/figures) never rejects values it will never use.
         if self.visualize:
-            if self.n_permutations <= 0:
+            if (
+                not isinstance(self.n_permutations, int)
+                or isinstance(self.n_permutations, bool)
+                or self.n_permutations <= 0
+            ):
                 raise ValueError(
-                    f"n_permutations must be positive when visualize=True, "
-                    f"got {self.n_permutations}"
+                    f"n_permutations must be a positive int when visualize=True, "
+                    f"got {self.n_permutations!r}"
                 )
-            if not isinstance(self.permutation_n_jobs, int) or (
-                self.permutation_n_jobs <= 0
+            if (
+                not isinstance(self.permutation_n_jobs, int)
+                or isinstance(self.permutation_n_jobs, bool)
+                or self.permutation_n_jobs <= 0
             ):
                 raise ValueError(
                     f"permutation_n_jobs must be a positive int when "

--- a/src/sleap_roots_analyze/pipeline/pipelines/cross_platform_pipeline.py
+++ b/src/sleap_roots_analyze/pipeline/pipelines/cross_platform_pipeline.py
@@ -33,6 +33,9 @@ from sleap_roots_analyze.pipeline.steps.visualize_cross_platform import (
 from sleap_roots_analyze.pipeline.steps.predict_cross_platform import (
     PredictCrossPlatformStep,
 )
+from sleap_roots_analyze.pipeline.steps.visualize_prediction import (
+    VisualizePredictionStep,
+)
 
 
 class CrossPlatformPipeline(BasePipeline):
@@ -45,6 +48,7 @@ class CrossPlatformPipeline(BasePipeline):
     4. Trait-level binomial enrichment (optional, config-gated)
     5. Generate visualizations of correlations
     6. Predict cross-platform genotype values via LOGO-CV (optional, config-gated)
+    7. Visualize prediction via permutation null + figure (optional, config-gated)
 
     The pipeline is designed to compare traits across different experimental
     platforms or conditions to identify which traits capture similar biological
@@ -100,7 +104,7 @@ class CrossPlatformPipeline(BasePipeline):
         return sanitized
 
     def create_tasks(self) -> List[Task]:
-        """Create the cross-platform analysis task graph with 5 or 6 steps.
+        """Create the cross-platform analysis task graph with 5-7 steps.
 
         Returns:
             List of Tasks defining the pipeline DAG:
@@ -112,6 +116,9 @@ class CrossPlatformPipeline(BasePipeline):
                 - Step 6: PredictCrossPlatform (optional, based on
                   config.prediction.enabled -- entirely absent, not merely
                   skipped, when disabled)
+                - Step 7: VisualizePrediction (optional, based on
+                  config.prediction.visualize -- entirely absent, not merely
+                  skipped, when disabled; Tier 4, #200)
         """
         tasks = []
 
@@ -180,6 +187,20 @@ class CrossPlatformPipeline(BasePipeline):
                         "05_visualize_cross_platform",
                     ],
                     description="Predict cross-platform genotype values via LOGO-CV",
+                )
+            )
+
+        # Step 7: Visualize prediction via permutation null + figure (Tier 4,
+        # #200; optional, config-gated; entirely absent -- not merely
+        # skipped -- when disabled). depends_on task 6 for both data AND
+        # ordering (unlike task 6's own ordering-only second dependency).
+        if self.config.prediction.visualize:
+            tasks.append(
+                Task(
+                    func=self._run_visualize_prediction,
+                    name="07_visualize_prediction",
+                    depends_on=["06_predict_cross_platform"],
+                    description="Permutation-null significance test + prediction figure",
                 )
             )
 
@@ -268,6 +289,27 @@ class CrossPlatformPipeline(BasePipeline):
         prev_task_result = kwargs["01_load_cross_platform_data"]
         prev_step_result = prev_task_result.data
         step = PredictCrossPlatformStep()
+        result = step.execute(
+            data=prev_step_result.data,
+            config=config,
+            run_dir=run_dir,
+            prev_result=prev_step_result,
+        )
+        return result
+
+    def _run_visualize_prediction(
+        self, config: Any, run_dir: Path, logger: Any, **kwargs: Any
+    ) -> StepResult:
+        """Execute Step 7: Visualize Prediction (optional, Tier 4, #200).
+
+        Reads task 6's data AND depends on it for ordering -- unlike task
+        6's own ordering-only second dependency (Decision 15), this step
+        genuinely reads task 6's ``predictor_matrices`` and observed results.
+        """
+        logger.info("Step 7/7: Visualizing prediction (permutation null + figure)...")
+        prev_task_result = kwargs["06_predict_cross_platform"]
+        prev_step_result = prev_task_result.data
+        step = VisualizePredictionStep()
         result = step.execute(
             data=prev_step_result.data,
             config=config,

--- a/src/sleap_roots_analyze/pipeline/steps/predict_cross_platform.py
+++ b/src/sleap_roots_analyze/pipeline/steps/predict_cross_platform.py
@@ -277,6 +277,21 @@ class PredictCrossPlatformStep(BaseStep):
             "target_dropped_columns": target_dropped_columns,
         }
 
+        # Additive extension (Tier 4, #200, design.md Decision 6): expose the
+        # already-computed predictor matrices for VisualizePredictionStep to
+        # reuse, rather than rebuilding BLUP-loading/NaN-dropping/alignment
+        # logic (Decisions 2/13/14/16/17) a second time. Safe as a sibling
+        # key alongside the per-method entries above only because no valid
+        # reduction_method/comparison_methods value can itself equal
+        # "predictor_matrices" -- both are constrained to
+        # _VALID_REDUCTION_METHODS-equivalent values in PredictionConfig.
+        results_by_method["predictor_matrices"] = {
+            "source_clean": source_clean,
+            "target_clean": target_clean,
+            "source_representative_names": list(source_representative_names),
+            "target_representatives": list(target_representatives),
+        }
+
         return StepResult(
             data=results_by_method,
             metadata=metadata,

--- a/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
+++ b/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
@@ -1,0 +1,120 @@
+"""Step: Visualize cross-platform prediction via permutation null + figure (Tier 4, #200)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from sklearn.preprocessing import StandardScaler
+
+from sleap_roots_analyze.cross_platform_prediction import permutation_test
+from sleap_roots_analyze.pca import fit_pca
+from sleap_roots_analyze.pipeline.core import BaseStep, StepResult
+
+
+class VisualizePredictionStep(BaseStep):
+    """Compute a permutation-null significance test and a summary figure per pair.
+
+    Optional 7th step on ``CrossPlatformPipeline``, entirely absent from
+    ``create_tasks()`` when ``config.prediction.visualize=False``.
+    ``depends_on=["06_predict_cross_platform"]`` for both data *and*
+    ordering (unlike task 6's own ordering-only second dependency on task 5,
+    Tier 3.5 Decision 15) -- this step genuinely reads task 6's
+    ``predictor_matrices`` and observed results.
+
+    Reuses task 6's already-computed ``source_clean``/``target_clean``
+    matrices and ``source_representative_names``/``target_representatives``
+    (``StepResult.data["predictor_matrices"]``, Tier 4 Decision 6) rather
+    than rebuilding BLUP-loading/NaN-dropping/alignment logic a second time.
+    The PC1 target's ground-truth values are recomputed identically to task
+    6's own computation (a fixed, deterministic ``fit_pca(...,
+    random_state=42)`` call on the same ``target_clean`` matrix) --
+    cross-checked by this step's own wiring tests, which assert this
+    recomputation exactly reproduces task 6's reported PC1 result.
+    """
+
+    def __init__(self) -> None:
+        """Initialize VisualizePredictionStep."""
+        super().__init__(
+            step_name="VisualizePrediction",
+            description="Permutation-null significance test + prediction figure",
+        )
+
+    def execute(
+        self,
+        data: Any,
+        config: Any,
+        run_dir: Path,
+        prev_result: Optional[StepResult] = None,
+    ) -> StepResult:
+        """Execute the visualize-prediction step.
+
+        Args:
+            data: Task 6's (``PredictCrossPlatformStep``) result data dict --
+                ``{method: {...}, "predictor_matrices": {...}}``.
+            config: CrossPlatformConfig with a populated ``prediction`` field
+                (``visualize=True``).
+            run_dir: Directory to save permutation JSON + figure outputs.
+            prev_result: Task 6's StepResult -- read for data and ordering
+                (this step's dependency, unlike task 6's own, is not
+                ordering-only).
+
+        Returns:
+            StepResult holding one ``PermutationTestResult`` per
+            ``(method, target_name)`` combination (Sections 7b/7c extend this
+            into the final JSON/figure output).
+        """
+        pcfg = config.prediction
+        predictor_matrices = data["predictor_matrices"]
+        source_clean = predictor_matrices["source_clean"]
+        target_clean = predictor_matrices["target_clean"]
+        source_representative_names = list(
+            predictor_matrices["source_representative_names"]
+        )
+        target_representatives = list(predictor_matrices["target_representatives"])
+
+        genotypes = list(source_clean.index)
+
+        # PC1-as-target: recomputed identically to task 6's own computation
+        # (whole-dataset ground truth, not a per-fold predictor reduction --
+        # Tier 3.5 Decision 6/12). Cross-checked by this step's own wiring
+        # tests against task 6's already-reported PC1 result.
+        _, pc1_transformed = fit_pca(
+            StandardScaler().fit_transform(target_clean.to_numpy()),
+            n_components=1,
+            random_state=42,
+        )
+        pc1_values = pc1_transformed.ravel()
+
+        # Canonical enumeration order: methods first ([reduction_method] +
+        # comparison_methods), then target_names in task 6's own
+        # CrossPlatformPredictionResult.predictions order (representative
+        # traits, then "PC1" last).
+        target_names = list(target_representatives) + ["PC1"]
+        target_y = {
+            name: target_clean[name].to_numpy() for name in target_representatives
+        }
+        target_y["PC1"] = pc1_values
+
+        methods = [pcfg.reduction_method] + list(pcfg.comparison_methods)
+
+        results_by_method: Dict[str, Dict[str, Any]] = {
+            method: {} for method in methods
+        }
+        for method in methods:
+            for target_name in target_names:
+                results_by_method[method][target_name] = permutation_test(
+                    X=source_clean,
+                    y=target_y[target_name],
+                    genotypes=genotypes,
+                    reduction_method=method,
+                    representative_names=(
+                        source_representative_names
+                        if method == "representatives"
+                        else None
+                    ),
+                    n_permutations=pcfg.n_permutations,
+                    random_state=pcfg.permutation_random_state,
+                )
+
+        return StepResult(data=results_by_method, metadata={}, files_generated=[])

--- a/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
+++ b/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 import numpy as np
 from joblib import Parallel, delayed
@@ -12,6 +12,11 @@ from sklearn.preprocessing import StandardScaler
 from sleap_roots_analyze.cross_platform_prediction import permutation_test
 from sleap_roots_analyze.pca import fit_pca
 from sleap_roots_analyze.pipeline.core import BaseStep, StepResult
+from sleap_roots_analyze.result_types import (
+    CrossPlatformPermutationResult,
+    TargetPrediction,
+)
+from sleap_roots_analyze.visualize_prediction import create_prediction_figure
 
 
 class VisualizePredictionStep(BaseStep):
@@ -128,15 +133,57 @@ class VisualizePredictionStep(BaseStep):
         # Parallelizes across independent (target, method) units, not across
         # individual permutation calls -- empirically measured slower than
         # serial at this workload's per-call cost (design.md Decision 4).
+        # joblib.Parallel(backend="loky") fails fast on the first worker
+        # exception, so collecting every result here before writing any
+        # output file below is a correct, simple all-or-nothing
+        # partial-failure contract -- no additional engineering needed.
         dispatched = Parallel(n_jobs=pcfg.permutation_n_jobs, backend="loky")(
             delayed(_run_unit)(method, target_name, seed)
             for (method, target_name), seed in zip(combinations, child_seeds)
         )
 
-        results_by_method: Dict[str, Dict[str, Any]] = {
+        permutation_test_results_by_method: Dict[str, Dict[str, Any]] = {
             method: {} for method in methods
         }
         for method, target_name, result in dispatched:
-            results_by_method[method][target_name] = result
+            permutation_test_results_by_method[method][target_name] = result
 
-        return StepResult(data=results_by_method, metadata={}, files_generated=[])
+        source_platform = prev_result.metadata["source_platform"]
+        target_platform = prev_result.metadata["target_platform"]
+
+        files_generated: List[Path] = []
+        results_by_method: Dict[str, Any] = {}
+        cp_results_by_method: Dict[str, CrossPlatformPermutationResult] = {}
+        for method in methods:
+            cp_result = CrossPlatformPermutationResult.from_permutation_test_results(
+                source_platform=source_platform,
+                target_platform=target_platform,
+                reduction_method=method,
+                permutation_test_results=permutation_test_results_by_method[method],
+            )
+            output_path = run_dir / f"07_permutation_{method}.json"
+            output_path.write_text(cp_result.to_json(indent=2))
+            files_generated.append(output_path)
+            results_by_method[method] = cp_result.to_dict()
+            cp_results_by_method[method] = cp_result
+
+        # Figure uses only the primary reduction_method's results (design.md
+        # Decision 9), built from task 6's observed CrossPlatformPredictionResult
+        # (for the PC1 obs-vs-pred scatter) and this step's own permutation
+        # results for the same method (for the R^2 violin / top-quartile bar).
+        primary_method = pcfg.reduction_method
+        target_predictions = [
+            TargetPrediction(**target_dict)
+            for target_dict in data[primary_method]["predictions"]
+        ]
+        fig = create_prediction_figure(
+            target_predictions=target_predictions,
+            permutation_results=cp_results_by_method[primary_method].predictions,
+        )
+        figure_path = run_dir / "07_prediction_figure.png"
+        fig.savefig(figure_path, dpi=300, bbox_inches="tight")
+        files_generated.append(figure_path)
+
+        return StepResult(
+            data=results_by_method, metadata={}, files_generated=files_generated
+        )

--- a/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
+++ b/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
@@ -1,10 +1,19 @@
-"""Step: Visualize cross-platform prediction via permutation null + figure (Tier 4, #200)."""
+"""Step: Visualize cross-platform prediction via permutation null + figure (Tier 4, #200).
+
+Naming note: this module shares its basename with
+``sleap_roots_analyze.visualize_prediction`` (a different module, in a
+different subpackage -- that one holds ``create_prediction_figure()`` and
+the other pure plotting helpers this step calls; this module holds only the
+pipeline-step wiring/orchestration). Full import paths never collide. See
+that module's own docstring for the same cross-reference.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import matplotlib.pyplot as plt
 import numpy as np
 from joblib import Parallel, delayed
 from sklearn.preprocessing import StandardScaler
@@ -182,6 +191,7 @@ class VisualizePredictionStep(BaseStep):
         )
         figure_path = run_dir / "07_prediction_figure.png"
         fig.savefig(figure_path, dpi=300, bbox_inches="tight")
+        plt.close(fig)
         files_generated.append(figure_path)
 
         return StepResult(

--- a/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
+++ b/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
@@ -18,7 +18,10 @@ import numpy as np
 from joblib import Parallel, delayed
 from sklearn.preprocessing import StandardScaler
 
-from sleap_roots_analyze.cross_platform_prediction import permutation_test
+from sleap_roots_analyze.cross_platform_prediction import (
+    PermutationTestResult,
+    permutation_test,
+)
 from sleap_roots_analyze.pca import fit_pca
 from sleap_roots_analyze.pipeline.core import BaseStep, StepResult
 from sleap_roots_analyze.result_types import (
@@ -80,6 +83,13 @@ class VisualizePredictionStep(BaseStep):
             ``(method, target_name)`` combination (Sections 7b/7c extend this
             into the final JSON/figure output).
         """
+        if prev_result is None:
+            raise ValueError(
+                "prev_result (task 6's StepResult) is required -- "
+                "VisualizePredictionStep reads its metadata "
+                "(source_platform/target_platform)"
+            )
+
         pcfg = config.prediction
         predictor_matrices = data["predictor_matrices"]
         source_clean = predictor_matrices["source_clean"]
@@ -125,7 +135,9 @@ class VisualizePredictionStep(BaseStep):
         seed_sequence = np.random.SeedSequence(pcfg.permutation_random_state)
         child_seeds = seed_sequence.spawn(len(combinations))
 
-        def _run_unit(method: str, target_name: str, seed: np.random.SeedSequence):
+        def _run_unit(
+            method: str, target_name: str, seed: np.random.SeedSequence
+        ) -> tuple[str, str, PermutationTestResult]:
             result = permutation_test(
                 X=source_clean,
                 y=target_y[target_name],

--- a/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
+++ b/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Dict, Optional
 
+import numpy as np
+from joblib import Parallel, delayed
 from sklearn.preprocessing import StandardScaler
 
 from sleap_roots_analyze.cross_platform_prediction import permutation_test
@@ -97,24 +99,44 @@ class VisualizePredictionStep(BaseStep):
         target_y["PC1"] = pc1_values
 
         methods = [pcfg.reduction_method] + list(pcfg.comparison_methods)
+        combinations = [
+            (method, target_name) for method in methods for target_name in target_names
+        ]
+
+        # Independent seed per (target, method) combination (design.md
+        # Decision 4, found during round 1's review): reusing one shared
+        # seed for every combination would correlate, not independently
+        # sample, the null draws the pooled violin panel (Section 6) later
+        # combines across targets.
+        seed_sequence = np.random.SeedSequence(pcfg.permutation_random_state)
+        child_seeds = seed_sequence.spawn(len(combinations))
+
+        def _run_unit(method: str, target_name: str, seed: np.random.SeedSequence):
+            result = permutation_test(
+                X=source_clean,
+                y=target_y[target_name],
+                genotypes=genotypes,
+                reduction_method=method,
+                representative_names=(
+                    source_representative_names if method == "representatives" else None
+                ),
+                n_permutations=pcfg.n_permutations,
+                random_state=seed,
+            )
+            return method, target_name, result
+
+        # Parallelizes across independent (target, method) units, not across
+        # individual permutation calls -- empirically measured slower than
+        # serial at this workload's per-call cost (design.md Decision 4).
+        dispatched = Parallel(n_jobs=pcfg.permutation_n_jobs, backend="loky")(
+            delayed(_run_unit)(method, target_name, seed)
+            for (method, target_name), seed in zip(combinations, child_seeds)
+        )
 
         results_by_method: Dict[str, Dict[str, Any]] = {
             method: {} for method in methods
         }
-        for method in methods:
-            for target_name in target_names:
-                results_by_method[method][target_name] = permutation_test(
-                    X=source_clean,
-                    y=target_y[target_name],
-                    genotypes=genotypes,
-                    reduction_method=method,
-                    representative_names=(
-                        source_representative_names
-                        if method == "representatives"
-                        else None
-                    ),
-                    n_permutations=pcfg.n_permutations,
-                    random_state=pcfg.permutation_random_state,
-                )
+        for method, target_name, result in dispatched:
+            results_by_method[method][target_name] = result
 
         return StepResult(data=results_by_method, metadata={}, files_generated=[])

--- a/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
+++ b/src/sleap_roots_analyze/pipeline/steps/visualize_prediction.py
@@ -202,8 +202,10 @@ class VisualizePredictionStep(BaseStep):
             permutation_results=cp_results_by_method[primary_method].predictions,
         )
         figure_path = run_dir / "07_prediction_figure.png"
-        fig.savefig(figure_path, dpi=300, bbox_inches="tight")
-        plt.close(fig)
+        try:
+            fig.savefig(figure_path, dpi=300, bbox_inches="tight")
+        finally:
+            plt.close(fig)
         files_generated.append(figure_path)
 
         return StepResult(

--- a/src/sleap_roots_analyze/result_types.py
+++ b/src/sleap_roots_analyze/result_types.py
@@ -1095,3 +1095,165 @@ class CrossPlatformPredictionResult:
             reduction_method=reduction_method,
             predictions=predictions,
         )
+
+
+@dataclass(frozen=True)
+class PermutationResult:
+    """JSON-serializable permutation-null significance test for one prediction target.
+
+    One entry per prediction target within a
+    :class:`CrossPlatformPermutationResult` run (Tier 4, #200). Kept
+    **separate** from (not nested inside) :class:`TargetPrediction` --
+    permutation is an optional, substantially heavier concern than the
+    observed-result computation it wraps (design.md Decision 3).
+
+    Attributes:
+        target_name: Name of the predicted target -- a representative trait
+            name, or ``"PC1"``.
+        observed_r2: Aggregate R^2 from one ``logo_cv_predict()`` call on the
+            real (unshuffled) ``y``.
+        observed_rmse: Aggregate RMSE from the same observed call.
+        observed_spearman_rho: Aggregate Spearman rho from the same observed
+            call.
+        observed_top_quartile_recovery: ``top_quartile_recovery()`` computed
+            from the same observed call's predictions.
+        null_r2: R^2 for each of ``n_permutations`` shuffled-``y`` calls.
+        null_rmse: RMSE for each shuffled-``y`` call.
+        null_spearman_rho: Spearman rho for each shuffled-``y`` call.
+        null_top_quartile_recovery: ``top_quartile_recovery()`` for each
+            shuffled-``y`` call, using that permutation's own shuffled ``y``
+            as ground truth (not the original, unshuffled ``y``).
+        p_value_r2: One-sided p-value, right-tailed (higher R^2 is better):
+            ``(count(null_r2 >= observed_r2) + 1) / (n_permutations + 1)``.
+        p_value_rmse: One-sided p-value, **left-tailed** (lower RMSE is
+            better -- the opposite convention from R^2/rho):
+            ``(count(null_rmse <= observed_rmse) + 1) / (n_permutations + 1)``.
+            Do not read a low ``p_value_rmse`` as indicating a bad fit.
+        p_value_spearman_rho: One-sided p-value, right-tailed, same formula
+            as ``p_value_r2``.
+        n_permutations: Number of permutations run (length of every
+            ``null_*`` list).
+    """
+
+    target_name: str
+    observed_r2: float
+    observed_rmse: float
+    observed_spearman_rho: float
+    observed_top_quartile_recovery: float
+    null_r2: list[float]
+    null_rmse: list[float]
+    null_spearman_rho: list[float]
+    null_top_quartile_recovery: list[float]
+    p_value_r2: float
+    p_value_rmse: float
+    p_value_spearman_rho: float
+    n_permutations: int
+
+
+@dataclass(frozen=True)
+class CrossPlatformPermutationResult:
+    """JSON-serializable view of a cross-platform permutation-null test run.
+
+    Mirrors :class:`CrossPlatformPredictionResult`'s shape and
+    ``to_dict()``/``to_json()`` convention exactly, but is a new, independent
+    dataclass (Tier 4, #200) -- not new fields grafted onto
+    :class:`CrossPlatformPredictionResult`/:class:`TargetPrediction` (design.md
+    Decision 3). Holds one instance per (platform pair, reduction method)
+    combination; a nested :class:`PermutationResult` list covers every
+    prediction target.
+
+    Attributes:
+        source_platform: Name of the platform whose genotype effects are the
+            predictor.
+        target_platform: Name of the platform whose genotype effects are
+            being predicted.
+        reduction_method: The dimensionality-reduction method used for this
+            run (``"pls_latent"``, ``"representatives"``, or ``"pc1"``).
+        predictions: One :class:`PermutationResult` per prediction target.
+    """
+
+    source_platform: str
+    target_platform: str
+    reduction_method: str
+    predictions: list[PermutationResult] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a plain ``dict`` view via :func:`dataclasses.asdict`."""
+        return dataclasses.asdict(self)
+
+    def to_json(self, **kwargs: Any) -> str:
+        """Serialize to a strict-JSON string, enforcing the finite-floats contract.
+
+        Defaults to ``allow_nan=False`` so a non-finite value raises a
+        ``ValueError`` here rather than emitting the non-standard tokens a
+        strict JSON consumer (e.g. bloom-mcp) rejects. Extra keyword
+        arguments are forwarded to :func:`json.dumps`.
+
+        Raises:
+            ValueError: If any float field is non-finite (under the default
+                ``allow_nan=False``).
+        """
+        kwargs.setdefault("allow_nan", False)
+        return json.dumps(self.to_dict(), **kwargs)
+
+    @classmethod
+    def from_permutation_test_results(
+        cls,
+        *,
+        source_platform: str,
+        target_platform: str,
+        reduction_method: str,
+        permutation_test_results: dict[str, Any],
+    ) -> "CrossPlatformPermutationResult":
+        """Build a :class:`CrossPlatformPermutationResult` from permutation_test outputs.
+
+        Accepts any object exposing ``observed_r2``/``observed_rmse``/
+        ``observed_spearman_rho``/``observed_top_quartile_recovery``,
+        ``null_r2``/``null_rmse``/``null_spearman_rho``/
+        ``null_top_quartile_recovery``, ``p_value_r2``/``p_value_rmse``/
+        ``p_value_spearman_rho``, and ``n_permutations`` attributes
+        (duck-typed to ``cross_platform_prediction.permutation_test()``'s
+        return value without importing it -- this module imports nothing
+        from the analytical modules, keeping dependencies one-way). Does not
+        mutate its inputs.
+
+        Args:
+            source_platform: Name of the predictor platform.
+            target_platform: Name of the predicted platform.
+            reduction_method: The reduction method used for this run.
+            permutation_test_results: Mapping of target name (a
+                representative trait name, or ``"PC1"``) to its
+                ``permutation_test()`` result object.
+
+        Returns:
+            A frozen :class:`CrossPlatformPermutationResult` holding only
+            JSON-serializable science.
+        """
+        predictions = [
+            PermutationResult(
+                target_name=str(target_name),
+                observed_r2=float(result.observed_r2),
+                observed_rmse=float(result.observed_rmse),
+                observed_spearman_rho=float(result.observed_spearman_rho),
+                observed_top_quartile_recovery=float(
+                    result.observed_top_quartile_recovery
+                ),
+                null_r2=[float(v) for v in result.null_r2],
+                null_rmse=[float(v) for v in result.null_rmse],
+                null_spearman_rho=[float(v) for v in result.null_spearman_rho],
+                null_top_quartile_recovery=[
+                    float(v) for v in result.null_top_quartile_recovery
+                ],
+                p_value_r2=float(result.p_value_r2),
+                p_value_rmse=float(result.p_value_rmse),
+                p_value_spearman_rho=float(result.p_value_spearman_rho),
+                n_permutations=int(result.n_permutations),
+            )
+            for target_name, result in permutation_test_results.items()
+        ]
+        return cls(
+            source_platform=source_platform,
+            target_platform=target_platform,
+            reduction_method=reduction_method,
+            predictions=predictions,
+        )

--- a/src/sleap_roots_analyze/visualize_prediction.py
+++ b/src/sleap_roots_analyze/visualize_prediction.py
@@ -43,13 +43,23 @@ def _pc1_scatter_panel(
 def _r2_violin_panel(
     ax: plt.Axes, permutation_results: Sequence[PermutationResult]
 ) -> None:
-    """Panel 2: every target's observed R^2 vs. the pooled all-targets null R^2."""
+    """Panel 2: every target's observed R^2 vs. the pooled all-targets null R^2.
+
+    Pooling every target's null distribution into one violin assumes every
+    target within a pair shares the same genotype count -- true here because
+    all targets are drawn from one shared, already-column-filtered
+    ``target_clean`` matrix (see ``predict_cross_platform.py``'s
+    ``dropna(axis=1, how="any")``, which never changes the row/genotype
+    count).
+    """
     pooled_null_r2 = np.concatenate(
         [np.asarray(pr.null_r2, dtype=float) for pr in permutation_results]
     )
     observed_r2 = [pr.observed_r2 for pr in permutation_results]
 
     ax.violinplot([pooled_null_r2], positions=[1], showmedians=True)
+    # Seed is jitter-only (horizontal scatter position for readability) --
+    # does not affect any reported statistic.
     rng = np.random.default_rng(0)
     x_jitter = 1 + rng.uniform(-0.05, 0.05, size=len(observed_r2))
     ax.scatter(x_jitter, observed_r2, color=_OBSERVED_COLOR, zorder=3, label="Observed")

--- a/src/sleap_roots_analyze/visualize_prediction.py
+++ b/src/sleap_roots_analyze/visualize_prediction.py
@@ -134,8 +134,16 @@ def create_prediction_figure(
         raise ValueError("permutation_results must be non-empty")
 
     fig, axes = plt.subplots(1, 3, figsize=figsize)
-    _pc1_scatter_panel(axes[0], target_predictions)
-    _r2_violin_panel(axes[1], permutation_results)
-    _top_quartile_bar_panel(axes[2], permutation_results)
+    try:
+        _pc1_scatter_panel(axes[0], target_predictions)
+        _r2_violin_panel(axes[1], permutation_results)
+        _top_quartile_bar_panel(axes[2], permutation_results)
+    except Exception:
+        # _pc1_scatter_panel's missing-"PC1" ValueError fires after
+        # plt.subplots() has already allocated `fig` -- close it here so a
+        # raised panel error never leaks a figure (round-2 /review-pr on PR
+        # #201, Behavioural Correctness).
+        plt.close(fig)
+        raise
     fig.tight_layout()
     return fig

--- a/src/sleap_roots_analyze/visualize_prediction.py
+++ b/src/sleap_roots_analyze/visualize_prediction.py
@@ -1,0 +1,131 @@
+"""Prediction/permutation figure content: 3-panel plotting functions (Tier 4, #200).
+
+Parallel to ``cross_experiment_analysis.py``'s home for
+``create_correlation_summary_plot`` etc. -- plotting logic as plain,
+independently-testable functions returning a ``matplotlib.Figure``, no file
+I/O. ``pipeline/steps/visualize_prediction.py`` (a different module, despite
+the shared basename -- see proposal.md's naming-collision note) is the only
+caller that saves the returned figure to disk.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from sleap_roots_analyze.result_types import PermutationResult, TargetPrediction
+
+_OBSERVED_COLOR = "#2E6E73"
+_NULL_COLOR = "#B0B0B0"
+
+
+def _pc1_scatter_panel(
+    ax: plt.Axes, target_predictions: Sequence[TargetPrediction]
+) -> None:
+    """Panel 1: observed-vs-predicted scatter, PC1 target only."""
+    pc1 = next((tp for tp in target_predictions if tp.target_name == "PC1"), None)
+    if pc1 is None:
+        raise ValueError(
+            "target_predictions must include a target named 'PC1' for the "
+            "obs-vs-pred scatter panel"
+        )
+    ax.scatter(pc1.y_true, pc1.y_pred, color=_OBSERVED_COLOR, alpha=0.8, zorder=2)
+    combined = list(pc1.y_true) + list(pc1.y_pred)
+    lo, hi = min(combined), max(combined)
+    ax.plot([lo, hi], [lo, hi], color="gray", linestyle="--", linewidth=1, alpha=0.6)
+    ax.set_xlabel("Observed PC1")
+    ax.set_ylabel("Predicted PC1 (LOGO-CV)")
+    ax.set_title("Observed vs. Predicted (PC1)")
+
+
+def _r2_violin_panel(
+    ax: plt.Axes, permutation_results: Sequence[PermutationResult]
+) -> None:
+    """Panel 2: every target's observed R^2 vs. the pooled all-targets null R^2."""
+    pooled_null_r2 = np.concatenate(
+        [np.asarray(pr.null_r2, dtype=float) for pr in permutation_results]
+    )
+    observed_r2 = [pr.observed_r2 for pr in permutation_results]
+
+    ax.violinplot([pooled_null_r2], positions=[1], showmedians=True)
+    rng = np.random.default_rng(0)
+    x_jitter = 1 + rng.uniform(-0.05, 0.05, size=len(observed_r2))
+    ax.scatter(x_jitter, observed_r2, color=_OBSERVED_COLOR, zorder=3, label="Observed")
+    ax.set_xticks([1])
+    ax.set_xticklabels(["All targets"])
+    ax.set_ylabel("R^2")
+    ax.set_title("Observed R^2 vs. Permutation Null")
+    ax.legend(loc="best", fontsize="small")
+
+
+def _top_quartile_bar_panel(
+    ax: plt.Axes, permutation_results: Sequence[PermutationResult]
+) -> None:
+    """Panel 3: mean observed vs. mean null top-quartile recovery, across all targets."""
+    mean_observed = float(
+        np.mean([pr.observed_top_quartile_recovery for pr in permutation_results])
+    )
+    pooled_null = np.concatenate(
+        [
+            np.asarray(pr.null_top_quartile_recovery, dtype=float)
+            for pr in permutation_results
+        ]
+    )
+    mean_null = float(np.mean(pooled_null))
+    ax.bar(
+        ["Observed", "Null"],
+        [mean_observed, mean_null],
+        color=[_OBSERVED_COLOR, _NULL_COLOR],
+    )
+    ax.set_ylabel("Mean top-quartile recovery")
+    ax.set_title("Top-Quartile Recovery: Observed vs. Null")
+
+
+def create_prediction_figure(
+    target_predictions: Sequence[TargetPrediction],
+    permutation_results: Sequence[PermutationResult],
+    figsize: tuple = (18, 6),
+) -> plt.Figure:
+    """Build the 3-panel prediction/permutation summary figure for one directed pair.
+
+    Uses only the primary ``reduction_method``'s results (design.md Decision
+    9) -- callers pass the primary method's observed
+    ``CrossPlatformPredictionResult.predictions`` and
+    ``CrossPlatformPermutationResult.predictions``, not any
+    ``comparison_methods`` entry.
+
+    Args:
+        target_predictions: The primary method's observed per-target
+            predictions (Tier 3.5's ``TargetPrediction``, from
+            ``CrossPlatformPredictionResult.predictions``) -- must include
+            one entry named ``"PC1"``, used for panel 1's scatter.
+        permutation_results: The primary method's per-target permutation
+            results (``PermutationResult``, from
+            ``CrossPlatformPermutationResult.predictions``) -- used for
+            panels 2 and 3, pooling every target's null distribution.
+        figsize: Figure size as ``(width, height)``.
+
+    Returns:
+        A 3-panel ``matplotlib.Figure``: (1) observed-vs-predicted scatter
+        (PC1 only), (2) observed R^2 per target vs. pooled all-targets null
+        R^2 violin, (3) mean observed vs. mean null top-quartile recovery bar
+        chart.
+
+    Raises:
+        ValueError: If ``target_predictions`` or ``permutation_results`` is
+            empty, or if no target named ``"PC1"`` is present in
+            ``target_predictions``.
+    """
+    if not target_predictions:
+        raise ValueError("target_predictions must be non-empty")
+    if not permutation_results:
+        raise ValueError("permutation_results must be non-empty")
+
+    fig, axes = plt.subplots(1, 3, figsize=figsize)
+    _pc1_scatter_panel(axes[0], target_predictions)
+    _r2_violin_panel(axes[1], permutation_results)
+    _top_quartile_bar_panel(axes[2], permutation_results)
+    fig.tight_layout()
+    return fig

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4381,6 +4381,32 @@ def cross_platform_planted_signal_fixture():
     return [_make_planted_signal_realization(19, 3, 0.8, seed) for seed in range(1, 21)]
 
 
+def _make_pure_noise_realization(n_genotypes, n_traits, seed):
+    """Build one pure-noise LOGO-CV realization: X and y independently drawn.
+
+    Factored out (Tier 4, #200) so both ``cross_platform_pure_noise_fixture``
+    and the K-S calibration fixture below can share the exact same generation
+    logic at different seed offsets/realization counts, and so a module-scoped
+    test fixture can call it directly without a pytest function-scope
+    mismatch.
+
+    Args:
+        n_genotypes: Number of genotypes (rows).
+        n_traits: Number of predictor traits (columns).
+        seed: Seed for ``np.random.default_rng``.
+
+    Returns:
+        tuple[pd.DataFrame, np.ndarray, list[str]]: ``(X, y, genotypes)``.
+    """
+    rng = np.random.default_rng(seed)
+    genotypes = [f"geno_{i:02d}" for i in range(n_genotypes)]
+    trait_names = [f"trait_{j}" for j in range(n_traits)]
+    X = rng.standard_normal((n_genotypes, n_traits))
+    y = rng.standard_normal(n_genotypes)
+    X_df = pd.DataFrame(X, index=genotypes, columns=trait_names)
+    return X_df, y, genotypes
+
+
 @pytest.fixture
 def cross_platform_pure_noise_fixture():
     """20 independent pure-noise LOGO-CV realizations (n=19, p=3 traits).
@@ -4396,17 +4422,7 @@ def cross_platform_pure_noise_fixture():
         list[tuple[pd.DataFrame, np.ndarray, list[str]]]: 20 ``(X, y,
         genotypes)`` realizations.
     """
-    realizations = []
-    for seed in range(1, 21):
-        rng = np.random.default_rng(seed + 10000)
-        n_genotypes, n_traits = 19, 3
-        genotypes = [f"geno_{i:02d}" for i in range(n_genotypes)]
-        trait_names = [f"trait_{j}" for j in range(n_traits)]
-        X = rng.standard_normal((n_genotypes, n_traits))
-        y = rng.standard_normal(n_genotypes)
-        X_df = pd.DataFrame(X, index=genotypes, columns=trait_names)
-        realizations.append((X_df, y, genotypes))
-    return realizations
+    return [_make_pure_noise_realization(19, 3, seed + 10000) for seed in range(1, 21)]
 
 
 @pytest.fixture
@@ -4458,14 +4474,4 @@ def cross_platform_permutation_calibration_fixture():
         list[tuple[pd.DataFrame, np.ndarray, list[str]]]: 40 ``(X, y,
         genotypes)`` realizations, seeds 1..40 (offset +30000).
     """
-    realizations = []
-    for seed in range(1, 41):
-        rng = np.random.default_rng(seed + 30000)
-        n_genotypes, n_traits = 19, 3
-        genotypes = [f"geno_{i:02d}" for i in range(n_genotypes)]
-        trait_names = [f"trait_{j}" for j in range(n_traits)]
-        X = rng.standard_normal((n_genotypes, n_traits))
-        y = rng.standard_normal(n_genotypes)
-        X_df = pd.DataFrame(X, index=genotypes, columns=trait_names)
-        realizations.append((X_df, y, genotypes))
-    return realizations
+    return [_make_pure_noise_realization(19, 3, seed + 30000) for seed in range(1, 41)]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4427,3 +4427,45 @@ def cross_platform_synthetic_non_edpie_fixture():
         _make_planted_signal_realization(25, 4, 0.8, seed + 20000)
         for seed in range(1, 21)
     ]
+
+
+# ============================================================================
+# PERMUTATION-TEST CALIBRATION FIXTURES (Tier 4, #200)
+# ============================================================================
+# K-S calibration oracle substrate (design.md Decision 11 / tasks.md 1.2):
+# exactly 40 independent pure-noise realizations, each with a fixed, committed
+# literal seed (not regenerated per test run) so the K-S-against-Uniform(0,1)
+# test is a deterministic golden check, not a live stochastic draw with an
+# intrinsic false-failure rate. Uses a seed offset of +30000 to guarantee
+# independence from the signal/noise/non-EDPIE fixtures above (offsets 0,
+# +10000, +20000). Same (n_genotypes=19, n_traits=3) shape as the primary
+# signal/noise fixtures -- this program's real scale.
+
+
+@pytest.fixture
+def cross_platform_permutation_calibration_fixture():
+    """40 independent pure-noise realizations for the K-S calibration oracle.
+
+    ``X`` and ``y`` are independently drawn with no planted relationship, at
+    this program's real (n_genotypes=19, n_traits=3) scale. Distinct from
+    ``cross_platform_pure_noise_fixture`` (20 realizations, seed offset
+    +10000) -- this fixture is exactly 40 realizations (seed offset +30000),
+    sized for the K-S calibration oracle's own statistical-power needs
+    (tasks.md 1.2/9.1), not the mean-R^2 comparison the 20-realization
+    fixtures are used for.
+
+    Returns:
+        list[tuple[pd.DataFrame, np.ndarray, list[str]]]: 40 ``(X, y,
+        genotypes)`` realizations, seeds 1..40 (offset +30000).
+    """
+    realizations = []
+    for seed in range(1, 41):
+        rng = np.random.default_rng(seed + 30000)
+        n_genotypes, n_traits = 19, 3
+        genotypes = [f"geno_{i:02d}" for i in range(n_genotypes)]
+        trait_names = [f"trait_{j}" for j in range(n_traits)]
+        X = rng.standard_normal((n_genotypes, n_traits))
+        y = rng.standard_normal(n_genotypes)
+        X_df = pd.DataFrame(X, index=genotypes, columns=trait_names)
+        realizations.append((X_df, y, genotypes))
+    return realizations

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4443,35 +4443,3 @@ def cross_platform_synthetic_non_edpie_fixture():
         _make_planted_signal_realization(25, 4, 0.8, seed + 20000)
         for seed in range(1, 21)
     ]
-
-
-# ============================================================================
-# PERMUTATION-TEST CALIBRATION FIXTURES (Tier 4, #200)
-# ============================================================================
-# K-S calibration oracle substrate (design.md Decision 11 / tasks.md 1.2):
-# exactly 40 independent pure-noise realizations, each with a fixed, committed
-# literal seed (not regenerated per test run) so the K-S-against-Uniform(0,1)
-# test is a deterministic golden check, not a live stochastic draw with an
-# intrinsic false-failure rate. Uses a seed offset of +30000 to guarantee
-# independence from the signal/noise/non-EDPIE fixtures above (offsets 0,
-# +10000, +20000). Same (n_genotypes=19, n_traits=3) shape as the primary
-# signal/noise fixtures -- this program's real scale.
-
-
-@pytest.fixture
-def cross_platform_permutation_calibration_fixture():
-    """40 independent pure-noise realizations for the K-S calibration oracle.
-
-    ``X`` and ``y`` are independently drawn with no planted relationship, at
-    this program's real (n_genotypes=19, n_traits=3) scale. Distinct from
-    ``cross_platform_pure_noise_fixture`` (20 realizations, seed offset
-    +10000) -- this fixture is exactly 40 realizations (seed offset +30000),
-    sized for the K-S calibration oracle's own statistical-power needs
-    (tasks.md 1.2/9.1), not the mean-R^2 comparison the 20-realization
-    fixtures are used for.
-
-    Returns:
-        list[tuple[pd.DataFrame, np.ndarray, list[str]]]: 40 ``(X, y,
-        genotypes)`` realizations, seeds 1..40 (offset +30000).
-    """
-    return [_make_pure_noise_realization(19, 3, seed + 30000) for seed in range(1, 41)]

--- a/tests/fixtures/harness/cross_platform/cross_platform_prediction_wiring_visualize.yaml
+++ b/tests/fixtures/harness/cross_platform/cross_platform_prediction_wiring_visualize.yaml
@@ -1,0 +1,39 @@
+# Tier 4 (add-prediction-permutation-and-figure, #200) CI-fast wiring fixture.
+#
+# Extends cross_platform_prediction_wiring.yaml (Tier 3.5's own wiring fixture)
+# with prediction.visualize=true and the 3 new permutation fields, for
+# VisualizePredictionStep wiring-correctness tests (Sections 6-8) -- not a
+# statistical-signal-recovery claim, see tasks.md Section 1.3. n_permutations
+# is kept small (20) to stay CI-fast at this fixture's tiny (19-genotype,
+# 3-trait) scale; permutation_n_jobs=1 is the wiring-test default (see the
+# mocking-across-process-boundary note at the top of tasks.md Section 7a) --
+# individual tests override n_jobs on the loaded config object directly
+# (PredictionConfig is a plain, non-frozen dataclass) when they need to
+# exercise real joblib.Parallel dispatch.
+
+exp1_data_path: tests/fixtures/synthetic/cross_platform_prediction/source_blup.csv
+exp1_name: SourcePlatform
+exp1_genotype_col: Genotype
+exp2_data_path: tests/fixtures/synthetic/cross_platform_prediction/target_blup.csv
+exp2_name: TargetPlatform
+exp2_genotype_col: Genotype
+correlation_method: spearman
+min_samples_per_genotype: 1
+trait_reduction_method: none
+
+prediction:
+  enabled: true
+  predictor_source: blup
+  reduction_method: pls_latent
+  comparison_methods:
+    - representatives
+  representative_selection_metric: variance
+  platform_pairs:
+    - source: SourcePlatform
+      target: TargetPlatform
+  source_blup_path: tests/fixtures/synthetic/cross_platform_prediction/source_blup.csv
+  target_blup_path: tests/fixtures/synthetic/cross_platform_prediction/target_blup.csv
+  visualize: true
+  n_permutations: 20
+  permutation_random_state: 42
+  permutation_n_jobs: 1

--- a/tests/reproducibility_cases.py
+++ b/tests/reproducibility_cases.py
@@ -20,6 +20,7 @@ import pandas as pd
 
 from sleap_roots_analyze import (
     clustering,
+    cross_platform_prediction,
     outlier_detection,
     outlier_removal,
     pca,
@@ -167,6 +168,28 @@ def _compare_remove_outlier_samples(a, b):
     (df_b, report_b) = b
     _exact(report_a["outlier_indices"], report_b["outlier_indices"], "outlier_indices")
     pd.testing.assert_frame_equal(df_a, df_b)
+
+
+def _compare_permutation_test(a, b):
+    """Compare ``permutation_test`` results: observed_*/null_*/p_value_*/n_permutations."""
+    for field in (
+        "observed_r2",
+        "observed_rmse",
+        "observed_spearman_rho",
+        "observed_top_quartile_recovery",
+        "p_value_r2",
+        "p_value_rmse",
+        "p_value_spearman_rho",
+    ):
+        _close(getattr(a, field), getattr(b, field), field)
+    for field in (
+        "null_r2",
+        "null_rmse",
+        "null_spearman_rho",
+        "null_top_quartile_recovery",
+    ):
+        _close(getattr(a, field), getattr(b, field), field)
+    assert a.n_permutations == b.n_permutations
 
 
 def _silence(fn):
@@ -336,6 +359,26 @@ CASES: List[Case] = [
             lambda: outlier_removal.remove_outlier_samples(ctx.df, random_state=seed)
         ),
         _compare_remove_outlier_samples,
+    ),
+    Case(
+        # Tier 4 (#200). y is a plain synthetic function of ctx.X (not one of
+        # its own columns) -- this sweep only checks bit-for-bit determinism
+        # given the same seed, not a scientific claim. n_permutations kept
+        # small (5) to bound this case's cost: it runs 3 times total (twice
+        # for the same-seed check, once for the random_state=None check),
+        # each a 60-genotype LOGO-CV loop x (1 observed + 5 permutations).
+        cross_platform_prediction.permutation_test,
+        lambda ctx, seed: _silence(
+            lambda: cross_platform_prediction.permutation_test(
+                X=ctx.df,
+                y=ctx.X.sum(axis=1),
+                genotypes=[f"g{i}" for i in range(len(ctx.df))],
+                reduction_method="pls_latent",
+                n_permutations=5,
+                random_state=seed,
+            )
+        ),
+        _compare_permutation_test,
     ),
 ]
 

--- a/tests/test_cli_cross_platform_prediction.py
+++ b/tests/test_cli_cross_platform_prediction.py
@@ -44,3 +44,32 @@ def test_cli_cross_platform_dry_run_omits_prediction_step_when_disabled(runner):
         "VisualizeCrossPlatform",
     ):
         assert step_name in result.output
+
+
+# =============================================================================
+# Tier 4 (add-prediction-permutation-and-figure, #200), tasks.md 8.4/8.5 --
+# --dry-run listing for VisualizePredictionStep (7th step).
+# =============================================================================
+
+
+def test_cli_cross_platform_dry_run_lists_visualize_prediction_step_when_enabled(
+    runner,
+):
+    """--dry-run lists a 7th step when prediction.visualize=True (tasks.md 8.4)."""
+    config_path = HARNESS_DIR / "cross_platform_prediction_wiring_visualize.yaml"
+
+    result = runner.invoke(cli, ["cross-platform", str(config_path), "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "VisualizePrediction" in result.output
+
+
+def test_cli_cross_platform_dry_run_omits_it_when_disabled(runner):
+    """--dry-run has exactly the existing 6 steps when visualize=False (tasks.md 8.4)."""
+    config_path = HARNESS_DIR / "cross_platform_prediction_wiring.yaml"
+
+    result = runner.invoke(cli, ["cross-platform", str(config_path), "--dry-run"])
+
+    assert result.exit_code == 0
+    assert "VisualizePrediction" not in result.output
+    assert "PredictCrossPlatform" in result.output

--- a/tests/test_cross_platform_config.py
+++ b/tests/test_cross_platform_config.py
@@ -781,11 +781,54 @@ def test_prediction_config_rejects_non_positive_n_permutations_when_visualize_tr
         )
 
 
+@pytest.mark.parametrize("n_permutations", [True, "not_an_int", 1.5])
+def test_prediction_config_rejects_non_int_n_permutations_when_visualize_true(
+    n_permutations,
+):
+    """A non-int n_permutations (incl. bool) raises ValueError when visualize=True.
+
+    Found during pre-merge self-review: unlike its sibling permutation_n_jobs/
+    permutation_random_state fields, n_permutations previously had no
+    isinstance check at all, so e.g. n_permutations=True would silently pass
+    (bool is an int subclass in Python).
+    """
+    from sleap_roots_analyze.pipeline.config.components import PredictionConfig
+
+    with pytest.raises(ValueError, match="n_permutations"):
+        PredictionConfig(
+            enabled=True,
+            predictor_source="genotype_means",
+            visualize=True,
+            n_permutations=n_permutations,
+        )
+
+
 @pytest.mark.parametrize("permutation_n_jobs", [0, -1])
 def test_prediction_config_rejects_non_positive_permutation_n_jobs_when_visualize_true(
     permutation_n_jobs,
 ):
     """permutation_n_jobs<=0 raises ValueError naming the field (tasks.md 4.4a)."""
+    from sleap_roots_analyze.pipeline.config.components import PredictionConfig
+
+    with pytest.raises(ValueError, match="permutation_n_jobs"):
+        PredictionConfig(
+            enabled=True,
+            predictor_source="genotype_means",
+            visualize=True,
+            permutation_n_jobs=permutation_n_jobs,
+        )
+
+
+@pytest.mark.parametrize("permutation_n_jobs", [True, "not_an_int", 1.5])
+def test_prediction_config_rejects_non_int_permutation_n_jobs_when_visualize_true(
+    permutation_n_jobs,
+):
+    """A non-int permutation_n_jobs (incl. bool) raises ValueError when visualize=True.
+
+    Found during pre-merge self-review: permutation_n_jobs=True previously
+    passed silently (bool is an int subclass), unlike the sibling
+    permutation_random_state field, which already excluded bool explicitly.
+    """
     from sleap_roots_analyze.pipeline.config.components import PredictionConfig
 
     with pytest.raises(ValueError, match="permutation_n_jobs"):

--- a/tests/test_cross_platform_config.py
+++ b/tests/test_cross_platform_config.py
@@ -706,3 +706,108 @@ def test_cross_platform_config_rejects_prediction_when_exp_names_are_equal():
                 platform_pairs=[{"source": "SamePlatform", "target": "SamePlatform"}],
             ),
         )
+
+
+# =============================================================================
+# Tier 4 (add-prediction-permutation-and-figure, #200): PredictionConfig's 4
+# new fields (visualize, n_permutations, permutation_random_state,
+# permutation_n_jobs) and the visualize-requires-enabled cross-check.
+# See design.md Decision 7 and tasks.md Section 4.
+# =============================================================================
+
+
+def test_prediction_config_visualize_defaults_to_false_and_no_op():
+    """PredictionConfig() defaults (tasks.md 4.1) construct without raising."""
+    from sleap_roots_analyze.pipeline.config.components import PredictionConfig
+
+    config = PredictionConfig()
+    assert config.visualize is False
+    assert config.n_permutations == 1000
+    assert config.permutation_random_state == 42
+    assert config.permutation_n_jobs == 8
+
+
+def test_cross_platform_config_rejects_visualize_true_with_enabled_false():
+    """visualize=True with enabled=False raises ValueError at construction (tasks.md 4.2)."""
+    from sleap_roots_analyze.pipeline.config.components import (
+        CrossPlatformConfig,
+        PredictionConfig,
+    )
+
+    with pytest.raises(ValueError, match="visualize"):
+        CrossPlatformConfig(
+            exp1_data_path="exp1.csv",
+            exp1_name="Exp1",
+            exp1_genotype_col="geno1",
+            exp2_data_path="exp2.csv",
+            exp2_name="Exp2",
+            exp2_genotype_col="geno2",
+            prediction=PredictionConfig(enabled=False, visualize=True),
+        )
+
+
+def test_prediction_config_permutation_fields_validation_skipped_when_visualize_false():
+    """No permutation-field validation runs when visualize=False (tasks.md 4.3)."""
+    from sleap_roots_analyze.pipeline.config.components import PredictionConfig
+
+    # All 3 permutation-related fields are simultaneously invalid; none of it
+    # should raise because visualize=False short-circuits their validation.
+    config = PredictionConfig(
+        enabled=True,
+        predictor_source="genotype_means",
+        visualize=False,
+        n_permutations=0,
+        permutation_n_jobs=0,
+        permutation_random_state=-1,
+    )
+    assert config.n_permutations == 0
+    assert config.permutation_n_jobs == 0
+    assert config.permutation_random_state == -1
+
+
+@pytest.mark.parametrize("n_permutations", [0, -1])
+def test_prediction_config_rejects_non_positive_n_permutations_when_visualize_true(
+    n_permutations,
+):
+    """n_permutations<=0 raises ValueError only when visualize=True (tasks.md 4.4)."""
+    from sleap_roots_analyze.pipeline.config.components import PredictionConfig
+
+    with pytest.raises(ValueError, match="n_permutations"):
+        PredictionConfig(
+            enabled=True,
+            predictor_source="genotype_means",
+            visualize=True,
+            n_permutations=n_permutations,
+        )
+
+
+@pytest.mark.parametrize("permutation_n_jobs", [0, -1])
+def test_prediction_config_rejects_non_positive_permutation_n_jobs_when_visualize_true(
+    permutation_n_jobs,
+):
+    """permutation_n_jobs<=0 raises ValueError naming the field (tasks.md 4.4a)."""
+    from sleap_roots_analyze.pipeline.config.components import PredictionConfig
+
+    with pytest.raises(ValueError, match="permutation_n_jobs"):
+        PredictionConfig(
+            enabled=True,
+            predictor_source="genotype_means",
+            visualize=True,
+            permutation_n_jobs=permutation_n_jobs,
+        )
+
+
+@pytest.mark.parametrize("permutation_random_state", [-1, "not_an_int"])
+def test_prediction_config_rejects_invalid_permutation_random_state_when_visualize_true(
+    permutation_random_state,
+):
+    """An invalid permutation_random_state raises ValueError naming the field (tasks.md 4.4b)."""
+    from sleap_roots_analyze.pipeline.config.components import PredictionConfig
+
+    with pytest.raises(ValueError, match="permutation_random_state"):
+        PredictionConfig(
+            enabled=True,
+            predictor_source="genotype_means",
+            visualize=True,
+            permutation_random_state=permutation_random_state,
+        )

--- a/tests/test_cross_platform_prediction.py
+++ b/tests/test_cross_platform_prediction.py
@@ -24,9 +24,14 @@ from sleap_roots_analyze.cross_platform_prediction import (
     LOGOCVResult,
     fit_pca_on_fold,
     logo_cv_predict,
+    permutation_test,
     top_quartile_recovery,
 )
-from sleap_roots_analyze.result_types import CrossPlatformPredictionResult
+from sleap_roots_analyze.result_types import (
+    CrossPlatformPredictionResult,
+    CrossPlatformPermutationResult,
+    PermutationResult,
+)
 
 
 class TestFitPcaOnFold:
@@ -932,6 +937,583 @@ class TestCrossPlatformPredictionResult:
         assert by_name["trait_a"].r2 in all_r2
 
 
+class TestPermutationTest:
+    """Tests for permutation_test() (design.md Decisions 1/4, tasks.md 2.5-2.14)."""
+
+    def test_permutation_test_observed_matches_direct_logo_cv_predict_call(self):
+        """observed_* fields exactly match an independent logo_cv_predict() call."""
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=8, seed=1)
+        result = permutation_test(
+            X,
+            y,
+            genotypes,
+            reduction_method="representatives",
+            representative_names=rep_names,
+            n_permutations=3,
+            random_state=0,
+        )
+        direct = logo_cv_predict(
+            X,
+            y,
+            genotypes,
+            reduction_method="representatives",
+            representative_names=rep_names,
+        )
+        assert result.observed_r2 == pytest.approx(direct.r2)
+        assert result.observed_rmse == pytest.approx(direct.rmse)
+        assert result.observed_spearman_rho == pytest.approx(direct.spearman_rho)
+        assert result.observed_top_quartile_recovery == pytest.approx(
+            top_quartile_recovery(direct.y_true, direct.y_pred)
+        )
+
+    def test_permutation_test_null_distributions_have_length_n_permutations(self):
+        """null_r2/rmse/spearman_rho/top_quartile_recovery each have length N."""
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=8, seed=2)
+        result = permutation_test(
+            X,
+            y,
+            genotypes,
+            reduction_method="representatives",
+            representative_names=rep_names,
+            n_permutations=5,
+            random_state=0,
+        )
+        assert len(result.null_r2) == 5
+        assert len(result.null_rmse) == 5
+        assert len(result.null_spearman_rho) == 5
+        assert len(result.null_top_quartile_recovery) == 5
+
+    def test_permutation_test_shuffles_y_not_x_or_genotypes(self):
+        """Each logo_cv_predict call's X/genotypes are unchanged; only y differs."""
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=8, seed=3)
+        calls = []
+        original = logo_cv_predict
+
+        def spy(*args, **kwargs):
+            X_arg = args[0] if len(args) > 0 else kwargs["X"]
+            y_arg = args[1] if len(args) > 1 else kwargs["y"]
+            genotypes_arg = args[2] if len(args) > 2 else kwargs["genotypes"]
+            calls.append((X_arg, np.asarray(y_arg).copy(), list(genotypes_arg)))
+            return original(*args, **kwargs)
+
+        with patch(
+            "sleap_roots_analyze.cross_platform_prediction.logo_cv_predict",
+            side_effect=spy,
+        ):
+            permutation_test(
+                X,
+                y,
+                genotypes,
+                reduction_method="representatives",
+                representative_names=rep_names,
+                n_permutations=4,
+                random_state=0,
+            )
+
+        assert len(calls) == 1 + 4  # 1 observed call + 4 permutation calls
+        for X_arg, _y_arg, genotypes_arg in calls:
+            pd.testing.assert_frame_equal(X_arg, X)
+            assert genotypes_arg == list(genotypes)
+        permutation_ys = [y_arg for _, y_arg, _ in calls[1:]]
+        assert any(not np.array_equal(py, np.asarray(y)) for py in permutation_ys)
+
+    def test_permutation_test_deterministic_given_same_random_state(self):
+        """Two calls with identical args (incl. random_state) give bit-identical nulls.
+
+        Parametrized inline (not via @pytest.mark.parametrize) over random_state
+        being a plain int and a numpy.random.SeedSequence instance -- both must
+        work, since VisualizePredictionStep (Section 7) passes SeedSequence
+        children, not raw ints.
+        """
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=8, seed=5)
+        for random_state_factory in (lambda: 7, lambda: np.random.SeedSequence(7)):
+            r1 = permutation_test(
+                X,
+                y,
+                genotypes,
+                reduction_method="representatives",
+                representative_names=rep_names,
+                n_permutations=5,
+                random_state=random_state_factory(),
+            )
+            r2 = permutation_test(
+                X,
+                y,
+                genotypes,
+                reduction_method="representatives",
+                representative_names=rep_names,
+                n_permutations=5,
+                random_state=random_state_factory(),
+            )
+            np.testing.assert_array_equal(r1.null_r2, r2.null_r2)
+            np.testing.assert_array_equal(r1.null_rmse, r2.null_rmse)
+
+    def test_permutation_test_different_random_state_differs(self):
+        """Two calls differing only in random_state produce different null_r2."""
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=8, seed=4)
+        r1 = permutation_test(
+            X,
+            y,
+            genotypes,
+            reduction_method="representatives",
+            representative_names=rep_names,
+            n_permutations=5,
+            random_state=1,
+        )
+        r2 = permutation_test(
+            X,
+            y,
+            genotypes,
+            reduction_method="representatives",
+            representative_names=rep_names,
+            n_permutations=5,
+            random_state=2,
+        )
+        assert not np.array_equal(r1.null_r2, r2.null_r2)
+
+    def test_permutation_test_null_top_quartile_recovery_uses_shuffled_y_as_truth(self):
+        """The null top-quartile-recovery uses that permutation's shuffled y as truth."""
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=8, seed=6)
+        captured = {}
+        original = logo_cv_predict
+
+        def spy(*args, **kwargs):
+            result = original(*args, **kwargs)
+            y_arg = args[1] if len(args) > 1 else kwargs["y"]
+            if not np.array_equal(np.asarray(y_arg), np.asarray(y)):
+                captured["y_shuffled"] = np.asarray(y_arg).copy()
+                captured["y_pred"] = result.y_pred.copy()
+            return result
+
+        with patch(
+            "sleap_roots_analyze.cross_platform_prediction.logo_cv_predict",
+            side_effect=spy,
+        ):
+            result = permutation_test(
+                X,
+                y,
+                genotypes,
+                reduction_method="representatives",
+                representative_names=rep_names,
+                n_permutations=1,
+                random_state=1,
+            )
+
+        expected_shuffled_truth = top_quartile_recovery(
+            captured["y_shuffled"], captured["y_pred"]
+        )
+        expected_original_truth = top_quartile_recovery(
+            np.asarray(y), captured["y_pred"]
+        )
+        # Sanity: the two hypotheses actually differ for this fixture/seed --
+        # otherwise this test wouldn't discriminate between them.
+        assert expected_shuffled_truth != pytest.approx(expected_original_truth)
+        assert result.null_top_quartile_recovery[0] == pytest.approx(
+            expected_shuffled_truth
+        )
+
+    def test_permutation_test_p_value_formula_r2_and_rho(self):
+        """p_value_r2/p_value_spearman_rho use the right-tail (higher is better) formula."""
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=4, seed=20)
+        genotypes = list(genotypes)
+        y_pred_fixture = np.array([1.1, 2.1, 2.9, 3.9])
+
+        def _mock_result(r2, rmse, spearman_rho):
+            return LOGOCVResult(
+                genotypes=genotypes,
+                y_true=np.asarray(y, dtype=float),
+                y_pred=y_pred_fixture,
+                r2=r2,
+                rmse=rmse,
+                spearman_rho=spearman_rho,
+                spearman_p=0.1,
+            )
+
+        # index 0 = observed; 1-4 = the 4 permutations.
+        mock_results = [
+            _mock_result(r2=0.5, rmse=1.0, spearman_rho=0.3),
+            _mock_result(r2=0.6, rmse=0.8, spearman_rho=0.5),
+            _mock_result(r2=0.4, rmse=1.2, spearman_rho=0.1),
+            _mock_result(r2=0.5, rmse=1.0, spearman_rho=0.3),  # tie w/ observed
+            _mock_result(r2=0.9, rmse=1.5, spearman_rho=0.9),
+        ]
+        call_count = [0]
+
+        def side_effect(*args, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            return mock_results[idx]
+
+        with patch(
+            "sleap_roots_analyze.cross_platform_prediction.logo_cv_predict",
+            side_effect=side_effect,
+        ):
+            result = permutation_test(
+                X,
+                y,
+                genotypes,
+                reduction_method="representatives",
+                representative_names=rep_names,
+                n_permutations=4,
+                random_state=0,
+            )
+
+        # null_r2 = [0.6, 0.4, 0.5, 0.9], observed_r2=0.5 -> count(>=0.5)=3 -> (3+1)/5.
+        assert result.p_value_r2 == pytest.approx(0.8)
+        # null_spearman_rho = [0.5, 0.1, 0.3, 0.9], observed=0.3 -> count(>=0.3)=3 -> (3+1)/5.
+        assert result.p_value_spearman_rho == pytest.approx(0.8)
+
+    def test_permutation_test_p_value_formula_rmse(self):
+        """p_value_rmse uses the opposite (left-tail, lower is better) formula."""
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=4, seed=21)
+        genotypes = list(genotypes)
+        y_pred_fixture = np.array([1.1, 2.1, 2.9, 3.9])
+
+        def _mock_result(r2, rmse, spearman_rho):
+            return LOGOCVResult(
+                genotypes=genotypes,
+                y_true=np.asarray(y, dtype=float),
+                y_pred=y_pred_fixture,
+                r2=r2,
+                rmse=rmse,
+                spearman_rho=spearman_rho,
+                spearman_p=0.1,
+            )
+
+        mock_results = [
+            _mock_result(r2=0.5, rmse=1.0, spearman_rho=0.3),  # observed
+            _mock_result(r2=0.6, rmse=0.8, spearman_rho=0.5),
+            _mock_result(r2=0.4, rmse=1.2, spearman_rho=0.1),
+            _mock_result(r2=0.5, rmse=1.0, spearman_rho=0.3),  # tie w/ observed
+            _mock_result(r2=0.9, rmse=1.5, spearman_rho=0.9),
+        ]
+        call_count = [0]
+
+        def side_effect(*args, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            return mock_results[idx]
+
+        with patch(
+            "sleap_roots_analyze.cross_platform_prediction.logo_cv_predict",
+            side_effect=side_effect,
+        ):
+            result = permutation_test(
+                X,
+                y,
+                genotypes,
+                reduction_method="representatives",
+                representative_names=rep_names,
+                n_permutations=4,
+                random_state=0,
+            )
+
+        # null_rmse = [0.8, 1.2, 1.0, 1.5], observed_rmse=1.0 -> count(<=1.0)=2 -> (2+1)/5.
+        assert result.p_value_rmse == pytest.approx(0.6)
+
+    @pytest.mark.parametrize("n_permutations", [0, -1])
+    def test_permutation_test_rejects_non_positive_n_permutations(self, n_permutations):
+        """n_permutations=0 or -1 raises ValueError before any logo_cv_predict call."""
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=8, seed=7)
+        with patch(
+            "sleap_roots_analyze.cross_platform_prediction.logo_cv_predict"
+        ) as mock_logo_cv:
+            with pytest.raises(ValueError, match="n_permutations"):
+                permutation_test(
+                    X,
+                    y,
+                    genotypes,
+                    reduction_method="representatives",
+                    representative_names=rep_names,
+                    n_permutations=n_permutations,
+                    random_state=0,
+                )
+            mock_logo_cv.assert_not_called()
+
+    def test_permutation_test_accepts_n_permutations_equal_1(self):
+        """n_permutations=1 does not raise; nulls have length 1; p-values degenerate."""
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=8, seed=8)
+        result = permutation_test(
+            X,
+            y,
+            genotypes,
+            reduction_method="representatives",
+            representative_names=rep_names,
+            n_permutations=1,
+            random_state=0,
+        )
+        assert len(result.null_r2) == 1
+        assert len(result.null_rmse) == 1
+        assert len(result.null_spearman_rho) == 1
+        assert len(result.null_top_quartile_recovery) == 1
+        assert result.p_value_r2 == pytest.approx(
+            0.5
+        ) or result.p_value_r2 == pytest.approx(1.0)
+        assert result.p_value_rmse == pytest.approx(
+            0.5
+        ) or result.p_value_rmse == pytest.approx(1.0)
+
+    def test_permutation_test_surfaces_logo_cv_predict_validation_errors(self):
+        """An invalid reduction_method raises the same ValueError logo_cv_predict would."""
+        X, y, genotypes, _rep_names = _build_simple_dataset(n_genotypes=8, seed=9)
+        with pytest.raises(ValueError):
+            permutation_test(
+                X, y, genotypes, reduction_method="not_a_real_method", n_permutations=3
+            )
+
+    def test_permutation_test_rejects_non_finite_null_values_with_named_error(self):
+        """A non-finite null value raises ValueError naming the metric and index.
+
+        Raised only after all n_permutations calls complete (fail-fast on the
+        first occurrence was considered and rejected -- see design.md).
+        """
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=8, seed=10)
+        n_permutations = 3
+        call_count = [0]
+        original = logo_cv_predict
+
+        def side_effect(*args, **kwargs):
+            idx = call_count[0]
+            call_count[0] += 1
+            result = original(*args, **kwargs)
+            if (
+                idx == 2
+            ):  # 2nd permutation call (0-based perm index 1; idx 0 = observed)
+                result = LOGOCVResult(
+                    genotypes=result.genotypes,
+                    y_true=result.y_true,
+                    y_pred=result.y_pred,
+                    r2=result.r2,
+                    rmse=result.rmse,
+                    spearman_rho=float("nan"),
+                    spearman_p=result.spearman_p,
+                )
+            return result
+
+        with patch(
+            "sleap_roots_analyze.cross_platform_prediction.logo_cv_predict",
+            side_effect=side_effect,
+        ):
+            with pytest.raises(ValueError) as excinfo:
+                permutation_test(
+                    X,
+                    y,
+                    genotypes,
+                    reduction_method="representatives",
+                    representative_names=rep_names,
+                    n_permutations=n_permutations,
+                    random_state=0,
+                )
+        assert "spearman_rho" in str(excinfo.value)
+        assert "1" in str(
+            excinfo.value
+        )  # 0-based permutation index of the injected failure
+        # Complete-then-report: all n_permutations calls happened before raising.
+        assert call_count[0] == 1 + n_permutations
+
+    def test_permutation_test_rejects_non_finite_observed_values_before_permutations_run(
+        self,
+    ):
+        """A constant y produces a non-finite observed value -- rejected before shuffling."""
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=8, seed=11)
+        constant_y = np.zeros(len(y))
+        with patch(
+            "sleap_roots_analyze.cross_platform_prediction.logo_cv_predict",
+            wraps=logo_cv_predict,
+        ) as mock_logo_cv:
+            with pytest.raises(ValueError, match="spearman_rho"):
+                permutation_test(
+                    X,
+                    constant_y,
+                    genotypes,
+                    reduction_method="representatives",
+                    representative_names=rep_names,
+                    n_permutations=5,
+                    random_state=0,
+                )
+            mock_logo_cv.assert_called_once()  # only the observed call, zero shuffled calls
+
+
+class TestPermutationResultTypes:
+    """Structural tests for PermutationResult/CrossPlatformPermutationResult (tasks.md 3.1-3.3a).
+
+    Dataclass-only tests -- no dependency on ``permutation_test()`` itself
+    (design.md's commit-boundary note: 3.1-3.4 can land before Section 2
+    finishes). The adapter (``from_permutation_test_results``, tasks.md
+    3.5-3.8) is tested separately, after ``permutation_test()`` exists.
+    """
+
+    @staticmethod
+    def _sample_permutation_result(n_permutations=5, target_name="trait_a"):
+        # PermutationResult is documented as a JSON-serializable contract type
+        # (like TargetPrediction) -- its own fields are always native Python
+        # types by construction; float()-casting raw numpy draws here mirrors
+        # what a valid caller (or the from_permutation_test_results adapter)
+        # is responsible for doing before constructing one directly.
+        rng = np.random.default_rng(0)
+        return PermutationResult(
+            target_name=target_name,
+            observed_r2=0.75,
+            observed_rmse=1.2,
+            observed_spearman_rho=0.8,
+            observed_top_quartile_recovery=0.9,
+            null_r2=[float(v) for v in rng.standard_normal(n_permutations)],
+            null_rmse=[float(v) for v in rng.uniform(0.5, 2.0, n_permutations)],
+            null_spearman_rho=[float(v) for v in rng.uniform(-1, 1, n_permutations)],
+            null_top_quartile_recovery=[
+                float(v) for v in rng.uniform(0, 1, n_permutations)
+            ],
+            p_value_r2=0.05,
+            p_value_rmse=0.04,
+            p_value_spearman_rho=0.06,
+            n_permutations=n_permutations,
+        )
+
+    def test_permutation_result_round_trips_through_json_as_native_types(self):
+        """json.dumps(asdict(result)) succeeds; numeric fields are native Python floats."""
+        result = CrossPlatformPermutationResult(
+            source_platform="Turface19",
+            target_platform="Cylinder",
+            reduction_method="pls_latent",
+            predictions=[self._sample_permutation_result()],
+        )
+        round_tripped = json.loads(result.to_json())
+        pred = round_tripped["predictions"][0]
+        for key in (
+            "observed_r2",
+            "observed_rmse",
+            "observed_spearman_rho",
+            "observed_top_quartile_recovery",
+            "p_value_r2",
+            "p_value_rmse",
+            "p_value_spearman_rho",
+        ):
+            assert isinstance(pred[key], float)
+        for key in (
+            "null_r2",
+            "null_rmse",
+            "null_spearman_rho",
+            "null_top_quartile_recovery",
+        ):
+            for v in pred[key]:
+                assert isinstance(v, float)
+
+    def test_permutation_result_null_lists_have_length_n_permutations(self):
+        """Every null_* list has exactly n_permutations elements."""
+        result = self._sample_permutation_result(n_permutations=7)
+        assert len(result.null_r2) == 7
+        assert len(result.null_rmse) == 7
+        assert len(result.null_spearman_rho) == 7
+        assert len(result.null_top_quartile_recovery) == 7
+
+    def test_cross_platform_prediction_result_has_no_permutation_result_field(self):
+        """CrossPlatformPredictionResult/TargetPrediction stay structurally independent."""
+        import dataclasses as dc
+
+        from sleap_roots_analyze.result_types import TargetPrediction
+
+        prediction_result_field_types = {
+            f.type for f in dc.fields(CrossPlatformPredictionResult)
+        }
+        target_prediction_field_types = {f.type for f in dc.fields(TargetPrediction)}
+        for field_type in prediction_result_field_types | target_prediction_field_types:
+            assert "PermutationResult" not in str(field_type)
+
+    def test_permutation_result_has_no_sklearn_or_numpy_object(self):
+        """dataclasses.asdict(result) contains only plain Python lists of float."""
+        import dataclasses as dc
+
+        result = self._sample_permutation_result()
+        as_dict = dc.asdict(result)
+
+        def _walk(obj):
+            if isinstance(obj, dict):
+                for v in obj.values():
+                    yield from _walk(v)
+            elif isinstance(obj, list):
+                for v in obj:
+                    yield from _walk(v)
+            else:
+                yield obj
+
+        for value in _walk(as_dict):
+            assert not isinstance(value, np.ndarray)
+            assert not isinstance(value, np.generic)
+
+    def test_cross_platform_permutation_result_adapter_maps_fields_from_real_output(
+        self,
+    ):
+        """The adapter maps every field from real permutation_test() outputs exactly."""
+        X, y, genotypes, rep_names = _build_simple_dataset(n_genotypes=8, seed=30)
+        X2, y2, genotypes2, rep_names2 = _build_simple_dataset(n_genotypes=8, seed=31)
+        result_a = permutation_test(
+            X,
+            y,
+            genotypes,
+            reduction_method="representatives",
+            representative_names=rep_names,
+            n_permutations=5,
+            random_state=0,
+        )
+        result_b = permutation_test(
+            X2,
+            y2,
+            genotypes2,
+            reduction_method="representatives",
+            representative_names=rep_names2,
+            n_permutations=5,
+            random_state=1,
+        )
+        results = {"trait_a": result_a, "PC1": result_b}
+
+        cp_result = CrossPlatformPermutationResult.from_permutation_test_results(
+            source_platform="Turface19",
+            target_platform="Cylinder",
+            reduction_method="representatives",
+            permutation_test_results=results,
+        )
+
+        assert cp_result.source_platform == "Turface19"
+        assert cp_result.target_platform == "Cylinder"
+        assert cp_result.reduction_method == "representatives"
+        by_name = {p.target_name: p for p in cp_result.predictions}
+        for name, source_result in results.items():
+            mapped = by_name[name]
+            assert mapped.observed_r2 == pytest.approx(source_result.observed_r2)
+            assert mapped.observed_rmse == pytest.approx(source_result.observed_rmse)
+            assert mapped.observed_spearman_rho == pytest.approx(
+                source_result.observed_spearman_rho
+            )
+            assert mapped.observed_top_quartile_recovery == pytest.approx(
+                source_result.observed_top_quartile_recovery
+            )
+            np.testing.assert_allclose(mapped.null_r2, source_result.null_r2)
+            np.testing.assert_allclose(mapped.null_rmse, source_result.null_rmse)
+            np.testing.assert_allclose(
+                mapped.null_spearman_rho, source_result.null_spearman_rho
+            )
+            np.testing.assert_allclose(
+                mapped.null_top_quartile_recovery,
+                source_result.null_top_quartile_recovery,
+            )
+            assert mapped.p_value_r2 == pytest.approx(source_result.p_value_r2)
+            assert mapped.p_value_rmse == pytest.approx(source_result.p_value_rmse)
+            assert mapped.p_value_spearman_rho == pytest.approx(
+                source_result.p_value_spearman_rho
+            )
+            assert mapped.n_permutations == source_result.n_permutations
+
+    def test_permutation_result_types_importable_from_package_root(self):
+        """CrossPlatformPermutationResult/PermutationResult are importable and in __all__."""
+        import sleap_roots_analyze as sra
+
+        assert sra.CrossPlatformPermutationResult is CrossPlatformPermutationResult
+        assert sra.PermutationResult is PermutationResult
+        assert "CrossPlatformPermutationResult" in sra.__all__
+        assert "PermutationResult" in sra.__all__
+        assert len(sra.__all__) == len(set(sra.__all__))
+
+
 class TestPublicApiExport:
     """Public package-root export (mirroring test_blup_result.py's precedent)."""
 
@@ -958,6 +1540,16 @@ class TestPublicApiExport:
         assert sra.logo_cv_predict is module_logo_cv_predict
         assert "fit_pca_on_fold" in sra.__all__
         assert "logo_cv_predict" in sra.__all__
+
+    def test_permutation_test_functions_importable_from_package_root(self):
+        """permutation_test/top_quartile_recovery are importable from the package root."""
+        import sleap_roots_analyze as sra
+
+        assert sra.permutation_test is permutation_test
+        assert sra.top_quartile_recovery is top_quartile_recovery
+        assert "permutation_test" in sra.__all__
+        assert "top_quartile_recovery" in sra.__all__
+        assert len(sra.__all__) == len(set(sra.__all__))
 
     def test_logo_cv_result_importable_from_package_root(self):
         """LOGOCVResult (logo_cv_predict's own return type) is importable and in __all__.

--- a/tests/test_cross_platform_prediction.py
+++ b/tests/test_cross_platform_prediction.py
@@ -1335,44 +1335,116 @@ class TestPermutationTest:
             mock_logo_cv.assert_called_once()  # only the observed call, zero shuffled calls
 
 
+@pytest.fixture(scope="module")
+def _calibration_permutation_results():
+    """permutation_test() on all 40 calibration realizations, computed ONCE.
+
+    Found during CI (not local) runs: the original per-test-method
+    `_permutation_results(...)` recomputation (once per oracle test that
+    shares a fixture) pushed this one file's CI wall time to ~20 minutes on
+    Ubuntu/Windows runners (vs. ~9.5 min measured locally), blowing the
+    30-minute `Tests` job budget together with the rest of the suite.
+    Sharing one computation across every test that uses this fixture (via a
+    module-scoped pytest fixture, calling the plain generator function
+    directly rather than the function-scoped pytest fixture in
+    tests/fixtures.py -- pytest forbids a wider-scoped fixture depending on a
+    narrower-scoped one) cuts the redundant ~2x recomputation for this
+    fixture. Combined with the matching signal/noise fixtures below and a
+    reduced n_permutations=100 (from 200), this brings total logo_cv_predict
+    calls for Section 9 down from ~36,000 to ~8,000.
+    """
+    from tests.fixtures import _make_pure_noise_realization
+
+    realizations = [
+        _make_pure_noise_realization(19, 3, seed + 30000) for seed in range(1, 41)
+    ]
+    return [
+        permutation_test(
+            X,
+            y,
+            genotypes,
+            reduction_method="pls_latent",
+            n_permutations=100,
+            random_state=0,
+        )
+        for X, y, genotypes in realizations
+    ]
+
+
+@pytest.fixture(scope="module")
+def _signal_permutation_results():
+    """permutation_test() on all 20 planted-signal realizations, computed ONCE.
+
+    See `_calibration_permutation_results`'s docstring for why this is
+    module-scoped and shared across every oracle test that uses the signal
+    fixture, instead of each test recomputing it independently.
+    """
+    from tests.fixtures import _make_planted_signal_realization
+
+    realizations = [
+        _make_planted_signal_realization(19, 3, 0.8, seed) for seed in range(1, 21)
+    ]
+    return [
+        permutation_test(
+            X,
+            y,
+            genotypes,
+            reduction_method="pls_latent",
+            n_permutations=100,
+            random_state=0,
+        )
+        for X, y, genotypes in realizations
+    ]
+
+
+@pytest.fixture(scope="module")
+def _noise_permutation_results():
+    """permutation_test() on all 20 pure-noise realizations, computed ONCE.
+
+    See `_calibration_permutation_results`'s docstring for why this is
+    module-scoped and shared across every oracle test that uses the noise
+    fixture, instead of each test recomputing it independently.
+    """
+    from tests.fixtures import _make_pure_noise_realization
+
+    realizations = [
+        _make_pure_noise_realization(19, 3, seed + 10000) for seed in range(1, 21)
+    ]
+    return [
+        permutation_test(
+            X,
+            y,
+            genotypes,
+            reduction_method="pls_latent",
+            n_permutations=100,
+            random_state=0,
+        )
+        for X, y, genotypes in realizations
+    ]
+
+
 class TestPermutationOracles:
     """Oracle tests for permutation_test() (design.md Decision 11, tasks.md Section 9).
 
     Uses the N=20-seed planted-signal/pure-noise fixtures (task 1.1) and the
-    40-realization pure-noise K-S calibration fixture (task 1.2). Every test
-    below states an explicit, CI-fast ``n_permutations=200`` (not the
+    40-realization pure-noise K-S calibration fixture (task 1.2), each
+    computed exactly once per test module (see the module-scoped fixtures
+    above) at an explicit, CI-fast ``n_permutations=100`` (not the
     ``n_permutations=1000`` production default) and a fixed, committed
     literal ``random_state=0``, per the CI-timeout note at the top of
     tasks.md Section 9.
     """
 
-    @staticmethod
-    def _permutation_results(realizations, **kwargs):
-        return [
-            permutation_test(
-                X, y, genotypes, n_permutations=200, random_state=0, **kwargs
-            )
-            for X, y, genotypes in realizations
-        ]
-
     def test_permutation_test_p_values_are_uniform_under_null(
-        self, cross_platform_permutation_calibration_fixture
+        self, _calibration_permutation_results
     ):
-        """K-S calibration oracle: p_value_r2 is uniform under a pure-noise null.
-
-        Empirically measured (this task's implementation): K-S p=0.273 across
-        the 40 fixtures at n_permutations=200, reduction_method="pls_latent".
-        """
-        results = self._permutation_results(
-            cross_platform_permutation_calibration_fixture,
-            reduction_method="pls_latent",
-        )
-        p_values = [r.p_value_r2 for r in results]
+        """K-S calibration oracle: p_value_r2 is uniform under a pure-noise null."""
+        p_values = [r.p_value_r2 for r in _calibration_permutation_results]
         ks_result = kstest(p_values, "uniform")
         assert ks_result.pvalue > 0.05
 
     def test_permutation_test_p_value_rmse_is_uniform_under_null(
-        self, cross_platform_permutation_calibration_fixture
+        self, _calibration_permutation_results
     ):
         """K-S calibration oracle for p_value_rmse -- calibration only, not direction.
 
@@ -1384,92 +1456,85 @@ class TestPermutationOracles:
         ``test_permutation_test_signal_p_value_rmse_reads_as_significant``
         below, not this test, is what actually guards the RMSE direction.
         """
-        results = self._permutation_results(
-            cross_platform_permutation_calibration_fixture,
-            reduction_method="pls_latent",
-        )
-        p_values = [r.p_value_rmse for r in results]
+        p_values = [r.p_value_rmse for r in _calibration_permutation_results]
         ks_result = kstest(p_values, "uniform")
         assert ks_result.pvalue > 0.05
 
     def test_permutation_test_signal_r2_exceeds_its_own_null_median(
-        self, cross_platform_planted_signal_fixture
+        self, _signal_permutation_results
     ):
         """Mean observed R2 across seeds is comfortably above the mean null median.
 
-        Empirically measured: mean observed R2 ~= 0.646, mean null median
-        R2 ~= -0.315 (gap ~= 0.96) at n_permutations=200.
+        Empirically measured (at n_permutations=200; see design.md Decision
+        11 -- the CI oracle above uses a smaller n_permutations=100 for
+        speed): mean observed R2 ~= 0.646, mean null median R2 ~= -0.315
+        (gap ~= 0.96).
         """
-        results = self._permutation_results(
-            cross_platform_planted_signal_fixture, reduction_method="pls_latent"
+        mean_observed = np.mean([r.observed_r2 for r in _signal_permutation_results])
+        mean_null_median = np.mean(
+            [np.median(r.null_r2) for r in _signal_permutation_results]
         )
-        mean_observed = np.mean([r.observed_r2 for r in results])
-        mean_null_median = np.mean([np.median(r.null_r2) for r in results])
         assert mean_observed - mean_null_median > 0.5
 
     def test_permutation_test_signal_p_value_rmse_reads_as_significant(
-        self, cross_platform_planted_signal_fixture
+        self, _signal_permutation_results
     ):
         """A genuinely low-RMSE (good) signal result reads as significant.
 
         Direct regression guard for the RMSE directional-inversion bug found
         during `/review-openspec` round 3 -- the naive R2/rho-style
         right-tail formula would instead produce p_value_rmse ~= 1.0 here.
-        Empirically measured: mean p_value_rmse ~= 0.0085 at
-        n_permutations=200.
+        Empirically measured (at n_permutations=200): mean p_value_rmse
+        ~= 0.0085.
         """
-        results = self._permutation_results(
-            cross_platform_planted_signal_fixture, reduction_method="pls_latent"
+        mean_p_value_rmse = np.mean(
+            [r.p_value_rmse for r in _signal_permutation_results]
         )
-        mean_p_value_rmse = np.mean([r.p_value_rmse for r in results])
         assert mean_p_value_rmse < 0.1
 
     def test_permutation_test_noise_r2_falls_within_its_own_null_band(
-        self, cross_platform_pure_noise_fixture
+        self, _noise_permutation_results
     ):
         """Mean observed R2 (noise) falls within mean-null-median +/- 1 SD.
 
-        Empirically measured: mean observed R2 ~= -0.254, mean null median
-        ~= -0.321, mean null SD ~= 0.213 at n_permutations=200.
+        Empirically measured (at n_permutations=200): mean observed R2
+        ~= -0.254, mean null median ~= -0.321, mean null SD ~= 0.213.
         """
-        results = self._permutation_results(
-            cross_platform_pure_noise_fixture, reduction_method="pls_latent"
+        mean_observed = np.mean([r.observed_r2 for r in _noise_permutation_results])
+        mean_null_median = np.mean(
+            [np.median(r.null_r2) for r in _noise_permutation_results]
         )
-        mean_observed = np.mean([r.observed_r2 for r in results])
-        mean_null_median = np.mean([np.median(r.null_r2) for r in results])
-        mean_null_sd = np.mean([np.std(r.null_r2) for r in results])
+        mean_null_sd = np.mean([np.std(r.null_r2) for r in _noise_permutation_results])
         assert abs(mean_observed - mean_null_median) <= mean_null_sd
 
     def test_permutation_test_top_quartile_recovery_signal_vs_noise(
-        self, cross_platform_planted_signal_fixture, cross_platform_pure_noise_fixture
+        self, _signal_permutation_results, _noise_permutation_results
     ):
         """Signal recovery >=80%; noise recovery close to the empirical null value.
 
-        Spike (tasks.md 9.4a), computed via this same fixture/n_permutations:
-        the pure-noise fixture's actual mean null top-quartile-recovery is
-        ~=0.443 (44.3%) -- cross-checked against the theoretical chance-level
-        baseline 2*q/n = 10/19 ~= 0.526 (design.md Decision 11): close but not
-        identical, since the theoretical value assumes a uniformly random
-        y_pred, while the empirical null instead reflects this fixture's real
+        Spike (tasks.md 9.4a): the pure-noise fixture's actual mean null
+        top-quartile-recovery (computed fresh from this same fixture/run, not
+        a hardcoded literal) is cross-checked against the theoretical
+        chance-level baseline 2*q/n = 10/19 ~= 0.526 (design.md Decision 11):
+        close but not identical (measured ~=0.443 at n_permutations=200),
+        since the theoretical value assumes a uniformly random y_pred, while
+        the empirical null instead reflects this fixture's real
         (correlated-by-construction) predictor structure fed through
-        `logo_cv_predict`. The noise fixture's own *observed* recovery
-        (~=0.45) is, as expected, close to this empirical null (not the
-        theoretical one), not a blindly-pinned "25%".
+        `logo_cv_predict`. The noise fixture's own *observed* recovery is, as
+        expected, close to this empirical null, not a blindly-pinned "25%".
         """
-        signal_results = self._permutation_results(
-            cross_platform_planted_signal_fixture, reduction_method="pls_latent"
-        )
-        noise_results = self._permutation_results(
-            cross_platform_pure_noise_fixture, reduction_method="pls_latent"
-        )
         mean_signal_tqr = np.mean(
-            [r.observed_top_quartile_recovery for r in signal_results]
+            [r.observed_top_quartile_recovery for r in _signal_permutation_results]
         )
         mean_noise_tqr = np.mean(
-            [r.observed_top_quartile_recovery for r in noise_results]
+            [r.observed_top_quartile_recovery for r in _noise_permutation_results]
         )
         empirical_null_tqr = np.mean(
-            [v for r in noise_results for v in r.null_top_quartile_recovery]
+            [
+                v
+                for r in _noise_permutation_results
+                for v in r.null_top_quartile_recovery
+            ]
         )
 
         assert mean_signal_tqr >= 0.8

--- a/tests/test_cross_platform_prediction.py
+++ b/tests/test_cross_platform_prediction.py
@@ -7,6 +7,7 @@ acceptance-criteria oracles this test suite implements against.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -1433,7 +1434,28 @@ class TestPermutationOracles:
     ``n_permutations=1000`` production default) and a fixed, committed
     literal ``random_state=0``, per the CI-timeout note at the top of
     tasks.md Section 9.
+
+    Linux-only in CI (round-2 `/review-pr` on PR #201, Testing/TDD +
+    Performance reviewers): unlike `test_numerical_stability.py`'s
+    single-OS gate, this is a CI-*budget* skip, not a cross-OS numerical
+    incompatibility one -- `permutation_test()` is pure numpy/pandas/sklearn
+    with no OS-dependent code path, so running this class's ~8,000
+    `logo_cv_predict` calls on all 3 CI matrix OSes buys zero additional
+    coverage, only 3x the cost. Windows CI was measured at 28m36s against
+    the `Tests` job's 30-minute timeout with this class running on every
+    platform; Ubuntu had the most headroom (16m51s) of the three, so it is
+    the canonical platform here.
     """
+
+    pytestmark = pytest.mark.skipif(
+        sys.platform != "linux",
+        reason=(
+            "CI-budget-only skip (see class docstring): permutation_test() "
+            "has no OS-dependent code path, so this oracle class runs on "
+            "Linux CI only to keep Windows/macOS Tests jobs under their "
+            "30-minute timeout."
+        ),
+    )
 
     def test_permutation_test_p_values_are_uniform_under_null(
         self, _calibration_permutation_results

--- a/tests/test_cross_platform_prediction.py
+++ b/tests/test_cross_platform_prediction.py
@@ -1707,6 +1707,22 @@ class TestPublicApiExport:
         assert sra.LOGOCVResult is LOGOCVResult
         assert "LOGOCVResult" in sra.__all__
 
+    def test_permutation_test_result_importable_from_package_root(self):
+        """PermutationTestResult (permutation_test's own return type) is importable and in __all__.
+
+        Found during pre-merge self-review: permutation_test was exported but
+        the dataclass it directly returns was not, the same gap round-2
+        review previously caught for logo_cv_predict/LOGOCVResult above.
+        """
+        import sleap_roots_analyze as sra
+        from sleap_roots_analyze.cross_platform_prediction import (
+            PermutationTestResult,
+        )
+
+        assert sra.PermutationTestResult is PermutationTestResult
+        assert "PermutationTestResult" in sra.__all__
+        assert len(sra.__all__) == len(set(sra.__all__))
+
 
 # =============================================================================
 # Tier 4 (add-prediction-permutation-and-figure, #200): permutation_test() /
@@ -1752,6 +1768,19 @@ class TestTopQuartileRecovery:
         assert default_result == pytest.approx(
             top_quartile_recovery(y_true, y_pred, q=1)
         )
+
+    def test_top_quartile_recovery_rejects_default_q_below_n_equals_2(self):
+        """At n=1, even the default q=1 would violate 2*q<=n -- raises, not a silent 1.0.
+
+        Found during pre-merge self-review: max(1, round(n/4)) with n=1 gives
+        q=1, but 2*1=2 > 1, which the explicit-q validation branch would
+        reject -- the default-q branch previously skipped that check
+        entirely, silently returning a vacuous "100% recovery" instead.
+        """
+        y_true = np.array([5.0])
+        y_pred = np.array([3.0])
+        with pytest.raises(ValueError, match="too small"):
+            top_quartile_recovery(y_true, y_pred)
 
     def test_top_quartile_recovery_rejects_explicit_invalid_q(self):
         """An explicit q=0, negative q, or 2*q > len(y_true) raises ValueError."""

--- a/tests/test_cross_platform_prediction.py
+++ b/tests/test_cross_platform_prediction.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 import numpy as np
 import pandas as pd
 import pytest
+from scipy.stats import kstest
 from sklearn.decomposition import PCA
 
 from sklearn.linear_model import Ridge
@@ -1332,6 +1333,148 @@ class TestPermutationTest:
                     random_state=0,
                 )
             mock_logo_cv.assert_called_once()  # only the observed call, zero shuffled calls
+
+
+class TestPermutationOracles:
+    """Oracle tests for permutation_test() (design.md Decision 11, tasks.md Section 9).
+
+    Uses the N=20-seed planted-signal/pure-noise fixtures (task 1.1) and the
+    40-realization pure-noise K-S calibration fixture (task 1.2). Every test
+    below states an explicit, CI-fast ``n_permutations=200`` (not the
+    ``n_permutations=1000`` production default) and a fixed, committed
+    literal ``random_state=0``, per the CI-timeout note at the top of
+    tasks.md Section 9.
+    """
+
+    @staticmethod
+    def _permutation_results(realizations, **kwargs):
+        return [
+            permutation_test(
+                X, y, genotypes, n_permutations=200, random_state=0, **kwargs
+            )
+            for X, y, genotypes in realizations
+        ]
+
+    def test_permutation_test_p_values_are_uniform_under_null(
+        self, cross_platform_permutation_calibration_fixture
+    ):
+        """K-S calibration oracle: p_value_r2 is uniform under a pure-noise null.
+
+        Empirically measured (this task's implementation): K-S p=0.273 across
+        the 40 fixtures at n_permutations=200, reduction_method="pls_latent".
+        """
+        results = self._permutation_results(
+            cross_platform_permutation_calibration_fixture,
+            reduction_method="pls_latent",
+        )
+        p_values = [r.p_value_r2 for r in results]
+        ks_result = kstest(p_values, "uniform")
+        assert ks_result.pvalue > 0.05
+
+    def test_permutation_test_p_value_rmse_is_uniform_under_null(
+        self, cross_platform_permutation_calibration_fixture
+    ):
+        """K-S calibration oracle for p_value_rmse -- calibration only, not direction.
+
+        Under a pure-noise null, the observed value's rank among the null
+        draws is uniform regardless of which tail the p-value formula uses --
+        both a correct left-tail and an incorrectly-reverted right-tail RMSE
+        formula would pass this test identically, since pure noise has no
+        asymmetry for either formula to get wrong.
+        ``test_permutation_test_signal_p_value_rmse_reads_as_significant``
+        below, not this test, is what actually guards the RMSE direction.
+        """
+        results = self._permutation_results(
+            cross_platform_permutation_calibration_fixture,
+            reduction_method="pls_latent",
+        )
+        p_values = [r.p_value_rmse for r in results]
+        ks_result = kstest(p_values, "uniform")
+        assert ks_result.pvalue > 0.05
+
+    def test_permutation_test_signal_r2_exceeds_its_own_null_median(
+        self, cross_platform_planted_signal_fixture
+    ):
+        """Mean observed R2 across seeds is comfortably above the mean null median.
+
+        Empirically measured: mean observed R2 ~= 0.646, mean null median
+        R2 ~= -0.315 (gap ~= 0.96) at n_permutations=200.
+        """
+        results = self._permutation_results(
+            cross_platform_planted_signal_fixture, reduction_method="pls_latent"
+        )
+        mean_observed = np.mean([r.observed_r2 for r in results])
+        mean_null_median = np.mean([np.median(r.null_r2) for r in results])
+        assert mean_observed - mean_null_median > 0.5
+
+    def test_permutation_test_signal_p_value_rmse_reads_as_significant(
+        self, cross_platform_planted_signal_fixture
+    ):
+        """A genuinely low-RMSE (good) signal result reads as significant.
+
+        Direct regression guard for the RMSE directional-inversion bug found
+        during `/review-openspec` round 3 -- the naive R2/rho-style
+        right-tail formula would instead produce p_value_rmse ~= 1.0 here.
+        Empirically measured: mean p_value_rmse ~= 0.0085 at
+        n_permutations=200.
+        """
+        results = self._permutation_results(
+            cross_platform_planted_signal_fixture, reduction_method="pls_latent"
+        )
+        mean_p_value_rmse = np.mean([r.p_value_rmse for r in results])
+        assert mean_p_value_rmse < 0.1
+
+    def test_permutation_test_noise_r2_falls_within_its_own_null_band(
+        self, cross_platform_pure_noise_fixture
+    ):
+        """Mean observed R2 (noise) falls within mean-null-median +/- 1 SD.
+
+        Empirically measured: mean observed R2 ~= -0.254, mean null median
+        ~= -0.321, mean null SD ~= 0.213 at n_permutations=200.
+        """
+        results = self._permutation_results(
+            cross_platform_pure_noise_fixture, reduction_method="pls_latent"
+        )
+        mean_observed = np.mean([r.observed_r2 for r in results])
+        mean_null_median = np.mean([np.median(r.null_r2) for r in results])
+        mean_null_sd = np.mean([np.std(r.null_r2) for r in results])
+        assert abs(mean_observed - mean_null_median) <= mean_null_sd
+
+    def test_permutation_test_top_quartile_recovery_signal_vs_noise(
+        self, cross_platform_planted_signal_fixture, cross_platform_pure_noise_fixture
+    ):
+        """Signal recovery >=80%; noise recovery close to the empirical null value.
+
+        Spike (tasks.md 9.4a), computed via this same fixture/n_permutations:
+        the pure-noise fixture's actual mean null top-quartile-recovery is
+        ~=0.443 (44.3%) -- cross-checked against the theoretical chance-level
+        baseline 2*q/n = 10/19 ~= 0.526 (design.md Decision 11): close but not
+        identical, since the theoretical value assumes a uniformly random
+        y_pred, while the empirical null instead reflects this fixture's real
+        (correlated-by-construction) predictor structure fed through
+        `logo_cv_predict`. The noise fixture's own *observed* recovery
+        (~=0.45) is, as expected, close to this empirical null (not the
+        theoretical one), not a blindly-pinned "25%".
+        """
+        signal_results = self._permutation_results(
+            cross_platform_planted_signal_fixture, reduction_method="pls_latent"
+        )
+        noise_results = self._permutation_results(
+            cross_platform_pure_noise_fixture, reduction_method="pls_latent"
+        )
+        mean_signal_tqr = np.mean(
+            [r.observed_top_quartile_recovery for r in signal_results]
+        )
+        mean_noise_tqr = np.mean(
+            [r.observed_top_quartile_recovery for r in noise_results]
+        )
+        empirical_null_tqr = np.mean(
+            [v for r in noise_results for v in r.null_top_quartile_recovery]
+        )
+
+        assert mean_signal_tqr >= 0.8
+        assert mean_signal_tqr - mean_noise_tqr > 0.3
+        assert abs(mean_noise_tqr - empirical_null_tqr) < 0.1
 
 
 class TestPermutationResultTypes:

--- a/tests/test_cross_platform_prediction.py
+++ b/tests/test_cross_platform_prediction.py
@@ -24,6 +24,7 @@ from sleap_roots_analyze.cross_platform_prediction import (
     LOGOCVResult,
     fit_pca_on_fold,
     logo_cv_predict,
+    top_quartile_recovery,
 )
 from sleap_roots_analyze.result_types import CrossPlatformPredictionResult
 
@@ -970,3 +971,60 @@ class TestPublicApiExport:
 
         assert sra.LOGOCVResult is LOGOCVResult
         assert "LOGOCVResult" in sra.__all__
+
+
+# =============================================================================
+# Tier 4 (add-prediction-permutation-and-figure, #200): permutation_test() /
+# top_quartile_recovery(). See design.md Decisions 1-2 and the
+# `cross-platform-prediction` spec delta for full rationale.
+# =============================================================================
+
+
+class TestTopQuartileRecovery:
+    """Unit tests for top_quartile_recovery() (design.md Decision 2, tasks.md 2.1-2.4)."""
+
+    def test_top_quartile_recovery_perfect_prediction_recovers_all(self):
+        """A strictly monotonic y_pred (== y_true) recovers all of the top quartile."""
+        y_true = np.array([5.0, 3.0, 1.0, 4.0, 2.0, 0.0, 6.0, 7.0])
+        y_pred = y_true.copy()
+        assert top_quartile_recovery(y_true, y_pred) == pytest.approx(1.0)
+
+    def test_top_quartile_recovery_uses_top_2q_predicted_set(self):
+        """True top-q genotypes absent from predicted top-q but present in top-2q count."""
+        # n=8, explicit q=2. True top-2 (by y_true): indices 0, 1 (values 10, 9).
+        y_true = np.array([10.0, 9.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0])
+        # Predicted ranking (desc): idx6 (10), idx7 (9), idx1 (6), idx0 (5), ...
+        # -> predicted top-2 = {6, 7} (excludes true top-2 entirely);
+        #    predicted top-4 = {6, 7, 1, 0} (includes both of true top-2).
+        y_pred = np.array([5.0, 6.0, 0.5, 0.6, 0.7, 0.8, 10.0, 9.0])
+        assert top_quartile_recovery(y_true, y_pred, q=2) == pytest.approx(1.0)
+
+    def test_top_quartile_recovery_default_q_is_quarter_of_n(self):
+        """With len(y_true)=19 and q omitted, the effective q used is round(19/4)=5."""
+        rng = np.random.default_rng(123)
+        y_true = rng.standard_normal(19)
+        y_pred = rng.standard_normal(19)
+        default_result = top_quartile_recovery(y_true, y_pred)
+        explicit_q5_result = top_quartile_recovery(y_true, y_pred, q=5)
+        assert default_result == pytest.approx(explicit_q5_result)
+
+    def test_top_quartile_recovery_small_n_gives_at_least_one_and_not_over_n(self):
+        """At n=3 (this program's smallest real scale), default q is >=1 and 2*q<=n."""
+        y_true = np.array([3.0, 1.0, 2.0])
+        y_pred = np.array([1.0, 3.0, 2.0])
+        default_result = top_quartile_recovery(y_true, y_pred)
+        # The only valid q satisfying q>=1 and 2*q<=3 is q=1.
+        assert default_result == pytest.approx(
+            top_quartile_recovery(y_true, y_pred, q=1)
+        )
+
+    def test_top_quartile_recovery_rejects_explicit_invalid_q(self):
+        """An explicit q=0, negative q, or 2*q > len(y_true) raises ValueError."""
+        y_true = np.array([1.0, 2.0, 3.0])
+        y_pred = np.array([1.0, 2.0, 3.0])
+        with pytest.raises(ValueError, match="q=0"):
+            top_quartile_recovery(y_true, y_pred, q=0)
+        with pytest.raises(ValueError, match="q=-1"):
+            top_quartile_recovery(y_true, y_pred, q=-1)
+        with pytest.raises(ValueError, match="q=2"):
+            top_quartile_recovery(y_true, y_pred, q=2)  # 2*2=4 > len(y_true)=3

--- a/tests/test_predict_cross_platform.py
+++ b/tests/test_predict_cross_platform.py
@@ -730,3 +730,99 @@ def test_predict_step_blup_refit_per_fold_is_inert(tmp_path):
         (tmp_path / "false" / "06_prediction_pls_latent.json").read_text()
     )
     assert saved_true == saved_false
+
+
+# =============================================================================
+# Tier 4 (add-prediction-permutation-and-figure, #200): additive
+# `predictor_matrices` extension to StepResult.data (design.md Decision 6,
+# tasks.md Section 5). VisualizePredictionStep (Section 7) reuses these
+# already-computed matrices instead of rebuilding BLUP-loading/NaN-dropping/
+# alignment logic a second time.
+# =============================================================================
+
+
+def test_predict_step_exposes_predictor_matrices_in_step_result_data(tmp_path):
+    """StepResult.data["predictor_matrices"] holds the step's own computed matrices."""
+    source_df, target_df, _ = _make_blup_tables()
+    config = _blup_config(
+        tmp_path,
+        source_df,
+        target_df,
+        reduction_method="pls_latent",
+        comparison_methods=["representatives"],
+    )
+    step = PredictCrossPlatformStep()
+    result = step.execute(data=None, config=config, run_dir=tmp_path, prev_result=None)
+
+    matrices = result.data["predictor_matrices"]
+    pd.testing.assert_frame_equal(
+        matrices["source_clean"], source_df.loc[result.metadata["common_genotypes"]]
+    )
+    pd.testing.assert_frame_equal(
+        matrices["target_clean"], target_df.loc[result.metadata["common_genotypes"]]
+    )
+    assert matrices["source_representative_names"]
+    assert set(matrices["source_representative_names"]) <= set(
+        matrices["source_clean"].columns
+    )
+    assert set(matrices["target_representatives"]) == set(
+        result.metadata["target_representative_traits"]
+    )
+
+
+def test_predict_step_existing_data_metadata_files_unchanged_by_predictor_matrices_addition(
+    tmp_path,
+):
+    """The predictor_matrices addition changes nothing else -- full backward-compat check.
+
+    Guards Decision 6's additive-only promise: every pre-Tier-4 `data` key
+    (method names only), every `metadata` key/value, and every
+    `files_generated` path must be identical to this step's pre-Tier-4
+    behavior on the same fixture -- and `"predictor_matrices"` must be the
+    *only* addition to `data`'s key set (catching any accidental extra key
+    leakage), not just that pre-existing keys are individually unchanged.
+    """
+    source_df, target_df, _ = _make_blup_tables()
+    config = _blup_config(
+        tmp_path,
+        source_df,
+        target_df,
+        reduction_method="pls_latent",
+        comparison_methods=["representatives"],
+    )
+    step = PredictCrossPlatformStep()
+    result = step.execute(data=None, config=config, run_dir=tmp_path, prev_result=None)
+
+    # Pre-Tier-4, StepResult.data was keyed by method name only.
+    assert set(result.data.keys()) - {"predictor_matrices"} == {
+        "pls_latent",
+        "representatives",
+    }
+    assert "predictor_matrices" in result.data
+
+    pls_saved = json.loads((tmp_path / "06_prediction_pls_latent.json").read_text())
+    rep_saved = json.loads(
+        (tmp_path / "06_prediction_representatives.json").read_text()
+    )
+    assert result.data["pls_latent"] == pls_saved
+    assert result.data["representatives"] == rep_saved
+
+    expected_metadata_keys = {
+        "source_platform",
+        "target_platform",
+        "predictor_source",
+        "methods",
+        "target_names",
+        "common_genotypes",
+        "n_common_genotypes",
+        "source_trait_columns",
+        "target_candidate_columns",
+        "target_representative_traits",
+        "source_dropped_columns",
+        "target_dropped_columns",
+    }
+    assert set(result.metadata.keys()) == expected_metadata_keys
+    assert [p.name for p in result.files_generated] == [
+        "06_prediction_pls_latent.json",
+        "06_prediction_representatives.json",
+    ]

--- a/tests/test_predict_cross_platform_pipeline.py
+++ b/tests/test_predict_cross_platform_pipeline.py
@@ -287,3 +287,43 @@ def test_predict_step_never_reads_task5_data(tmp_path):
 
     assert result.data.data is not None
     assert task1_result is not None
+
+
+# =============================================================================
+# Tier 4 (add-prediction-permutation-and-figure, #200), tasks.md 8.1/8.2 --
+# task presence/absence for VisualizePredictionStep (7th task).
+# =============================================================================
+
+
+def test_cross_platform_pipeline_appends_visualize_prediction_task_when_visualize_enabled():
+    """A 7th task, depending on task 6, is added when prediction.visualize=True (tasks.md 8.1)."""
+    config = load_cross_platform_config(
+        HARNESS_DIR / "cross_platform_prediction_wiring_visualize.yaml"
+    )
+    pipeline = CrossPlatformPipeline(config=config)
+
+    tasks = pipeline.create_tasks()
+
+    assert len(tasks) == 7
+    visualize_task = tasks[6]
+    assert visualize_task.name == "07_visualize_prediction"
+    assert set(visualize_task.depends_on) == {"06_predict_cross_platform"}
+
+
+def test_cross_platform_pipeline_omits_visualize_prediction_task_when_disabled():
+    """create_tasks() returns exactly 6 tasks when visualize=False (tasks.md 8.2).
+
+    Including when prediction.enabled=True alone (prediction with no
+    visualization).
+    """
+    config = load_cross_platform_config(
+        HARNESS_DIR / "cross_platform_prediction_wiring.yaml"
+    )
+    assert config.prediction.enabled is True
+    assert config.prediction.visualize is False
+    pipeline = CrossPlatformPipeline(config=config)
+
+    tasks = pipeline.create_tasks()
+
+    assert len(tasks) == 6
+    assert all(not t.name.startswith("07_") for t in tasks)

--- a/tests/test_reproducibility.py
+++ b/tests/test_reproducibility.py
@@ -46,6 +46,7 @@ EXPECTED_QUALNAMES = frozenset(
         "sleap_roots_analyze.outlier_detection.detect_outliers_pca",
         "sleap_roots_analyze.pca.calculate_mahalanobis_distances",
         "sleap_roots_analyze.outlier_removal.remove_outlier_samples",
+        "sleap_roots_analyze.cross_platform_prediction.permutation_test",
     }
 )
 

--- a/tests/test_step_visualize_prediction.py
+++ b/tests/test_step_visualize_prediction.py
@@ -241,3 +241,284 @@ def test_visualize_prediction_step_calls_permutation_test_n_times_when_compariso
 
     n_targets = len(predict_result.metadata["target_names"])
     assert mock_perm.call_count == n_targets
+
+
+# =============================================================================
+# 7b. joblib parallelization across targets
+# =============================================================================
+
+
+def test_visualize_prediction_step_parallelizes_across_target_method_units_not_within_one(
+    tmp_path,
+):
+    """One dispatched job per (target, method) combination, not per permutation."""
+    config = _visualize_config(
+        tmp_path, reduction_method="pls_latent", comparison_methods=["representatives"]
+    )
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+
+    from joblib import Parallel as RealParallel
+
+    captured = {}
+
+    class _SpyParallel(RealParallel):
+        def __call__(self, iterable):
+            jobs = list(iterable)
+            captured["n_jobs_dispatched"] = len(jobs)
+            return super().__call__(jobs)
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.visualize_prediction.Parallel",
+        _SpyParallel,
+    ):
+        step.execute(
+            data=predict_result.data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=predict_result,
+        )
+
+    n_targets = len(predict_result.metadata["target_names"])
+    n_methods = 2
+    assert captured["n_jobs_dispatched"] == n_targets * n_methods
+
+
+def test_visualize_prediction_step_joblib_n_jobs_and_backend_match_config(tmp_path):
+    """joblib.Parallel is constructed with n_jobs=config's value, backend='loky'."""
+    config = _visualize_config(tmp_path, permutation_n_jobs=3)
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+
+    from joblib import Parallel as RealParallel
+
+    captured = {}
+
+    class _SpyParallel(RealParallel):
+        def __init__(self, *args, **kwargs):
+            captured["n_jobs"] = kwargs.get("n_jobs")
+            captured["backend"] = kwargs.get("backend")
+            super().__init__(*args, **kwargs)
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.visualize_prediction.Parallel",
+        _SpyParallel,
+    ):
+        step.execute(
+            data=predict_result.data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=predict_result,
+        )
+
+    assert captured["n_jobs"] == 3
+    assert captured["backend"] == "loky"
+
+
+def test_visualize_prediction_step_derives_independent_seed_per_target_method(tmp_path):
+    """N (target, method) combinations get N distinct SeedSequence.spawn(N) children."""
+    config = _visualize_config(
+        tmp_path, reduction_method="pls_latent", comparison_methods=["representatives"]
+    )
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+
+    from sleap_roots_analyze.cross_platform_prediction import (
+        permutation_test as real_permutation_test,
+    )
+
+    captured_seeds = []
+
+    def spy(*args, **kwargs):
+        captured_seeds.append(kwargs["random_state"])
+        return real_permutation_test(*args, **kwargs)
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.visualize_prediction.permutation_test",
+        side_effect=spy,
+    ):
+        step.execute(
+            data=predict_result.data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=predict_result,
+        )
+
+    n_targets = len(predict_result.metadata["target_names"])
+    n_methods = 2
+    n_combinations = n_targets * n_methods
+    assert len(captured_seeds) == n_combinations
+
+    expected_children = np.random.SeedSequence(
+        config.prediction.permutation_random_state
+    ).spawn(n_combinations)
+    # SeedSequence has no value __eq__ -- compare via generated random state.
+    for actual, expected in zip(captured_seeds, expected_children):
+        np.testing.assert_array_equal(
+            actual.generate_state(4), expected.generate_state(4)
+        )
+    # Re-running with the same permutation_random_state and combinations
+    # reproduces the same derived seeds.
+    assert len({id(s) for s in captured_seeds}) == n_combinations  # no two identical
+
+
+def test_visualize_prediction_step_permutation_test_receives_derived_seed(tmp_path):
+    """Each permutation_test call's random_state is that combination's derived child."""
+    config = _visualize_config(
+        tmp_path, reduction_method="pls_latent", comparison_methods=[]
+    )
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+
+    from sleap_roots_analyze.cross_platform_prediction import (
+        permutation_test as real_permutation_test,
+    )
+
+    captured_seeds = []
+
+    def spy(*args, **kwargs):
+        captured_seeds.append(kwargs["random_state"])
+        return real_permutation_test(*args, **kwargs)
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.visualize_prediction.permutation_test",
+        side_effect=spy,
+    ):
+        step.execute(
+            data=predict_result.data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=predict_result,
+        )
+
+    n_targets = len(predict_result.metadata["target_names"])
+    expected_children = np.random.SeedSequence(
+        config.prediction.permutation_random_state
+    ).spawn(n_targets)
+    assert len(captured_seeds) == n_targets
+    for actual, expected in zip(captured_seeds, expected_children):
+        assert isinstance(actual, np.random.SeedSequence)
+        np.testing.assert_array_equal(
+            actual.generate_state(4), expected.generate_state(4)
+        )
+
+
+def test_visualize_prediction_step_parallel_vs_serial_results_agree_within_tolerance(
+    tmp_path,
+):
+    """n_jobs=1 vs n_jobs=4 agree via assert_allclose(rtol=1e-6, atol=1e-9).
+
+    Uses an explicitly small n_permutations=50 to bound the elementwise-
+    comparison surface and keep this test CI-fast. Calls the real
+    permutation_test (no mocking) at both n_jobs settings.
+    """
+    source_df, target_df, _ = _make_blup_tables()
+    (tmp_path / "serial").mkdir()
+    (tmp_path / "parallel").mkdir()
+    config_serial = _visualize_config(
+        tmp_path / "serial",
+        source_df,
+        target_df,
+        reduction_method="pls_latent",
+        comparison_methods=[],
+        n_permutations=50,
+        permutation_n_jobs=1,
+    )
+    config_parallel = _visualize_config(
+        tmp_path / "parallel",
+        source_df,
+        target_df,
+        reduction_method="pls_latent",
+        comparison_methods=[],
+        n_permutations=50,
+        permutation_n_jobs=4,
+    )
+
+    predict_serial = _run_predict_step(config_serial, tmp_path / "serial")
+    predict_parallel = _run_predict_step(config_parallel, tmp_path / "parallel")
+
+    result_serial = VisualizePredictionStep().execute(
+        data=predict_serial.data,
+        config=config_serial,
+        run_dir=tmp_path / "serial",
+        prev_result=predict_serial,
+    )
+    result_parallel = VisualizePredictionStep().execute(
+        data=predict_parallel.data,
+        config=config_parallel,
+        run_dir=tmp_path / "parallel",
+        prev_result=predict_parallel,
+    )
+
+    for method in result_serial.data:
+        for target_name in result_serial.data[method]:
+            r_serial = result_serial.data[method][target_name]
+            r_parallel = result_parallel.data[method][target_name]
+            for field in (
+                "observed_r2",
+                "observed_rmse",
+                "observed_spearman_rho",
+                "observed_top_quartile_recovery",
+                "p_value_r2",
+                "p_value_rmse",
+                "p_value_spearman_rho",
+            ):
+                np.testing.assert_allclose(
+                    getattr(r_serial, field),
+                    getattr(r_parallel, field),
+                    rtol=1e-6,
+                    atol=1e-9,
+                )
+            for field in (
+                "null_r2",
+                "null_rmse",
+                "null_spearman_rho",
+                "null_top_quartile_recovery",
+            ):
+                np.testing.assert_allclose(
+                    getattr(r_serial, field),
+                    getattr(r_parallel, field),
+                    rtol=1e-6,
+                    atol=1e-9,
+                )
+
+
+def test_visualize_prediction_step_handles_pc1_only_targets_via_joblib(tmp_path):
+    """The PC1-only degenerate case still works dispatched through real joblib.Parallel."""
+    from sleap_roots_analyze.cross_experiment_analysis import (
+        select_cluster_representatives as real_select_cluster_representatives,
+    )
+
+    source_df, target_df, _ = _make_blup_tables()
+    config = _visualize_config(
+        tmp_path,
+        source_df,
+        target_df,
+        reduction_method="pls_latent",
+        comparison_methods=["representatives"],
+        permutation_n_jobs=4,
+    )
+
+    def _target_only_empty(df, clusters):
+        if set(df.columns) == set(target_df.columns):
+            return []
+        return real_select_cluster_representatives(df, clusters)
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.predict_cross_platform."
+        "select_cluster_representatives",
+        side_effect=_target_only_empty,
+    ):
+        predict_result = _run_predict_step(config, tmp_path)
+
+    step = VisualizePredictionStep()
+    result = step.execute(
+        data=predict_result.data,
+        config=config,
+        run_dir=tmp_path,
+        prev_result=predict_result,
+    )
+
+    assert set(result.data.keys()) == {"pls_latent", "representatives"}
+    for method in result.data:
+        assert set(result.data[method].keys()) == {"PC1"}

--- a/tests/test_step_visualize_prediction.py
+++ b/tests/test_step_visualize_prediction.py
@@ -137,6 +137,30 @@ def test_visualize_prediction_step_reuses_task6_predictor_matrices(tmp_path):
     mock_load.assert_not_called()
 
 
+def test_visualize_prediction_step_raises_when_prev_result_is_none(tmp_path):
+    """execute(prev_result=None) raises ValueError before touching `data`.
+
+    Regression test for the round-2 `/review-pr` finding (PR #201, Code
+    Quality): the mypy-motivated `if prev_result is None: raise ValueError`
+    guard at the top of `execute()` was added without a test exercising it.
+    Unreachable via the real DAG (`cross_platform_pipeline.py`'s
+    `_run_visualize_prediction` always passes a populated task-6
+    `StepResult`), but `execute()` is public API and must fail predictably
+    on direct/standalone misuse.
+    """
+    config = _visualize_config(tmp_path)
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+
+    with pytest.raises(ValueError, match="prev_result"):
+        step.execute(
+            data=predict_result.data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=None,
+        )
+
+
 def test_visualize_prediction_step_handles_pc1_only_targets(tmp_path):
     """With zero representative-trait targets, exactly N=1 unit per method runs."""
     from sleap_roots_analyze.cross_experiment_analysis import (

--- a/tests/test_step_visualize_prediction.py
+++ b/tests/test_step_visualize_prediction.py
@@ -1,0 +1,243 @@
+"""Tests for VisualizePredictionStep (Tier 4, #200, tasks.md Section 7).
+
+Distinct from ``tests/test_visualize_prediction.py`` (Section 6's
+``create_prediction_figure()`` tests) -- see proposal.md's naming-collision
+note. Step-level tests call ``PredictCrossPlatformStep.execute()`` for real
+first (to get a genuine task-6 ``StepResult``, including
+``predictor_matrices``), then feed that directly into
+``VisualizePredictionStep.execute()`` -- matching
+``test_predict_cross_platform.py``'s own "construct inputs by hand" style.
+
+**Mocking-across-process-boundary note (tasks.md Section 7a, added during
+`/review-openspec` round 3):** every test below that mocks/spies on
+``permutation_test`` MUST fix ``config.prediction.permutation_n_jobs=1`` in
+its fixture. ``joblib.Parallel(n_jobs=1)`` runs sequentially in-process
+(never touching the ``loky`` backend), so a ``unittest.mock.patch`` in the
+test process stays valid; at ``n_jobs>1``, ``loky`` dispatches to separate
+worker processes where a parent-process mock is invisible.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from sleap_roots_analyze.pipeline.config.components import (
+    CrossPlatformConfig,
+    PredictionConfig,
+)
+from sleap_roots_analyze.pipeline.steps.predict_cross_platform import (
+    PredictCrossPlatformStep,
+)
+from sleap_roots_analyze.pipeline.steps.visualize_prediction import (
+    VisualizePredictionStep,
+)
+
+N_GENOTYPES = 19
+GENOTYPES = [f"G{i:02d}" for i in range(1, N_GENOTYPES + 1)]
+
+
+def _make_blup_tables(genotype_col="Genotype", n=N_GENOTYPES, seed=0):
+    """Build a small (source_df, target_df) BLUP-shaped pair with planted signal."""
+    rng = np.random.default_rng(seed)
+    genotypes = [f"G{i:02d}" for i in range(1, n + 1)]
+    source = pd.DataFrame(
+        {
+            "trait_a": rng.normal(10, 2, n),
+            "trait_b": rng.normal(5, 1, n),
+        },
+        index=genotypes,
+    )
+    target = pd.DataFrame(
+        {
+            "trait_x": 2.0 * source["trait_a"].to_numpy() + rng.normal(0, 0.1, n),
+            "trait_y": rng.normal(3, 1, n),
+        },
+        index=genotypes,
+    )
+    source.index.name = genotype_col
+    target.index.name = genotype_col
+    return source, target, genotypes
+
+
+def _write_blup_csv(df, path, genotype_col="Genotype"):
+    df.reset_index(names=genotype_col).to_csv(path, index=False)
+    return path
+
+
+def _visualize_config(
+    tmp_path,
+    source_df=None,
+    target_df=None,
+    genotype_col="Genotype",
+    **prediction_overrides,
+):
+    """Build a CrossPlatformConfig with visualize=True, CI-fast permutation defaults."""
+    if source_df is None or target_df is None:
+        source_df, target_df, _ = _make_blup_tables()
+    source_path = tmp_path / "source_blup.csv"
+    target_path = tmp_path / "target_blup.csv"
+    _write_blup_csv(source_df, source_path, genotype_col)
+    _write_blup_csv(target_df, target_path, genotype_col)
+
+    prediction_kwargs = dict(
+        enabled=True,
+        predictor_source="blup",
+        source_blup_path=str(source_path),
+        target_blup_path=str(target_path),
+        platform_pairs=[{"source": "SourcePlatform", "target": "TargetPlatform"}],
+        visualize=True,
+        n_permutations=5,
+        permutation_random_state=42,
+        permutation_n_jobs=1,
+    )
+    prediction_kwargs.update(prediction_overrides)
+    prediction = PredictionConfig(**prediction_kwargs)
+    return CrossPlatformConfig(
+        exp1_data_path="unused_exp1.csv",
+        exp1_name="SourcePlatform",
+        exp1_genotype_col="Genotype",
+        exp2_data_path="unused_exp2.csv",
+        exp2_name="TargetPlatform",
+        exp2_genotype_col="Genotype",
+        prediction=prediction,
+    )
+
+
+def _run_predict_step(config, run_dir):
+    step = PredictCrossPlatformStep()
+    return step.execute(data=None, config=config, run_dir=run_dir, prev_result=None)
+
+
+# =============================================================================
+# 7a. Wiring and predictor-matrix reuse
+# =============================================================================
+
+
+def test_visualize_prediction_step_reuses_task6_predictor_matrices(tmp_path):
+    """No BLUP-loading call happens when predictor_matrices is already supplied."""
+    config = _visualize_config(tmp_path)
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.predict_cross_platform."
+        "PredictCrossPlatformStep._load_blup_table"
+    ) as mock_load:
+        step.execute(
+            data=predict_result.data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=predict_result,
+        )
+    mock_load.assert_not_called()
+
+
+def test_visualize_prediction_step_handles_pc1_only_targets(tmp_path):
+    """With zero representative-trait targets, exactly N=1 unit per method runs."""
+    from sleap_roots_analyze.cross_experiment_analysis import (
+        select_cluster_representatives as real_select_cluster_representatives,
+    )
+
+    source_df, target_df, _ = _make_blup_tables()
+    config = _visualize_config(
+        tmp_path,
+        source_df,
+        target_df,
+        reduction_method="pls_latent",
+        comparison_methods=["representatives"],
+    )
+
+    def _target_only_empty(df, clusters):
+        if set(df.columns) == set(target_df.columns):
+            return []
+        return real_select_cluster_representatives(df, clusters)
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.predict_cross_platform."
+        "select_cluster_representatives",
+        side_effect=_target_only_empty,
+    ):
+        predict_result = _run_predict_step(config, tmp_path)
+
+    step = VisualizePredictionStep()
+    from sleap_roots_analyze.cross_platform_prediction import (
+        permutation_test as real_permutation_test,
+    )
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.visualize_prediction.permutation_test",
+        side_effect=real_permutation_test,
+    ) as mock_perm:
+        step.execute(
+            data=predict_result.data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=predict_result,
+        )
+
+    n_methods = 1 + len(config.prediction.comparison_methods)
+    assert mock_perm.call_count == n_methods
+
+
+def test_visualize_prediction_step_calls_permutation_test_once_per_target_per_method(
+    tmp_path,
+):
+    """permutation_test is called exactly N targets x M methods times."""
+    config = _visualize_config(
+        tmp_path, reduction_method="pls_latent", comparison_methods=["representatives"]
+    )
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+
+    from sleap_roots_analyze.cross_platform_prediction import (
+        permutation_test as real_permutation_test,
+    )
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.visualize_prediction.permutation_test",
+        side_effect=real_permutation_test,
+    ) as mock_perm:
+        step.execute(
+            data=predict_result.data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=predict_result,
+        )
+
+    n_targets = len(predict_result.metadata["target_names"])
+    n_methods = 2
+    assert mock_perm.call_count == n_targets * n_methods
+
+
+def test_visualize_prediction_step_calls_permutation_test_n_times_when_comparison_methods_empty(
+    tmp_path,
+):
+    """With comparison_methods=[] (K=0), permutation_test is called exactly N times."""
+    config = _visualize_config(
+        tmp_path, reduction_method="pls_latent", comparison_methods=[]
+    )
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+
+    from sleap_roots_analyze.cross_platform_prediction import (
+        permutation_test as real_permutation_test,
+    )
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.visualize_prediction.permutation_test",
+        side_effect=real_permutation_test,
+    ) as mock_perm:
+        step.execute(
+            data=predict_result.data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=predict_result,
+        )
+
+    n_targets = len(predict_result.metadata["target_names"])
+    assert mock_perm.call_count == n_targets

--- a/tests/test_step_visualize_prediction.py
+++ b/tests/test_step_visualize_prediction.py
@@ -715,3 +715,49 @@ def test_visualize_prediction_step_writes_no_partial_json_files_when_any_combina
     # All-or-nothing: zero JSON files exist, including for methods whose own
     # combinations (e.g. the first 2 calls) all individually succeeded.
     assert not list(tmp_path.glob("07_permutation_*.json"))
+
+
+def test_visualize_prediction_step_figure_provenance(tmp_path):
+    """Two runs with different input CSVs produce different figures (tasks.md 9.5).
+
+    Also checks a given run's figure mtime is at or after its input CSVs'
+    mtimes -- confirming the figure was regenerated from the current run's
+    inputs, not stale from a prior run.
+    """
+    import hashlib
+
+    source_df_a, target_df_a, _ = _make_blup_tables(seed=0)
+    source_df_b, target_df_b, _ = _make_blup_tables(seed=1)
+
+    (tmp_path / "run_a").mkdir()
+    (tmp_path / "run_b").mkdir()
+    config_a = _visualize_config(tmp_path / "run_a", source_df_a, target_df_a)
+    config_b = _visualize_config(tmp_path / "run_b", source_df_b, target_df_b)
+
+    predict_a = _run_predict_step(config_a, tmp_path / "run_a")
+    predict_b = _run_predict_step(config_b, tmp_path / "run_b")
+
+    VisualizePredictionStep().execute(
+        data=predict_a.data,
+        config=config_a,
+        run_dir=tmp_path / "run_a",
+        prev_result=predict_a,
+    )
+    VisualizePredictionStep().execute(
+        data=predict_b.data,
+        config=config_b,
+        run_dir=tmp_path / "run_b",
+        prev_result=predict_b,
+    )
+
+    figure_a = tmp_path / "run_a" / "07_prediction_figure.png"
+    figure_b = tmp_path / "run_b" / "07_prediction_figure.png"
+    hash_a = hashlib.sha256(figure_a.read_bytes()).hexdigest()
+    hash_b = hashlib.sha256(figure_b.read_bytes()).hexdigest()
+    assert hash_a != hash_b
+
+    input_mtimes = [
+        (tmp_path / "run_a" / "source_blup.csv").stat().st_mtime,
+        (tmp_path / "run_a" / "target_blup.csv").stat().st_mtime,
+    ]
+    assert figure_a.stat().st_mtime >= max(input_mtimes)

--- a/tests/test_step_visualize_prediction.py
+++ b/tests/test_step_visualize_prediction.py
@@ -437,50 +437,47 @@ def test_visualize_prediction_step_parallel_vs_serial_results_agree_within_toler
     predict_serial = _run_predict_step(config_serial, tmp_path / "serial")
     predict_parallel = _run_predict_step(config_parallel, tmp_path / "parallel")
 
-    result_serial = VisualizePredictionStep().execute(
+    VisualizePredictionStep().execute(
         data=predict_serial.data,
         config=config_serial,
         run_dir=tmp_path / "serial",
         prev_result=predict_serial,
     )
-    result_parallel = VisualizePredictionStep().execute(
+    VisualizePredictionStep().execute(
         data=predict_parallel.data,
         config=config_parallel,
         run_dir=tmp_path / "parallel",
         prev_result=predict_parallel,
     )
 
-    for method in result_serial.data:
-        for target_name in result_serial.data[method]:
-            r_serial = result_serial.data[method][target_name]
-            r_parallel = result_parallel.data[method][target_name]
-            for field in (
-                "observed_r2",
-                "observed_rmse",
-                "observed_spearman_rho",
-                "observed_top_quartile_recovery",
-                "p_value_r2",
-                "p_value_rmse",
-                "p_value_spearman_rho",
-            ):
-                np.testing.assert_allclose(
-                    getattr(r_serial, field),
-                    getattr(r_parallel, field),
-                    rtol=1e-6,
-                    atol=1e-9,
-                )
-            for field in (
-                "null_r2",
-                "null_rmse",
-                "null_spearman_rho",
-                "null_top_quartile_recovery",
-            ):
-                np.testing.assert_allclose(
-                    getattr(r_serial, field),
-                    getattr(r_parallel, field),
-                    rtol=1e-6,
-                    atol=1e-9,
-                )
+    saved_serial = json.loads(
+        (tmp_path / "serial" / "07_permutation_pls_latent.json").read_text()
+    )
+    saved_parallel = json.loads(
+        (tmp_path / "parallel" / "07_permutation_pls_latent.json").read_text()
+    )
+    by_target_serial = {p["target_name"]: p for p in saved_serial["predictions"]}
+    by_target_parallel = {p["target_name"]: p for p in saved_parallel["predictions"]}
+    assert set(by_target_serial) == set(by_target_parallel)
+
+    for target_name, pred_serial in by_target_serial.items():
+        pred_parallel = by_target_parallel[target_name]
+        for field in (
+            "observed_r2",
+            "observed_rmse",
+            "observed_spearman_rho",
+            "observed_top_quartile_recovery",
+            "p_value_r2",
+            "p_value_rmse",
+            "p_value_spearman_rho",
+            "null_r2",
+            "null_rmse",
+            "null_spearman_rho",
+            "null_top_quartile_recovery",
+        ):
+            np.testing.assert_allclose(
+                pred_serial[field], pred_parallel[field], rtol=1e-6, atol=1e-9
+            )
 
 
 def test_visualize_prediction_step_handles_pc1_only_targets_via_joblib(tmp_path):
@@ -521,4 +518,200 @@ def test_visualize_prediction_step_handles_pc1_only_targets_via_joblib(tmp_path)
 
     assert set(result.data.keys()) == {"pls_latent", "representatives"}
     for method in result.data:
-        assert set(result.data[method].keys()) == {"PC1"}
+        target_names = {p["target_name"] for p in result.data[method]["predictions"]}
+        assert target_names == {"PC1"}
+
+
+# =============================================================================
+# 7c. JSON/figure output
+# =============================================================================
+
+
+def test_visualize_prediction_step_saves_one_json_per_method(tmp_path):
+    """K + 1 07_permutation_<method>.json files for reduction_method + K comparison_methods."""
+    config = _visualize_config(
+        tmp_path, reduction_method="pls_latent", comparison_methods=["representatives"]
+    )
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+    step.execute(
+        data=predict_result.data,
+        config=config,
+        run_dir=tmp_path,
+        prev_result=predict_result,
+    )
+
+    assert (tmp_path / "07_permutation_pls_latent.json").is_file()
+    assert (tmp_path / "07_permutation_representatives.json").is_file()
+
+
+def test_visualize_prediction_step_saves_one_json_when_comparison_methods_empty(
+    tmp_path,
+):
+    """With K=0, exactly 1 07_permutation_<method>.json file is saved, not 0."""
+    config = _visualize_config(
+        tmp_path, reduction_method="pls_latent", comparison_methods=[]
+    )
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+    step.execute(
+        data=predict_result.data,
+        config=config,
+        run_dir=tmp_path,
+        prev_result=predict_result,
+    )
+
+    json_files = sorted(tmp_path.glob("07_permutation_*.json"))
+    assert len(json_files) == 1
+    assert json_files[0].name == "07_permutation_pls_latent.json"
+
+
+def test_visualize_prediction_step_permutation_observed_matches_task6_prediction_exactly(
+    tmp_path,
+):
+    """Each target/method's observed_* exactly matches task 6's own reported values."""
+    config = _visualize_config(
+        tmp_path, reduction_method="pls_latent", comparison_methods=["representatives"]
+    )
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+    step.execute(
+        data=predict_result.data,
+        config=config,
+        run_dir=tmp_path,
+        prev_result=predict_result,
+    )
+
+    for method in ("pls_latent", "representatives"):
+        task6_saved = json.loads(
+            (tmp_path / f"06_prediction_{method}.json").read_text()
+        )
+        permutation_saved = json.loads(
+            (tmp_path / f"07_permutation_{method}.json").read_text()
+        )
+        task6_by_target = {p["target_name"]: p for p in task6_saved["predictions"]}
+        permutation_by_target = {
+            p["target_name"]: p for p in permutation_saved["predictions"]
+        }
+        assert set(task6_by_target) == set(permutation_by_target)
+        for target_name, task6_pred in task6_by_target.items():
+            perm_pred = permutation_by_target[target_name]
+            assert perm_pred["observed_r2"] == pytest.approx(task6_pred["r2"])
+            assert perm_pred["observed_rmse"] == pytest.approx(task6_pred["rmse"])
+            assert perm_pred["observed_spearman_rho"] == pytest.approx(
+                task6_pred["spearman_rho"]
+            )
+
+
+def test_visualize_prediction_step_saves_one_figure_using_primary_method_only(
+    tmp_path,
+):
+    """Exactly one figure PNG, built only from the primary reduction_method's results."""
+    config = _visualize_config(
+        tmp_path, reduction_method="pls_latent", comparison_methods=["representatives"]
+    )
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+
+    from sleap_roots_analyze.visualize_prediction import (
+        create_prediction_figure as real_create_prediction_figure,
+    )
+
+    captured = {}
+
+    def spy(target_predictions, permutation_results, **kwargs):
+        captured["permutation_results"] = list(permutation_results)
+        return real_create_prediction_figure(
+            target_predictions, permutation_results, **kwargs
+        )
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.visualize_prediction.create_prediction_figure",
+        side_effect=spy,
+    ):
+        step.execute(
+            data=predict_result.data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=predict_result,
+        )
+
+    figure_files = sorted(tmp_path.glob("07_prediction_figure*.png"))
+    assert len(figure_files) == 1
+    assert (tmp_path / "07_prediction_figure.png").is_file()
+
+    saved_pls = json.loads((tmp_path / "07_permutation_pls_latent.json").read_text())
+    expected_target_names = {p["target_name"] for p in saved_pls["predictions"]}
+    actual_target_names = {pr.target_name for pr in captured["permutation_results"]}
+    assert actual_target_names == expected_target_names
+
+
+def test_visualize_prediction_step_rejects_non_finite_permutation_result_with_named_error(
+    tmp_path,
+):
+    """A non-finite permutation result raises ValueError, before writing any JSON."""
+    config = _visualize_config(
+        tmp_path, reduction_method="pls_latent", comparison_methods=["representatives"]
+    )
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+
+    def _broken(*args, **kwargs):
+        raise ValueError(
+            "Observed value(s) for metric(s) ['spearman_rho'] are non-finite "
+            "(permutation index 3)"
+        )
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.visualize_prediction.permutation_test",
+        side_effect=_broken,
+    ):
+        with pytest.raises(ValueError, match="spearman_rho"):
+            step.execute(
+                data=predict_result.data,
+                config=config,
+                run_dir=tmp_path,
+                prev_result=predict_result,
+            )
+
+    assert not list(tmp_path.glob("07_permutation_*.json"))
+    assert not (tmp_path / "07_prediction_figure.png").exists()
+
+
+def test_visualize_prediction_step_writes_no_partial_json_files_when_any_combination_fails(
+    tmp_path,
+):
+    """One failing combination leaves zero 07_permutation_<method>.json files, all-or-nothing."""
+    config = _visualize_config(
+        tmp_path, reduction_method="pls_latent", comparison_methods=["representatives"]
+    )
+    predict_result = _run_predict_step(config, tmp_path)
+    step = VisualizePredictionStep()
+
+    from sleap_roots_analyze.cross_platform_prediction import (
+        permutation_test as real_permutation_test,
+    )
+
+    call_count = [0]
+
+    def _fail_on_third_call(*args, **kwargs):
+        call_count[0] += 1
+        if call_count[0] == 3:
+            raise ValueError("injected failure for one combination")
+        return real_permutation_test(*args, **kwargs)
+
+    with patch(
+        "sleap_roots_analyze.pipeline.steps.visualize_prediction.permutation_test",
+        side_effect=_fail_on_third_call,
+    ):
+        with pytest.raises(ValueError, match="injected failure"):
+            step.execute(
+                data=predict_result.data,
+                config=config,
+                run_dir=tmp_path,
+                prev_result=predict_result,
+            )
+
+    # All-or-nothing: zero JSON files exist, including for methods whose own
+    # combinations (e.g. the first 2 calls) all individually succeeded.
+    assert not list(tmp_path.glob("07_permutation_*.json"))

--- a/tests/test_visualize_prediction.py
+++ b/tests/test_visualize_prediction.py
@@ -1,0 +1,153 @@
+"""Tests for create_prediction_figure() (Tier 4, #200, tasks.md Section 6).
+
+Distinct from ``tests/test_step_visualize_prediction.py`` (Section 7's
+``VisualizePredictionStep`` wiring tests) -- see proposal.md's naming-
+collision note: this repo has two new ``visualize_prediction.py`` source
+files (this one, and ``pipeline/steps/visualize_prediction.py``), sharing a
+basename in two different subpackages.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from sleap_roots_analyze.result_types import PermutationResult, TargetPrediction
+from sleap_roots_analyze.visualize_prediction import create_prediction_figure
+
+
+def _target_prediction(target_name, y_true, y_pred, r2=0.8, rmse=1.0, rho=0.7):
+    n = len(y_true)
+    return TargetPrediction(
+        target_name=target_name,
+        r2=r2,
+        rmse=rmse,
+        spearman_rho=rho,
+        spearman_p=0.05,
+        genotype_names=[f"g{i}" for i in range(n)],
+        y_true=list(y_true),
+        y_pred=list(y_pred),
+    )
+
+
+def _permutation_result(
+    target_name, observed_r2, null_r2, observed_top_quartile_recovery, null_tqr
+):
+    n = len(null_r2)
+    return PermutationResult(
+        target_name=target_name,
+        observed_r2=observed_r2,
+        observed_rmse=1.0,
+        observed_spearman_rho=0.7,
+        observed_top_quartile_recovery=observed_top_quartile_recovery,
+        null_r2=list(null_r2),
+        null_rmse=[1.0] * n,
+        null_spearman_rho=[0.0] * n,
+        null_top_quartile_recovery=list(null_tqr),
+        p_value_r2=0.05,
+        p_value_rmse=0.5,
+        p_value_spearman_rho=0.05,
+        n_permutations=n,
+    )
+
+
+def test_create_prediction_figure_scatter_panel_uses_pc1_target_only():
+    """The obs-vs-pred scatter panel's points correspond only to the PC1 target."""
+    pc1_y_true = [1.0, 2.0, 3.0, 4.0]
+    pc1_y_pred = [1.1, 1.9, 3.2, 3.8]
+    target_predictions = [
+        _target_prediction(
+            "trait_a", [10.0, 20.0, 30.0, 40.0], [11.0, 19.0, 29.0, 42.0]
+        ),
+        _target_prediction("PC1", pc1_y_true, pc1_y_pred),
+    ]
+    permutation_results = [
+        _permutation_result("trait_a", 0.7, [0.1, 0.2, 0.3], 0.5, [0.2, 0.3, 0.4]),
+        _permutation_result("PC1", 0.8, [0.1, 0.2, 0.3], 0.6, [0.2, 0.3, 0.4]),
+    ]
+
+    fig = create_prediction_figure(target_predictions, permutation_results)
+
+    scatter_ax = fig.axes[0]
+    offsets = scatter_ax.collections[0].get_offsets()
+    plotted_x = sorted(offsets[:, 0].tolist())
+    plotted_y = sorted(offsets[:, 1].tolist())
+    assert plotted_x == sorted(pc1_y_true)
+    assert plotted_y == sorted(pc1_y_pred)
+
+
+def test_create_prediction_figure_violin_panel_pools_all_targets_nulls():
+    """The violin panel's null data is every target's null_r2 concatenated."""
+    target_predictions = [
+        _target_prediction("trait_a", [1.0, 2.0], [1.1, 1.9]),
+        _target_prediction("PC1", [3.0, 4.0], [3.1, 3.9]),
+    ]
+    null_a = [0.1, 0.2, 0.3]
+    null_pc1 = [0.4, 0.5, 0.6]
+    permutation_results = [
+        _permutation_result("trait_a", 0.7, null_a, 0.5, [0.2, 0.3, 0.4]),
+        _permutation_result("PC1", 0.8, null_pc1, 0.6, [0.2, 0.3, 0.4]),
+    ]
+
+    fig = create_prediction_figure(target_predictions, permutation_results)
+
+    violin_ax = fig.axes[1]
+    # The violin body's vertices span the pooled null distribution's range.
+    violin_body = violin_ax.collections[0]
+    all_y = np.concatenate([path.vertices[:, 1] for path in violin_body.get_paths()])
+    pooled_null = np.array(null_a + null_pc1)
+    assert all_y.min() <= pooled_null.min()
+    assert all_y.max() >= pooled_null.max()
+    # Observed points: one per target.
+    observed_scatter = violin_ax.collections[-1]
+    observed_y = sorted(observed_scatter.get_offsets()[:, 1].tolist())
+    assert observed_y == sorted([0.7, 0.8])
+
+
+def test_create_prediction_figure_bar_chart_shows_observed_vs_null_mean():
+    """The bar chart's two bars equal mean observed and mean null top-quartile recovery."""
+    target_predictions = [
+        _target_prediction("trait_a", [1.0, 2.0], [1.1, 1.9]),
+        _target_prediction("PC1", [3.0, 4.0], [3.1, 3.9]),
+    ]
+    tqr_null_a = [0.2, 0.3, 0.4]
+    tqr_null_pc1 = [0.5, 0.6, 0.7]
+    permutation_results = [
+        _permutation_result("trait_a", 0.7, [0.1, 0.2, 0.3], 0.5, tqr_null_a),
+        _permutation_result("PC1", 0.8, [0.1, 0.2, 0.3], 0.9, tqr_null_pc1),
+    ]
+
+    fig = create_prediction_figure(target_predictions, permutation_results)
+
+    bar_ax = fig.axes[2]
+    bar_heights = [patch.get_height() for patch in bar_ax.patches]
+    expected_observed_mean = np.mean([0.5, 0.9])
+    expected_null_mean = np.mean(tqr_null_a + tqr_null_pc1)
+    assert bar_heights[0] == pytest.approx(expected_observed_mean)
+    assert bar_heights[1] == pytest.approx(expected_null_mean)
+
+
+def test_create_prediction_figure_returns_a_figure_with_three_axes():
+    """create_prediction_figure returns a matplotlib.Figure with exactly 3 axes."""
+    target_predictions = [_target_prediction("PC1", [1.0, 2.0], [1.1, 1.9])]
+    permutation_results = [
+        _permutation_result("PC1", 0.8, [0.1, 0.2, 0.3], 0.6, [0.2, 0.3, 0.4])
+    ]
+
+    fig = create_prediction_figure(target_predictions, permutation_results)
+
+    assert len(fig.axes) == 3
+
+
+def test_create_prediction_figure_handles_single_target():
+    """A single (PC1-only) target still builds successfully with all 3 panels."""
+    target_predictions = [_target_prediction("PC1", [1.0, 2.0, 3.0], [1.1, 1.9, 3.2])]
+    permutation_results = [
+        _permutation_result("PC1", 0.8, [0.1, 0.2, 0.3, 0.4], 0.6, [0.2, 0.3, 0.4, 0.5])
+    ]
+
+    fig = create_prediction_figure(target_predictions, permutation_results)
+
+    assert len(fig.axes) == 3
+    for ax in fig.axes:
+        assert ax is not None

--- a/tests/test_visualize_prediction.py
+++ b/tests/test_visualize_prediction.py
@@ -9,6 +9,7 @@ basename in two different subpackages.
 
 from __future__ import annotations
 
+import matplotlib.pyplot as plt
 import numpy as np
 import pytest
 
@@ -151,3 +152,49 @@ def test_create_prediction_figure_handles_single_target():
     assert len(fig.axes) == 3
     for ax in fig.axes:
         assert ax is not None
+    plt.close(fig)
+
+
+def test_create_prediction_figure_raises_on_empty_target_predictions():
+    """Empty target_predictions raises ValueError before any figure is allocated."""
+    permutation_results = [
+        _permutation_result("PC1", 0.8, [0.1, 0.2, 0.3], 0.6, [0.2, 0.3, 0.4])
+    ]
+    open_before = set(plt.get_fignums())
+
+    with pytest.raises(ValueError, match="target_predictions must be non-empty"):
+        create_prediction_figure([], permutation_results)
+
+    assert set(plt.get_fignums()) == open_before
+
+
+def test_create_prediction_figure_raises_on_empty_permutation_results():
+    """Empty permutation_results raises ValueError before any figure is allocated."""
+    target_predictions = [_target_prediction("PC1", [1.0, 2.0], [1.1, 1.9])]
+    open_before = set(plt.get_fignums())
+
+    with pytest.raises(ValueError, match="permutation_results must be non-empty"):
+        create_prediction_figure(target_predictions, [])
+
+    assert set(plt.get_fignums()) == open_before
+
+
+def test_create_prediction_figure_raises_on_missing_pc1_target_and_closes_figure():
+    """Missing 'PC1' target raises ValueError and leaks no figure.
+
+    Regression test for the round-2 `/review-pr` finding (PR #201,
+    Behavioural Correctness): `_pc1_scatter_panel`'s ValueError fires after
+    `plt.subplots()` has already allocated a figure, so without the
+    `create_prediction_figure` try/except closing it, this path would leak
+    one figure per call.
+    """
+    target_predictions = [_target_prediction("trait_a", [1.0, 2.0], [1.1, 1.9])]
+    permutation_results = [
+        _permutation_result("trait_a", 0.7, [0.1, 0.2, 0.3], 0.5, [0.2, 0.3, 0.4])
+    ]
+    open_before = set(plt.get_fignums())
+
+    with pytest.raises(ValueError, match="PC1"):
+        create_prediction_figure(target_predictions, permutation_results)
+
+    assert set(plt.get_fignums()) == open_before

--- a/uv.lock
+++ b/uv.lock
@@ -2138,6 +2138,7 @@ source = { editable = "." }
 dependencies = [
     { name = "adjusttext" },
     { name = "click" },
+    { name = "joblib" },
     { name = "matplotlib" },
     { name = "networkx" },
     { name = "numpy" },
@@ -2180,6 +2181,7 @@ dev = [
 requires-dist = [
     { name = "adjusttext", specifier = ">=1.3.0" },
     { name = "click", specifier = ">=8.0.0" },
+    { name = "joblib", specifier = ">=1.5.2" },
     { name = "matplotlib", specifier = ">=3.10.6" },
     { name = "networkx", specifier = ">=3.5" },
     { name = "numpy", specifier = ">=2.3.2" },


### PR DESCRIPTION
## Summary

Tier 4 of the wheat EDPIE cross-platform genotype-prediction program — closes the gap Tier 3's
own Decision 9 flagged: `logo_cv_predict`'s `spearman_p` uses `scipy.stats.spearmanr`'s asymptotic
approximation, documented as unreliable below n≈20-30, and this program's real sample size is
n≈15-24 genotypes. This tier adds an empirical permutation-null significance test and a
paper-ready summary figure, as strictly additive extensions to Tier 3 (`logo_cv_predict`,
merged #195) and Tier 3.5 (`PredictCrossPlatformStep`, merged #199) — no existing function, CLI
flag, or config field changes shape.

- **`permutation_test()` / `top_quartile_recovery()`** (`cross_platform_prediction.py`, Python-API
  only, hard-depends on Tier 3 only): self-contained — computes the observed R²/RMSE/Spearman ρ/
  top-quartile-recovery via one `logo_cv_predict()` call, then null distributions via
  `n_permutations` shuffled-`y` calls. One-sided p-values are right-tailed for R²/ρ (higher is
  better) and **left-tailed** for RMSE (lower is better — the opposite convention; this exact
  directional bug was caught during this tier's own 4-round adversarial proposal review and is
  guarded by a direct regression test). `top_quartile_recovery`'s chance-level baseline is `2*q/n`,
  not a fixed 25%.
- **`PermutationResult`/`CrossPlatformPermutationResult`** (`result_types.py`), mirroring
  `TargetPrediction`/`CrossPlatformPredictionResult`'s `to_dict()`/`to_json()` contract, kept
  structurally separate (not nested) from the existing prediction result types.
- **`VisualizePredictionStep`**, an optional 7th `CrossPlatformPipeline` task (gated on
  `config.prediction.visualize`, entirely absent — not merely skipped — when disabled). Runs
  `permutation_test()` for every `(target, method)` combination via `joblib.Parallel` parallelized
  across independent targets — empirically verified during design that parallelizing individual
  permutation calls is *slower* than serial, while parallelizing whole per-target loops gives a
  real speedup. Saves one `07_permutation_<method>.json` per method and one composite
  `07_prediction_figure.png` per pair (PC1 obs-vs-pred scatter, all-targets R²-vs-pooled-null
  violin, top-quartile-recovery bar chart) from the primary `reduction_method`'s results.
- Additive `predictor_matrices` extension to `PredictCrossPlatformStep`'s `StepResult.data`, reused
  by the new step instead of rebuilding BLUP-loading/alignment logic a second time.
- `joblib` added as an explicit direct dependency (previously only transitive via scikit-learn).

## Process

Full OpenSpec change at `openspec/changes/add-prediction-permutation-and-figure/` (proposal,
design, tasks, 3 spec deltas). **4 independent rounds of `/review-openspec`** before
implementation — round 1: 5 BLOCKING (a dropped-scenario spec bug, a missing non-finite-value
guard, wrong assumed top-quartile-recovery null math, doc task errors); round 2: 2 new BLOCKING
(an invalid `numpy.random.Generator` API call in round 1's own fix, a task-sequencing bug); round
3: 1 new BLOCKING — a genuine statistical bug (the RMSE p-value formula had the wrong tail
direction, copied from R²/ρ) — plus 1 BLOCKING-adjacent (mock-based tests would silently break
under real multi-process `joblib` dispatch); round 4: **0 new BLOCKING**, first round showing
genuine convergence.

**Manual, non-CI, sign-off-gated real-EDPIE-data validation** (mirroring Tier 3/3.5's own Section
8): all 4 directed pairs ran successfully; total wall time ~21.6 min, worst-case pair (~129
targets) 12m58s — well under the 30-minute gate and less than half the synthetic-fixture-
extrapolated 27.4-minute estimate. Both of Tier 3.5's own nominally-significant correlation hits
remain significant under permutation-based inference; the permutation-based multiple-testing
check (9/354 raw significant, 0/354 FDR-significant) reinforces Tier 3.5's own caveat that
individual hits shouldn't be read as confirmed cross-platform predictability at this sample size.
Signed off by Elizabeth 2026-07-17.

**Post-implementation 5-subagent `/review-pr` self-review** (Code Quality, Testing/TDD,
Statistical Rigor, Performance/Cross-Platform, Behavioural Correctness): 0 BLOCKING across all 5
lenses. Fixed: a real, confirmed `plt.close(fig)` leak in `VisualizePredictionStep` (broke this
codebase's established per-figure-step convention); inconsistent int/bool validation across the 3
permutation config fields; `top_quartile_recovery`'s default `q` silently wrong at `n=1`;
`PermutationTestResult` missing from package-root exports; a naming-collision docstring
cross-reference; a pooling-validity comment.

The full local test suite (`uv run pytest --cov --cov-branch`) also caught a real gap outside this
tier's own new code: `permutation_test`'s new `random_state` parameter made it newly-discoverable
by this repo's whole-package stochastic-function reproducibility sweep
(`test_sweep_covers_all_stochastic_functions`), with no case registered — fixed by adding it to
`tests/reproducibility_cases.py`.

## Test plan

- [x] `openspec validate add-prediction-permutation-and-figure --strict` passes
- [x] `black --check` / `ruff check` clean on every file this branch touches
- [x] Full `uv run pytest --cov --cov-branch`: 2823 passed, 31 skipped, 0 failed
- [x] Full re-run of all Tier 3/3.5/4 + reproducibility + public-API test files together: 298
      passed, 18 skipped, 0 failed (after the self-review fixes: 193 passed, 0 failed)
- [x] Section 11 manual real-EDPIE-data validation, signed off by Elizabeth
- [x] Pre-PR 5-subagent `/review-pr` self-review, all BLOCKING/IMPORTANT findings fixed
- [x] Second, fresh `/review-pr` pass once CI runs on this open PR (mirroring Tier 3/3.5's
      precedent — this pass has caught a real cross-OS/BLAS floating-point issue before)

## Out of scope (follow-ups, not this tier's job)

- #197 — `CrossPlatformSummaryGenerator`/`/cross-platform-summary` doesn't surface prediction or
  permutation results. This tier's new figures/JSON increase the pressure to fix this.
- #198 — `/configure-run-all`/`/dry-run`/`/validate-config` cross-platform/prediction coverage
  gaps (pre-existing).
- Heritability-based `representative_selection_metric` (Tier 3.5 Decision 7, still deferred).

Tracking issue: #200 (also cross-references epic #49, and will close #194 alongside this PR, since
#194's own acceptance criterion #1 — "pure-noise input → R² ≈ 0 within the permutation null" — was
explicitly deferred to this tier).

Closes #200
Closes #194

🤖 Generated with [Claude Code](https://claude.com/claude-code)