### PR TITLE
fix(#80): propagate PCA-filtered trait_names to UMAP and static figures

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -113,6 +113,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (PR #193 review).
 
 ### Fixed
+- `PCAAnalysisStep` now updates `metadata["trait_names"]`/`valid_trait_names`
+  to the zero-variance-filtered feature set after PCA, instead of leaving
+  them as the pre-filter list while only recording
+  `excluded_zero_variance_traits`/`n_traits_after_filtering` alongside them
+  (#80). The pre-filter list is preserved under a new
+  `metadata["original_trait_names"]` key. Downstream, `UMAPAnalysisStep`
+  inherited the stale list directly (silently re-including excluded traits
+  in `feature_cols` and the logged `n_traits`), and the `VizPipeline`
+  orchestrator's `_run_generate_static_figures` cherry-picks `trait_names`/
+  `original_trait_names` from the PCA branch alongside `pca_results`/
+  `top_features` (previously omitted), so static figures now use the
+  corrected set too — this also fixes a latent bug in `create_pca_biplot`,
+  which indexes its `trait_names` argument positionally against
+  `pca_results["loadings"]` and would silently mislabel feature arrows when
+  an excluded trait wasn't the last column of the original trait list.
 - `VizPipelineConfig` now automatically unions `statistics.fixed_effects` into
   `data.additional_exclude_cols` at construction time, so a fixed-effect column
   named outside the hardcoded metadata-substring list (e.g. `"block"`) is no

--- a/openspec/changes/fix-post-pca-trait-names-propagation/design.md
+++ b/openspec/changes/fix-post-pca-trait-names-propagation/design.md
@@ -1,0 +1,134 @@
+## Context
+
+Issue #80 reports that `PCAAnalysisStep` filters zero-variance traits into
+`pca_results["feature_names"]` but never writes that filtered list back into
+pipeline metadata, so downstream steps reading `metadata["trait_names"]` get
+the pre-PCA list. The issue's own "Proposed Fix" section suggests a single
+change: update `pca_analysis.py`'s metadata dict. This document records why
+that alone is insufficient, and what the actual fix requires.
+
+`VizPipeline` (`viz_pipeline.py`) runs 12 steps as a NetworkX DAG, not a
+strict linear chain. Two steps read `trait_names` downstream of PCA, and
+they reach it through different paths:
+
+```
+02_calculate_statistics ─┬─→ 03_pca_analysis ─┬─→ 04_umap_analysis
+                          │                    └─→ 05_cluster_analysis
+                          └─→ 06_heritability_analysis ─→ 08_genotype_aggregation ─→ 09_generate_static_figures
+```
+
+`04_umap_analysis` receives `prev_result` **directly** from `03_pca_analysis`
+(`viz_pipeline.py:333-344`), and `UMAPAnalysisStep.execute` spreads
+`**prev_result.metadata` verbatim (`umap_analysis.py:161-165`). So once
+`PCAAnalysisStep` writes the corrected `trait_names`, UMAP inherits it for
+free — no change needed in `viz_pipeline.py` for that path.
+
+`09_generate_static_figures` does **not** receive `prev_result` from PCA at
+all. Its primary metadata source is `08_genotype_aggregation`
+(`viz_pipeline.py:414-465`), which is a pure passthrough
+(`genotype_aggregation.py:31`) of `06_heritability_analysis`'s metadata,
+itself forked from `02_calculate_statistics` — a branch that never touches
+PCA. The orchestrator already knows it needs specific values from the PCA
+branch and hand-picks them into `combined_metadata`
+(`pca_results`/`top_features`/`n_pca_components`/`pca_explained_variance` at
+`viz_pipeline.py:427-442`, `umap_results` from the UMAP branch at
+443-450) — but `trait_names` isn't one of the picked keys. Fixing
+`pca_analysis.py` alone is therefore a no-op for every static figure: Step 9
+would keep reading the pre-PCA (heritability-filtered, not
+zero-variance-filtered) trait list regardless.
+
+**Severity finding beyond the issue's own description:** `generate_static_figures.py`
+forwards its `trait_cols` variable as `trait_names=` into two plotting
+functions in `visualization.py` that accept a `pca_results` dict alongside
+it: `create_pca_biplot` and `create_feature_contribution_plot`. Both were
+initially suspected of the same bug — positionally indexing into
+`pca_results["loadings"]` using a `trait_names` list that, without this fix,
+is longer than `loadings.shape[0]` whenever a trait was excluded. Verified
+against current source:
+
+- `create_pca_biplot` (`visualization.py:2092`,
+  `n_features = min(len(trait_names), loadings.shape[0])`) **is** affected:
+  `trait_names[idx]` labels each plotted feature arrow where `idx` indexes
+  into `loadings` rows (post-filter). If the unfiltered, longer `trait_cols`
+  is passed and the excluded trait isn't the last column of the original
+  list, arrows get labeled with the wrong trait name — the same "positional
+  misalignment, not a length mismatch a caller would notice" bug class
+  already fixed for the clustering producers under #183, just reached via
+  the pipeline metadata path instead of a producer's own return dict.
+  `tests/test_viz_pipeline_zero_variance.py`'s existing fixture can't catch
+  this: its 4 constant traits are appended *after* the 4 variable ones, so
+  `trait_names[0:n_features]` happens to equal the correct filtered set by
+  coincidence of column order — the mislabeling is latent, not currently
+  exercised by any test.
+- `create_feature_contribution_plot` is **not** affected in current usage:
+  `perform_pca_analysis()` unconditionally sets
+  `result["feature_contributions"]` (`pca.py:889`), a DataFrame already
+  indexed by the correct, filtered `feature_names`. `create_feature_contribution_plot`
+  always takes its "pre-calculated contributions" branch
+  (`visualization.py:1837-1921`) given that key is present, and never reaches
+  the on-the-fly branch that would positionally index the passed-in
+  `trait_names` (that branch is dead code given current pipeline data flow).
+  Passing the corrected `trait_names` is still strictly more correct
+  defensively, but is not fixing an active bug for this function today.
+
+## Goals / Non-Goals
+
+- Goals: make `metadata["trait_names"]`/`valid_trait_names` reflect the
+  traits PCA actually used, for every step that can reach them; preserve the
+  pre-filter list under a new, additive key; fix the verified
+  `create_pca_biplot` mislabeling as a consequence.
+- Non-Goals: restructuring the `VizPipeline` DAG (e.g. routing Step 9 through
+  the PCA branch directly) — the existing cherry-pick pattern is the
+  established convention for this orchestrator and extending it is the
+  minimal, consistent change; persisting excluded-trait metadata to disk
+  (see "Known limitation" in `proposal.md`); touching the
+  heritability/aggregation branch's own (unrelated) trait filtering.
+
+## Decisions
+
+- **Decision:** Fix `pca_analysis.py`'s own metadata output AND extend
+  `viz_pipeline.py`'s existing PCA-branch cherry-pick block, rather than
+  restructuring the DAG so Step 9 depends on PCA metadata directly.
+  **Why:** the cherry-pick pattern already exists and is exactly how this
+  orchestrator wires cross-branch data (see the `umap_results` merge
+  immediately below it); duplicating that pattern for `trait_names` is
+  consistent with the codebase's own convention and touches the fewest
+  lines. Restructuring the DAG's dependency edges would be a larger,
+  riskier change for no additional benefit here.
+- **Decision:** Do not modify `create_feature_contribution_plot` or add a
+  test asserting it mislabels today — it doesn't. Document why in this
+  proposal instead of silently dropping the (incorrect) initial claim, so a
+  future reader doesn't wonder why only `create_pca_biplot` gets a
+  regression test.
+- **Alternative considered:** Have `PCAAnalysisStep` return a *new* key
+  (e.g. `pca_filtered_trait_names`) instead of overwriting `trait_names`/
+  `valid_trait_names` in place. Rejected: every other filtering step
+  (`cleanup_traits.py`, `filter_heritability.py`, `remove_outliers.py`,
+  `detect_outliers.py`) already treats `trait_names`/`valid_trait_names` as
+  the single mutable "traits still in play" contract, updating it in place
+  each time a step filters. Introducing a differently-named key for PCA
+  alone would be inconsistent with that established convention and would
+  require every downstream consumer to know to check yet another key.
+
+## Risks / Trade-offs
+
+- Risk: a caller outside this pipeline's tests relies on `PCAAnalysisStep`'s
+  `trait_names` being the *unfiltered* list. Mitigation: grepped all
+  consumers of `PCAAnalysisStep` output within `src/` and `tests/`; the only
+  consumers are `UMAPAnalysisStep`, `ClusterAnalysisStep`,
+  `IdentifyInterestingGenotypesStep` (via the DAG), and this repo's own
+  tests — no external/public API depends on the old (buggy) value.
+- Trade-off: as noted above, the excluded-trait diagnostics remain
+  in-memory-only (not persisted to disk). Accepted for this proposal's
+  scope; flagged as a follow-up.
+
+## Migration Plan
+
+None required — this is a same-run metadata correction with no persisted
+state or schema to migrate. No breaking changes to any dict's key set.
+
+## Open Questions
+
+- Should excluded-trait metadata be persisted to a run's output directory
+  (e.g. `data/pca/pca_metadata.json`) for post-hoc auditability? Deferred to
+  a follow-up issue per the "Known limitation" note in `proposal.md`.

--- a/openspec/changes/fix-post-pca-trait-names-propagation/proposal.md
+++ b/openspec/changes/fix-post-pca-trait-names-propagation/proposal.md
@@ -1,0 +1,113 @@
+## Why
+
+Fixes #80. Follow-up to #74/#76: `PCAAnalysisStep` correctly computes a
+zero-variance-filtered trait list (`pca_results["feature_names"]`) but never
+writes it back into `metadata["trait_names"]`/`valid_trait_names"`
+(`pca_analysis.py:166-174`) — the shared "traits still in play" contract
+every other filtering step in the pipeline maintains
+(`cleanup_traits.py`, `filter_heritability.py`, `remove_outliers.py`,
+`detect_outliers.py`). Downstream steps that read `trait_names` silently get
+the pre-PCA list instead. See `design.md` for the full investigation:
+why the fix must touch two files, not one (`UMAPAnalysisStep` and
+`GenerateStaticFiguresStep` sit on asymmetric DAG branches relative to
+`PCAAnalysisStep`), and the severity finding that one plotting function
+(`create_pca_biplot`) has a latent positional-mislabeling bug from this same
+root cause, beyond what issue #80 describes.
+
+## What Changes
+
+- `pca_analysis.py` (`PCAAnalysisStep.execute`, ~L166-174): update
+  `metadata["trait_names"]` and `metadata["valid_trait_names"]` (mirrored
+  key, per the existing pipeline-wide convention) to the post-filter
+  `feature_names` list. Add `metadata["original_trait_names"] = list(trait_cols)`
+  to preserve the pre-filter list for traceability. `excluded_zero_variance_traits`
+  and `n_traits_after_filtering` are unchanged.
+- `viz_pipeline.py` (`_run_generate_static_figures`, ~L427-442): extend the
+  existing PCA-branch cherry-pick block to also copy `trait_names` and
+  `original_trait_names` into `combined_metadata`, so Step 9 uses the
+  PCA-corrected list instead of the pre-PCA list relayed from
+  Step 8 → Step 6 → Step 2. This merge is only applied `if pca_task_result:`
+  (existing guard) — when PCA doesn't run, Step 9 keeps the
+  `08_genotype_aggregation` branch's own value unchanged.
+- `generate_static_figures.py` (~L121): no logic change — once the
+  orchestrator forwards the corrected key, the existing
+  `metadata.get("trait_names", metadata.get("valid_trait_names", []))`
+  lookup and its downstream uses (lines 345, 409, 537) automatically resolve
+  to the filtered, correctly-aligned set. This corrects the real, verified
+  positional-mislabeling bug in `create_pca_biplot` (arrows silently
+  mislabeled when an excluded trait isn't the last original column, see
+  `design.md`). It does **not** change `create_feature_contribution_plot`'s
+  behavior: that function always takes the "pre-calculated contributions"
+  branch (`pca_results["feature_contributions"]`, unconditionally set by
+  `perform_pca_analysis()` at `pca.py:889`, already indexed by the correct
+  filtered `feature_names`) and never uses its own `trait_names` parameter
+  positionally in current pipeline usage — passing the corrected list is
+  still strictly more correct, just not a behavior change for this function
+  today.
+- Do **not** touch `generate_summary_viz.py`. Step 12 deliberately sources
+  `trait_names` from `02_calculate_statistics` (pre-PCA) via
+  `viz_pipeline.py:504`, for an "how many traits were in the input" report
+  number (`n_traits_final`), not "how many made it into PCA/UMAP." Changing
+  that source would change the meaning of an existing summary-report field;
+  it isn't flagged in #80 and the heritability/aggregation branch's own
+  trait-filtering logic (steps 6-8) is untouched by this proposal.
+- Add regression coverage (see `tasks.md` for full detail, including reuse
+  of existing interleaved-trait fixtures instead of hand-rolling new ones):
+  - `test_step_pca_analysis.py`: assert the corrected metadata contract on
+    an **interleaved** (non-trailing) zero-variance fixture, and the
+    unchanged-value case when nothing is excluded.
+  - `test_step_umap_analysis.py`: assert `UMAPAnalysisStep`, driven by an
+    actually-executed `PCAAnalysisStep` result (not a hand-mocked one) that
+    excluded traits, uses the filtered `trait_names` for `feature_cols` and
+    the logged `n_traits`.
+  - `test_viz_pipeline_zero_variance.py`: an interleaved-constant-trait
+    pipeline variant (catching the biplot mislabeling the existing
+    trailing-only fixture cannot), a `config.umap.enabled = True` assertion
+    that `umap_parameters.json`'s `n_traits` is 4 not 8, an assertion that
+    `09_generate_static_figures`'s effective `trait_names` matches the
+    PCA-filtered set, and a regression test that Step 9 keeps the
+    pre-PCA value when the PCA step doesn't run.
+
+## Impact
+
+- Affected specs: `visualization-pipeline` — modify the "Pipeline Step
+  Parameter Passing" requirement to add `trait_names`/`original_trait_names`
+  propagation rules for `PCAAnalysisStep`, and add a new requirement
+  covering the orchestrator's metadata merge for `GenerateStaticFiguresStep`.
+- Affected code:
+  - `src/sleap_roots_analyze/pipeline/steps/pca_analysis.py` (~L166-174)
+  - `src/sleap_roots_analyze/pipeline/pipelines/viz_pipeline.py`
+    (`_run_generate_static_figures`, ~L427-450)
+  - `src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py`
+    (~L121) — no logic change, benefits once the orchestrator forwards the
+    corrected key
+  - `tests/test_step_pca_analysis.py`, `tests/test_step_umap_analysis.py`,
+    `tests/test_viz_pipeline_zero_variance.py`
+  - `docs/CHANGELOG.md` `[Unreleased]` — new `### Fixed` entry
+- No breaking changes: `trait_names`/`valid_trait_names` keys already exist
+  on every step's metadata; only their *value* changes, and only for inputs
+  that have zero-variance traits — a case the issue documents as already
+  producing wrong values downstream today. `original_trait_names` is a new,
+  additive key. No change to step ordering, DAG shape, or any dict's key
+  set otherwise.
+- Explicitly out of scope: `generate_summary_viz.py`'s pre-PCA trait count
+  (see above); `HierarchicalResult`/clustering `feature_names` (separate bug
+  class, already handled for clustering producers under #183); the
+  heritability/aggregation branch's own trait-filtering logic (steps 6-8),
+  which is independent of PCA's zero-variance filter and stays untouched;
+  reordering or renaming any trait — this proposal only propagates a list
+  that `perform_pca_analysis()` already computes correctly. **Known
+  limitation, not fixed here:** none of the trait-name metadata this
+  proposal corrects (`trait_names`, `original_trait_names`,
+  `excluded_zero_variance_traits`) is persisted to a run's output directory
+  today — it only lives in the in-memory `StepResult` chain for the
+  duration of one pipeline execution, so a scientist auditing a completed
+  run's files after the fact still can't see which traits PCA excluded.
+  Persisting it (e.g. a small `pca_metadata.json` alongside
+  `data/pca/loadings.csv`) is a reasonable follow-up but is additional new
+  scope beyond what #80 asks for, so it's left for a separate issue/proposal.
+- Related: #74/#76 (original PCA zero-variance fix; this proposal is its
+  direct follow-up for the metadata side-effect it left unaddressed); #183
+  (same "positional relabeling from an unfiltered name list" bug class,
+  fixed for the clustering producers' own return dicts rather than pipeline
+  metadata).

--- a/openspec/changes/fix-post-pca-trait-names-propagation/specs/visualization-pipeline/spec.md
+++ b/openspec/changes/fix-post-pca-trait-names-propagation/specs/visualization-pipeline/spec.md
@@ -1,0 +1,114 @@
+## MODIFIED Requirements
+
+### Requirement: Pipeline Step Parameter Passing
+The `GenerateStaticFiguresStep` SHALL pass genotype highlighting parameters from configuration to underlying plotting functions.
+
+The `PCAAnalysisStep` SHALL use the post-filtering feature names returned by
+`perform_pca_analysis()` (via `pca_results["feature_names"]`) instead of the original
+`trait_cols` list when constructing the loadings DataFrame index, computing
+`n_features_total` for feature selection, and mapping feature indices to names.
+
+The `PCAAnalysisStep` SHALL log the names and count of any traits excluded due to zero
+variance, and SHALL emit a Python `UserWarning` when more than 50% of input traits are
+excluded.
+
+The `PCAAnalysisStep` SHALL store `excluded_zero_variance_traits` (list of excluded trait
+names) and `n_traits_after_filtering` (int) in its output metadata for downstream
+inspection and reproducibility.
+
+The `PCAAnalysisStep` SHALL update `metadata["trait_names"]` and
+`metadata["valid_trait_names"]` to the post-filtering feature name list
+(`pca_results["feature_names"]`), matching the same-named keys' meaning
+("traits still in play") maintained by every other filtering step in the
+pipeline (`cleanup_traits.py`, `filter_heritability.py`,
+`remove_outliers.py`, `detect_outliers.py`). The `PCAAnalysisStep` SHALL
+additionally store `metadata["original_trait_names"]`, the pre-filtering
+trait list, so the excluded traits remain traceable from metadata alone.
+
+#### Scenario: Pass parameters to PCA biplot
+- **WHEN** generating PCA biplot via `create_pca_biplot`
+- **THEN** the step SHALL pass `config.static_viz.genotypes_to_color` to the function
+- **AND** the step SHALL pass `config.static_viz.highlight_genotypes` to the function
+
+#### Scenario: Pass parameters to PC boxplots
+- **WHEN** generating PC boxplots via `create_pc_genotype_boxplots`
+- **THEN** the step SHALL pass `config.static_viz.highlight_genotypes` to the function
+- **AND** the highlighted genotypes SHALL appear in gold with bold labels
+
+#### Scenario: PCA step handles zero-variance traits gracefully
+- **WHEN** the input DataFrame contains traits with zero variance (constant values)
+- **THEN** the PCA step SHALL complete successfully using only non-zero-variance traits
+- **AND** the loadings CSV index SHALL match the actual features used in PCA
+- **AND** `excluded_zero_variance_traits` SHALL list the excluded trait names in metadata
+- **AND** `n_traits_after_filtering` SHALL reflect the count of traits actually used
+
+#### Scenario: PCA step warns on high zero-variance fraction
+- **WHEN** more than 50% of input traits have zero variance
+- **THEN** the PCA step SHALL emit a `UserWarning` indicating potential data quality issues
+- **AND** the step SHALL still complete successfully with the remaining traits
+
+#### Scenario: PCA step with no zero-variance traits
+- **WHEN** all input traits have non-zero variance
+- **THEN** the PCA step SHALL behave identically to current behavior
+- **AND** `excluded_zero_variance_traits` SHALL be an empty list
+- **AND** no warning SHALL be emitted
+
+#### Scenario: trait_names reflects the post-PCA-filter set
+- **WHEN** `PCAAnalysisStep` excludes one or more zero-variance traits
+- **THEN** `metadata["trait_names"]` and `metadata["valid_trait_names"]` SHALL
+  equal `pca_results["feature_names"]` (the filtered set), not the pre-filter
+  `trait_cols`
+- **AND** `metadata["original_trait_names"]` SHALL equal the pre-filter
+  `trait_cols`, in original order
+
+#### Scenario: trait_names unchanged when nothing is excluded
+- **WHEN** all input traits have non-zero variance
+- **THEN** `metadata["trait_names"]`, `metadata["valid_trait_names"]`, and
+  `metadata["original_trait_names"]` SHALL all be equal to the input
+  `trait_cols`
+
+#### Scenario: UMAP inherits the corrected trait set via direct metadata spread
+- **WHEN** `UMAPAnalysisStep` executes with `prev_result` from
+  `PCAAnalysisStep`
+- **THEN** the trait columns used for `feature_cols` in
+  `perform_umap_analysis()`, and the `n_traits` value logged to
+  `umap_parameters.json`, SHALL reflect the PCA-filtered trait count, not the
+  pre-filter count
+
+## ADDED Requirements
+
+### Requirement: Static Figures Trait Metadata Merge
+The `VizPipeline` orchestrator's `_run_generate_static_figures` task SHALL
+merge the PCA-corrected `trait_names` and `original_trait_names` from the
+`03_pca_analysis` branch into `GenerateStaticFiguresStep`'s combined
+metadata, in addition to the `pca_results`/`top_features`/
+`n_pca_components`/`pca_explained_variance` keys it already merges from that
+branch. `GenerateStaticFiguresStep`'s primary metadata source
+(`08_genotype_aggregation`) is on a separate DAG branch
+(`02_calculate_statistics` → `06_heritability_analysis` →
+`08_genotype_aggregation`) that never passes through PCA, so without this
+merge the step would continue to see the pre-PCA trait list regardless of
+what `PCAAnalysisStep` writes to its own metadata.
+
+#### Scenario: Static figures use the PCA-filtered trait set
+- **WHEN** `PCAAnalysisStep` has excluded one or more zero-variance traits
+  and `GenerateStaticFiguresStep` subsequently runs
+- **THEN** `GenerateStaticFiguresStep`'s `trait_cols` (read from
+  `metadata.get("trait_names", ...)`) SHALL equal the PCA-filtered set
+- **AND** trait distribution plots (histograms, boxplots) SHALL NOT be
+  generated for excluded zero-variance traits
+- **AND** `create_pca_biplot` SHALL receive a `trait_names` list whose length
+  and order match `pca_results["loadings"].shape[0]`, so biplot feature
+  arrows are not silently mislabeled when an excluded trait is not the last
+  column of the original trait list
+
+#### Scenario: Static figures keep the pre-PCA trait list when the PCA task result is absent
+- **WHEN** `_run_generate_static_figures` is invoked with no
+  `"03_pca_analysis"` entry in its task-result kwargs (there is no
+  `config.pca.enabled` flag in this codebase — PCA always executes when
+  scheduled; this models the DAG executor omitting a task result, e.g. after
+  an upstream task failure)
+- **THEN** `GenerateStaticFiguresStep`'s combined metadata SHALL keep the
+  `trait_names` value relayed from `08_genotype_aggregation`, unmodified —
+  the PCA-branch merge (guarded by `if pca_task_result:`) SHALL NOT overwrite
+  it with a missing/empty value

--- a/openspec/changes/fix-post-pca-trait-names-propagation/tasks.md
+++ b/openspec/changes/fix-post-pca-trait-names-propagation/tasks.md
@@ -1,0 +1,149 @@
+# Tasks: fix-post-pca-trait-names-propagation
+
+**Suggested commit grouping**: Tasks 1-3 → one `test(#80):` commit (red);
+Task 4 → one `fix(#80):` commit (green); Task 5 → folded into whichever
+commit is last, plus a final `docs(#80):` commit for the checklist. (Note:
+the `fix-clustering-feature-names-mismatch` precedent this pattern was
+originally modeled on actually landed as 6 interleaved commits and was
+squash-merged into `main` as a single commit — the fine-grained sequence
+matters less than it might seem, since squash-merge collapses it anyway.
+What matters is: never leave a red/broken state as the branch tip while the
+PR is open for review, and land Tasks 4.1+4.2 together, never split across
+commits — see the note in Task 4.) Recent merged PRs in this repo (#185,
+#195, #199, #201) all target `main` directly, including release-cut PRs —
+this PR should too.
+
+## Task 1: Fixtures
+- [x] 1.1 For the `test_step_pca_analysis.py` unit test in Task 2, reuse an
+      existing interleaved-trait fixture from `tests/fixtures.py` instead of
+      hand-rolling new data — `pca_zero_std_features` (`fixtures.py:1608`,
+      alternating normal/zero-std columns) or `pca_constant_feature_data`
+      (`fixtures.py:1269`, constant/constant/variable/variable/constant) both
+      already interleave constant and variable columns, which is exactly
+      what's needed to distinguish "filtered by value" from "filtered by
+      trailing-slice coincidence". Used `pca_constant_feature_data`.
+- [x] 1.2 For the `test_viz_pipeline_zero_variance.py` pipeline-level CSV
+      fixture (Task 3), add a new variant of `csv_with_zero_variance_traits`
+      with constant traits interleaved among the variable ones (no existing
+      fixture carries the Barcode/Genotype/Replicate columns a full
+      `VizPipeline` run needs) — use `viz_constant_trait_data`
+      (`fixtures.py:1880`) as precedent for column shape/order, not
+      `csv_with_zero_variance_traits`'s current trailing-only order. Added
+      `csv_with_interleaved_zero_variance_traits`.
+
+## Task 2: Write failing tests — PCA step metadata contract (TDD Red Phase)
+- [x] 2.1 In `test_step_pca_analysis.py`, add a test asserting
+      `metadata["trait_names"] == metadata["valid_trait_names"] == pca_results["feature_names"]`
+      after running `PCAAnalysisStep` on the interleaved fixture (Task 1.1)
+- [x] 2.2 Assert `metadata["original_trait_names"] == trait_cols` (the
+      pre-filter list, same order as input)
+- [x] 2.3 Add a test for the no-exclusions case (spec scenario "trait_names
+      unchanged when nothing is excluded"): using the existing non-zero-variance
+      `sample_data` fixture, assert `trait_names == valid_trait_names ==
+      original_trait_names == trait_cols`
+- [x] 2.4 Run tests, confirm 2.1/2.2 FAIL on current code (`trait_names`
+      still equals the unfiltered `trait_cols`, and `original_trait_names`
+      doesn't exist yet); confirm 2.3 already PASSES on current code (it's a
+      regression guard, not a red test — nothing changes in the
+      no-exclusions path). Confirmed exactly as predicted.
+
+## Task 3: Write failing tests — downstream propagation (TDD Red Phase)
+- [x] 3.1 In `test_step_umap_analysis.py`, add a test that **actually
+      executes** `PCAAnalysisStep` on the interleaved fixture (Task 1.1) and
+      feeds its real resulting `StepResult` into `UMAPAnalysisStep` — do NOT
+      reuse the file's existing hand-mocked `prev_result` fixture (it
+      hard-codes `trait_names` to the full list and would pass both before
+      and after the fix, never exercising the bug). Assert the UMAP
+      params/logged `n_traits` reflect the filtered trait count, not the
+      original.
+- [x] 3.2 In `test_viz_pipeline_zero_variance.py`, add a test using the
+      interleaved fixture (Task 1.2) with `config.umap.enabled = True`
+      asserting `umap_parameters.json`'s `n_traits` equals 4 (filtered), not
+      8 (original)
+- [x] 3.3 In `test_viz_pipeline_zero_variance.py`, add a test asserting
+      `results["09_generate_static_figures"].data.metadata["trait_names"]`
+      equals the PCA-filtered set — confirm it currently equals the
+      pre-PCA set relayed from `08_genotype_aggregation` instead
+- [x] 3.4 There is no `config.pca.enabled` flag in this codebase (unlike
+      `umap`/`clustering`/`heritability`) — PCA always executes when
+      scheduled, so "PCA disabled" isn't reachable through config. Instead,
+      add a focused unit test (in `test_viz_pipeline_zero_variance.py` or a
+      new `test_viz_pipeline_orchestrator.py`) that calls
+      `VizPipeline._run_generate_static_figures(config, run_dir, logger, **kwargs)`
+      directly with `"08_genotype_aggregation"` present but `"03_pca_analysis"`
+      omitted from `kwargs` (simulating the DAG executor never producing a
+      PCA task result, e.g. after an upstream failure) and
+      `config.static_viz.enabled = False` (so the step returns
+      `prev_result.metadata` verbatim with no figure generation needed).
+      Assert the returned metadata's `trait_names` equals the
+      `08_genotype_aggregation` branch's own value, unmodified — this should
+      already PASS on current code (guards against the Task 4.2 merge
+      accidentally overwriting with a missing value when the PCA task result
+      isn't in kwargs). Added `TestGenerateStaticFiguresMetadataMergeGuard`
+      in `test_viz_pipeline_zero_variance.py`; confirmed it passes both
+      before and after Task 4.
+- [x] 3.5 Do not add `@pytest.mark.integration` to any of the new
+      `test_viz_pipeline_zero_variance.py` tests — the existing tests in
+      that file already run a full 12-step pipeline without that marker and
+      execute in CI's default `-m "not integration"` job on all 3 OSes;
+      adding the marker would silently skip these new regression tests in CI
+- [x] 3.6 Run tests, confirm 3.1-3.3 FAIL on current code and 3.4 PASSES.
+      Confirmed exactly as predicted (3.1: n_traits=6 got vs 4 expected;
+      3.2: n_traits=8 vs 4; 3.3: full pre-PCA 8-trait list vs the 4-trait
+      filtered list; 3.4 passed pre-fix as a true no-op regression guard).
+
+## Task 4: Implement the fix (TDD Green Phase)
+- [x] 4.1 `pca_analysis.py` (~L166-174): set `metadata["trait_names"]` and
+      `metadata["valid_trait_names"]` to `feature_names`; add
+      `metadata["original_trait_names"] = list(trait_cols)`
+- [x] 4.2 `viz_pipeline.py` (`_run_generate_static_figures`, ~L427-442):
+      extend the PCA-branch cherry-pick block to also copy `trait_names` and
+      `original_trait_names` from `pca_step_result.metadata` into
+      `combined_metadata`, inside the existing `if pca_task_result:` guard
+      (so Task 3.4's PCA-disabled regression stays green)
+- [x] 4.3 Commit 4.1 and 4.2 together, never split across commits — Task
+      3.3's test stays red with only 4.1 applied (see `design.md`)
+- [x] 4.4 Run all Task 2-3 tests, confirm PASS (green). All 8 new tests
+      pass; the 2 sanity/regression-guard tests continued passing throughout.
+- [x] 4.5 Run the full existing suite for the three affected test files plus
+      `test_step_generate_static_figures.py`, confirm no regressions (in
+      particular, `test_viz_pipeline_zero_variance.py`'s existing
+      trailing-only-fixture tests must still pass unchanged). 115/115 passed.
+
+## Task 5: Verify no regressions
+- [x] 5.1 Full test suite: **could not be completed locally.** Four separate
+      attempts to run the full ~1939-test suite (and a ~46-file
+      `test_step_*.py` subset) in this environment — via background
+      execution, foreground execution with an explicit 590-600s timeout, and
+      with output redirected to a file — all failed to return usable output
+      (empty output, non-pytest exit codes), while the same invocation
+      pattern reliably succeeds for smaller/faster runs (confirmed for the
+      115-test directly-affected-files run, which completed in ~123s with
+      full output). This looks like an environment/tooling limitation on
+      long-running commands in this session, not a test failure — CI runs
+      this exact suite (`pytest -m "not integration" tests/` per
+      `.github/workflows/ci.yml`) across Ubuntu/Windows/macOS with a 30
+      minute budget per OS, and is the authoritative full-suite gate for
+      this PR. Local verification is scoped to: the three directly-modified
+      test files, `test_step_generate_static_figures.py` (115 tests, all
+      pass, Task 4.5), ruff, black, and mypy (below) — the actual code
+      change is two small, targeted edits (`pca_analysis.py` metadata dict,
+      `viz_pipeline.py` cherry-pick block) with no plausible mechanism for
+      breaking unrelated modules.
+- [x] 5.2 Linting, formatting, and the frozen mypy baseline pass
+      (`uv run ruff check`, `uv run black --check`,
+      `uv run mypy src/sleap_roots_analyze | uv run mypy-baseline filter --baseline-path .mypy-baseline.txt`).
+      `ruff check src/sleap_roots_analyze` (CI's actual scope): all checks
+      passed. `black --check src/sleap_roots_analyze tests`: clean (after
+      running `black` once to reformat the two new/modified test files).
+      `ruff check` on the modified test files (not CI-gated, since CI only
+      lints `src/`, but fixed anyway to match repo docstring conventions):
+      clean. mypy vs. baseline: 0 new errors (375 pre-existing/unresolved,
+      unchanged; 0 fixed, 0 new).
+- [x] 5.3 Update `docs/CHANGELOG.md` `[Unreleased]` with a `### Fixed` entry.
+      No existing #76 entry was found in `docs/CHANGELOG.md` to distinguish
+      from (unlike the `fix-clustering-feature-names-mismatch` precedent,
+      #74/#76 were never given their own changelog entry), so the new entry
+      stands alone; it explains both the `trait_names`/`original_trait_names`
+      metadata correction and the `create_pca_biplot` mislabeling
+      consequence.

--- a/src/sleap_roots_analyze/pipeline/pipelines/viz_pipeline.py
+++ b/src/sleap_roots_analyze/pipeline/pipelines/viz_pipeline.py
@@ -438,6 +438,14 @@ class VizPipeline(BasePipeline):
                     "pca_explained_variance": pca_step_result.metadata.get(
                         "pca_explained_variance"
                     ),
+                    # Issue #80: trait_names/original_trait_names must come
+                    # from the PCA branch too, not just pca_results/top_features
+                    # above — otherwise this step keeps the pre-PCA trait list
+                    # relayed from the heritability/aggregation branch.
+                    "trait_names": pca_step_result.metadata.get("trait_names"),
+                    "original_trait_names": pca_step_result.metadata.get(
+                        "original_trait_names"
+                    ),
                 }
             )
 

--- a/src/sleap_roots_analyze/pipeline/steps/pca_analysis.py
+++ b/src/sleap_roots_analyze/pipeline/steps/pca_analysis.py
@@ -162,7 +162,13 @@ class PCAAnalysisStep(BaseStep):
         # but not the PCA model object itself
         pca_results_serializable = {k: v for k, v in pca_results.items() if k != "pca"}
 
-        # Update metadata
+        # Update metadata. `trait_names`/`valid_trait_names` are corrected to
+        # the post-filtering feature set here, matching the "traits still in
+        # play" contract every other filtering step maintains (cleanup_traits,
+        # filter_heritability, remove_outliers, detect_outliers) — downstream
+        # steps that read `trait_names` must see the traits PCA actually used,
+        # not the pre-filter list. `original_trait_names` preserves the
+        # pre-filter list for traceability.
         metadata = {
             **prev_result.metadata,
             "pca_results": pca_results_serializable,
@@ -171,6 +177,9 @@ class PCAAnalysisStep(BaseStep):
             "pca_explained_variance": explained_var,
             "excluded_zero_variance_traits": excluded_traits,
             "n_traits_after_filtering": len(feature_names),
+            "trait_names": feature_names,
+            "valid_trait_names": feature_names,
+            "original_trait_names": list(trait_cols),
         }
 
         return StepResult(

--- a/tests/test_step_pca_analysis.py
+++ b/tests/test_step_pca_analysis.py
@@ -725,3 +725,130 @@ class TestPCAZeroVarianceHandling:
             f"Loadings index {set(loadings.index)} does not match "
             f"expected variable traits {variable_traits}"
         )
+
+
+class TestPCATraitNamesMetadataPropagation:
+    """Regression tests for Issue #80.
+
+    `PCAAnalysisStep` must update `metadata["trait_names"]`/
+    `valid_trait_names` to the post-filter feature set (matching the
+    "traits still in play" contract every other filtering step maintains),
+    and preserve the pre-filter list under `original_trait_names`.
+    """
+
+    @pytest.fixture
+    def config_interleaved(self):
+        """Config for the interleaved zero-variance fixture (2 real features)."""
+        return QCPipelineConfig(
+            pipeline_name="test_pca_trait_names_interleaved",
+            data=DataConfig(csv_path="test.csv"),
+            pca=PCAConfig(
+                n_components=1,
+                standardize=True,
+                n_top_features=2,
+                feature_selection_strategy="top_absolute",
+            ),
+        )
+
+    @pytest.fixture
+    def prev_result_interleaved(self, pca_constant_feature_data):
+        """Previous step result using the interleaved constant/variable fixture.
+
+        `pca_constant_feature_data` (tests/fixtures.py) has columns
+        [constant1, constant2, variable1, variable2, constant3] — the
+        excluded traits are NOT confined to the end of the list, so a
+        buggy prefix-slice (`trait_names[:n_features]`) would wrongly
+        yield [constant1, constant2] instead of the correct
+        [variable1, variable2].
+        """
+        trait_cols = list(pca_constant_feature_data.columns)
+        return StepResult(
+            data=pca_constant_feature_data,
+            metadata={"trait_cols": trait_cols},
+        )
+
+    def test_trait_names_reflects_post_filter_feature_set(
+        self,
+        config_interleaved,
+        pca_constant_feature_data,
+        prev_result_interleaved,
+        tmp_path,
+    ):
+        """metadata['trait_names']/'valid_trait_names' equal the filtered feature_names."""
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=pca_constant_feature_data,
+            config=config_interleaved,
+            run_dir=tmp_path,
+            prev_result=prev_result_interleaved,
+        )
+
+        feature_names = result.metadata["pca_results"]["feature_names"]
+        assert feature_names == ["variable1", "variable2"]
+
+        assert result.metadata["trait_names"] == feature_names
+        assert result.metadata["valid_trait_names"] == feature_names
+
+        # Guard against the specific bug this regression targets: a naive
+        # prefix slice of the original (unfiltered) list would silently
+        # substitute the wrong names instead of raising an error.
+        original_trait_cols = list(pca_constant_feature_data.columns)
+        naive_prefix_slice = original_trait_cols[: len(feature_names)]
+        assert result.metadata["trait_names"] != naive_prefix_slice
+
+    def test_original_trait_names_preserves_pre_filter_list(
+        self,
+        config_interleaved,
+        pca_constant_feature_data,
+        prev_result_interleaved,
+        tmp_path,
+    ):
+        """metadata['original_trait_names'] preserves the full pre-filter list, in order."""
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=pca_constant_feature_data,
+            config=config_interleaved,
+            run_dir=tmp_path,
+            prev_result=prev_result_interleaved,
+        )
+
+        assert result.metadata["original_trait_names"] == list(
+            pca_constant_feature_data.columns
+        )
+
+    def test_trait_names_unchanged_when_nothing_excluded(
+        self, config, sample_data, tmp_path
+    ):
+        """Verify trait_names/valid_trait_names/original_trait_names are unchanged.
+
+        When no trait is zero-variance, all three equal the input trait list.
+
+        Seeds `prev_result.metadata` with `trait_names`/`valid_trait_names`
+        already set (as the real upstream `StatisticalAnalysisStep` does),
+        rather than only `trait_cols` — this is a pure passthrough guard, not
+        a red test, so it must reflect the metadata shape PCAAnalysisStep
+        actually receives in production.
+        """
+        trait_cols = ["trait1", "trait2", "trait3", "trait4", "trait5", "trait6"]
+        prev_result_with_trait_names = StepResult(
+            data=sample_data,
+            metadata={
+                "trait_names": trait_cols,
+                "valid_trait_names": trait_cols,
+                "metadata_cols": ["Barcode", "geno", "rep"],
+            },
+        )
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=sample_data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=prev_result_with_trait_names,
+        )
+
+        assert result.metadata["trait_names"] == trait_cols
+        assert result.metadata["valid_trait_names"] == trait_cols
+        assert result.metadata["original_trait_names"] == trait_cols

--- a/tests/test_step_umap_analysis.py
+++ b/tests/test_step_umap_analysis.py
@@ -18,7 +18,7 @@ from sleap_roots_analyze.pipeline import (
 from sleap_roots_analyze.pipeline.config.components import StatisticsConfig, UMAPConfig
 from sleap_roots_analyze.pipeline.config.viz_config import VizPipelineConfig
 from sleap_roots_analyze.pipeline.core import StepResult
-from sleap_roots_analyze.pipeline.steps import UMAPAnalysisStep
+from sleap_roots_analyze.pipeline.steps import PCAAnalysisStep, UMAPAnalysisStep
 
 
 @pytest.fixture
@@ -440,3 +440,81 @@ class TestUMAPConfigParameters:
             )
 
             assert result.metadata["umap_results"]["min_dist"] == min_dist
+
+
+class TestUMAPTraitNamesPropagation:
+    """Regression tests for Issue #80.
+
+    `UMAPAnalysisStep` inherits `prev_result.metadata` verbatim from
+    `PCAAnalysisStep` via a direct dict spread, so once PCA writes the
+    corrected `trait_names`, UMAP must pick it up automatically. Unlike this
+    file's other tests, `prev_result` here must come from an actually-executed
+    `PCAAnalysisStep` (not a hand-mocked `StepResult`) — a mock with
+    `trait_names` hard-coded to the full list would pass both before and
+    after the fix, never exercising the bug.
+    """
+
+    @pytest.fixture
+    def interleaved_trait_data(self):
+        """Data with zero-variance traits interleaved among variable ones."""
+        np.random.seed(42)
+        n_samples = 60
+        return pd.DataFrame(
+            {
+                "Barcode": [f"sample_{i}" for i in range(n_samples)],
+                "Genotype": [f"geno_{i % 4}" for i in range(n_samples)],
+                "Replicate": [i % 3 + 1 for i in range(n_samples)],
+                "trait_constant_a": np.full(n_samples, 1.0),
+                "trait_variable_1": np.random.normal(10.0, 2.0, n_samples),
+                "trait_variable_2": np.random.normal(5.0, 1.0, n_samples),
+                "trait_constant_b": np.full(n_samples, 0.0),
+                "trait_variable_3": np.random.normal(20.0, 3.0, n_samples),
+                "trait_variable_4": np.random.normal(8.0, 1.5, n_samples),
+            }
+        )
+
+    @pytest.fixture
+    def pca_result(self, interleaved_trait_data, viz_config, tmp_path):
+        """Run a real PCAAnalysisStep on interleaved data to build UMAP's prev_result."""
+        trait_cols = [
+            c for c in interleaved_trait_data.columns if c.startswith("trait_")
+        ]
+        prior = StepResult(
+            data=interleaved_trait_data,
+            metadata={"trait_names": trait_cols, "valid_trait_names": trait_cols},
+        )
+        pca_step = PCAAnalysisStep()
+        return pca_step.execute(
+            data=interleaved_trait_data,
+            config=viz_config,
+            run_dir=tmp_path / "pca_run",
+            prev_result=prior,
+        )
+
+    def test_pca_result_excludes_the_two_constant_traits(self, pca_result):
+        """Sanity check on the fixture/PCA step itself, before testing UMAP."""
+        excluded = set(pca_result.metadata["excluded_zero_variance_traits"])
+        assert excluded == {"trait_constant_a", "trait_constant_b"}
+
+    def test_umap_uses_pca_filtered_trait_count(
+        self, viz_config, interleaved_trait_data, pca_result, tmp_path
+    ):
+        """UMAP's feature_cols/logged n_traits reflect PCA's filtered set, not the original."""
+        step = UMAPAnalysisStep()
+
+        step.execute(
+            data=interleaved_trait_data,
+            config=viz_config,
+            run_dir=tmp_path / "umap_run",
+            prev_result=pca_result,
+        )
+
+        umap_dir = tmp_path / "umap_run" / "data" / "umap"
+        with open(umap_dir / "umap_parameters.json") as f:
+            params = json.load(f)
+
+        assert params["n_traits"] == 4, (
+            "UMAP should use the 4 PCA-filtered traits (trait_variable_1..4), "
+            f"not the original 6 (including the 2 excluded constants). "
+            f"Got n_traits={params['n_traits']}"
+        )

--- a/tests/test_viz_pipeline_zero_variance.py
+++ b/tests/test_viz_pipeline_zero_variance.py
@@ -7,11 +7,15 @@ Addresses GitHub Issue #74.
 
 from __future__ import annotations
 
+import json
+import logging
+
 import numpy as np
 import pandas as pd
 import pytest
 
 from sleap_roots_analyze.pipeline import VizPipelineConfig
+from sleap_roots_analyze.pipeline.core import StepResult
 from sleap_roots_analyze.pipeline.pipelines.viz_pipeline import VizPipeline
 
 
@@ -188,3 +192,211 @@ class TestVizPipelineZeroVariance:
         # Should have 2 columns (PC1, PC2) matching config.pca.n_components
         assert loadings.shape[1] == 2
         assert list(loadings.columns) == ["PC1", "PC2"]
+
+
+@pytest.fixture
+def csv_with_interleaved_zero_variance_traits(tmp_path):
+    """CSV with the same trait composition as `csv_with_zero_variance_traits`.
+
+    4 variable + 4 constant traits, but with the constant traits interleaved
+    among the variable ones instead of trailing.
+
+    The trailing-only fixture above cannot distinguish "filtered by value"
+    from "filtered by trailing-slice coincidence" — this one can, since a
+    naive `trait_names[:n_features]` slice of the original column order
+    would wrongly keep the first excluded (constant) trait instead of
+    raising an error or silently substituting the correct one.
+    """
+    np.random.seed(42)
+    n_genotypes = 4
+    n_reps = 5
+    n_samples = n_genotypes * n_reps * 3  # 60 samples
+
+    genotypes = []
+    reps = []
+    for g in range(n_genotypes):
+        for r in range(n_reps):
+            for _ in range(3):
+                genotypes.append(f"GEN_{g:02d}")
+                reps.append(r + 1)
+
+    data = {
+        "Barcode": [f"S{i:03d}" for i in range(n_samples)],
+        "Genotype": genotypes,
+        "Replicate": reps,
+        # constant trait first
+        "lateral_count_day0": np.full(n_samples, 1.0),
+        "primary_root_length": [
+            np.random.normal(10 + int(g.split("_")[1]) * 2, 2.0) for g in genotypes
+        ],
+        "lateral_length_day0": np.full(n_samples, 0.0),
+        "lateral_root_density": [
+            np.random.normal(3 + int(g.split("_")[1]) * 0.5, 0.8) for g in genotypes
+        ],
+        "secondary_count_day0": np.full(n_samples, 0.0),
+        "network_area": [
+            np.random.normal(100 + int(g.split("_")[1]) * 10, 15.0) for g in genotypes
+        ],
+        "tip_angle_day0": np.full(n_samples, 45.0),
+        "root_depth": [
+            np.random.normal(8 + int(g.split("_")[1]), 1.5) for g in genotypes
+        ],
+    }
+
+    df = pd.DataFrame(data)
+    csv_path = tmp_path / "test_interleaved_zero_variance.csv"
+    df.to_csv(csv_path, index=False)
+    return csv_path
+
+
+@pytest.fixture
+def viz_config_for_interleaved_zero_variance(csv_with_interleaved_zero_variance_traits):
+    """VizPipelineConfig with PCA and UMAP enabled, on the interleaved fixture."""
+    config = VizPipelineConfig(pipeline_name="test_interleaved_zero_variance_viz")
+    config.data.csv_path = str(csv_with_interleaved_zero_variance_traits)
+    config.columns.barcode = "Barcode"
+    config.columns.genotype = "Genotype"
+    config.columns.replicate = "Replicate"
+
+    config.pca.n_components = 2
+    config.pca.standardize = True
+    config.pca.n_top_features = 3
+    config.pca.feature_selection_strategy = "top_absolute"
+
+    config.statistics.calculate_anova = True
+    config.statistics.calculate_heritability = True
+
+    # UMAP enabled here (unlike viz_config_for_zero_variance) to exercise
+    # the direct PCA -> UMAP metadata spread end-to-end.
+    config.umap.enabled = True
+    config.clustering.enabled = False
+    config.heritability.enabled = False
+    config.interesting_genotypes.enabled = False
+    config.interactive_viz.enabled = False
+    config.dashboard.enabled = False
+
+    config.static_viz.enabled = True
+
+    return config
+
+
+class TestVizPipelineInterleavedZeroVariance:
+    """Regression tests for Issue #80.
+
+    `PCAAnalysisStep` must update `metadata["trait_names"]` to the
+    zero-variance-filtered set, and that correction must reach both
+    `UMAPAnalysisStep` (direct metadata spread) and
+    `GenerateStaticFiguresStep` (via the orchestrator's PCA-branch
+    cherry-pick in `_run_generate_static_figures`).
+    """
+
+    def test_umap_receives_pca_filtered_trait_count(
+        self, viz_config_for_interleaved_zero_variance, tmp_path
+    ):
+        """Verify UMAP receives the PCA-filtered trait count, not the original.
+
+        `umap_parameters.json`'s `n_traits` reflects the PCA-filtered count
+        (4), not the original count (8), even with interleaved
+        zero-variance traits.
+        """
+        pipeline = VizPipeline(
+            viz_config_for_interleaved_zero_variance,
+            output_dir=tmp_path / "viz_runs",
+            validate=False,
+        )
+        pipeline.run()
+
+        umap_params_path = pipeline.run_dir / "data" / "umap" / "umap_parameters.json"
+        assert umap_params_path.exists()
+        with open(umap_params_path) as f:
+            params = json.load(f)
+
+        assert params["n_traits"] == 4, (
+            f"UMAP should receive the 4 PCA-filtered traits, not the "
+            f"original 8. Got n_traits={params['n_traits']}"
+        )
+
+    def test_static_figures_receive_pca_filtered_trait_names(
+        self, viz_config_for_interleaved_zero_variance, tmp_path
+    ):
+        """Verify static figures receive PCA's filtered trait_names.
+
+        `GenerateStaticFiguresStep`'s effective `trait_names` must equal
+        PCA's filtered `feature_names`, not the pre-PCA list relayed from
+        the heritability/aggregation branch.
+        """
+        pipeline = VizPipeline(
+            viz_config_for_interleaved_zero_variance,
+            output_dir=tmp_path / "viz_runs",
+            validate=False,
+        )
+        results = pipeline.run()
+
+        pca_result = results["03_pca_analysis"].data
+        figures_result = results["09_generate_static_figures"].data
+
+        expected = pca_result.metadata["pca_results"]["feature_names"]
+        actual = figures_result.metadata.get("trait_names")
+
+        assert expected == [
+            "primary_root_length",
+            "lateral_root_density",
+            "network_area",
+            "root_depth",
+        ]
+        assert actual == expected, (
+            f"Static figures step should receive PCA-filtered trait_names "
+            f"{expected}, got {actual} (likely relayed unchanged from the "
+            f"pre-PCA heritability/aggregation branch instead)"
+        )
+
+
+class TestGenerateStaticFiguresMetadataMergeGuard:
+    """Regression guard for Issue #80's fix.
+
+    The orchestrator's PCA-branch metadata merge must not clobber
+    `trait_names` when no PCA task result is available. There is no
+    `config.pca.enabled` flag in this codebase (PCA always executes when
+    scheduled), so this models the DAG executor never producing a
+    `"03_pca_analysis"` result (e.g. after an upstream failure) by calling
+    the orchestrator method directly rather than a full run.
+    """
+
+    def test_keeps_aggregation_branch_trait_names_when_pca_result_absent(
+        self, tmp_path
+    ):
+        """Guard against overwriting trait_names with a missing value.
+
+        Merging PCA-branch metadata must not overwrite `trait_names` when
+        the PCA task result is absent from kwargs.
+        """
+        config = VizPipelineConfig(pipeline_name="test_pca_result_absent_guard")
+        # Skip actual figure generation — GenerateStaticFiguresStep then
+        # returns prev_result.metadata verbatim, so we can assert on the
+        # merged metadata directly without needing real trait/PCA data.
+        config.static_viz.enabled = False
+
+        pipeline = VizPipeline(config, output_dir=tmp_path / "viz_runs", validate=False)
+
+        aggregation_result = StepResult(
+            data=pd.DataFrame({"a": [1, 2, 3]}),
+            metadata={
+                "trait_names": ["trait_a", "trait_b"],
+                "valid_trait_names": ["trait_a", "trait_b"],
+            },
+            files_generated=[],
+        )
+
+        class _FakeTaskResult:
+            def __init__(self, data):
+                self.data = data
+
+        result = pipeline._run_generate_static_figures(
+            config=config,
+            run_dir=tmp_path / "run",
+            logger=logging.getLogger("test_pca_result_absent_guard"),
+            **{"08_genotype_aggregation": _FakeTaskResult(aggregation_result)},
+            # "03_pca_analysis" and "04_umap_analysis" deliberately omitted
+        )
+
+        assert result.metadata["trait_names"] == ["trait_a", "trait_b"]


### PR DESCRIPTION
## Summary

Fixes #80. Follow-up to #74/#76.

`PCAAnalysisStep` correctly computes a zero-variance-filtered trait list (`pca_results["feature_names"]`) but never wrote it back into `metadata["trait_names"]`/`valid_trait_names`. Every other filtering step in the pipeline (`cleanup_traits`, `filter_heritability`, `remove_outliers`, `detect_outliers`) keeps those two keys in lock-step as the shared "traits still in play" contract — PCA was the one step that computed a filtered set and didn't write it back.

- `PCAAnalysisStep` now updates `trait_names`/`valid_trait_names` to the post-filter feature set, and adds `original_trait_names` to preserve the pre-filter list.
- `UMAPAnalysisStep` inherits the fix automatically (direct metadata spread from the PCA step result).
- `GenerateStaticFiguresStep` does **not** inherit it automatically: the `VizPipeline` orchestrator's `_run_generate_static_figures` sources its primary metadata from a separate DAG branch (`02_calculate_statistics -> 06_heritability_analysis -> 08_genotype_aggregation`) that never touches PCA. Its existing PCA-branch cherry-pick (`pca_results`/`top_features`/`n_pca_components`/`pca_explained_variance`) is extended to also copy `trait_names`/`original_trait_names` — fixing `pca_analysis.py` alone would have been a no-op for every static figure.
- This also fixes a latent bug in `create_pca_biplot`, which indexes its `trait_names` argument positionally against `pca_results["loadings"]` and would silently mislabel feature arrows whenever an excluded trait wasn't the last column of the original trait list (same bug class as #183, reached via the pipeline metadata path instead of a producer's own return dict).

Full investigation, severity analysis, and the design rationale (why two files need to change, and why `create_feature_contribution_plot` is *not* affected in current usage) are in `openspec/changes/fix-post-pca-trait-names-propagation/design.md`.

## Process

- OpenSpec proposal drafted, then critically reviewed by a 5-agent adversarial review (spec quality, code/architecture feasibility, GitHub issue alignment, TDD/testing strategy, data traceability + git workflow). All findings addressed: corrected an overstated claim about `create_feature_contribution_plot`, fixed an untestable "PCA disabled" scenario (no such config flag exists), added a missing regression scenario/task, fixed fixture-reuse and test-specificity gaps, and split the deep investigation out into `design.md`.
- TDD: tests written first against an **interleaved** zero-variance fixture (existing fixtures only have trailing constant columns, which can't distinguish "filtered by value" from "filtered by trailing-slice coincidence"), confirmed red, then the two-file fix applied, confirmed green.

## Test plan

- [x] New regression tests in `test_step_pca_analysis.py`, `test_step_umap_analysis.py`, `test_viz_pipeline_zero_variance.py` — all pass
- [x] Full existing suite for the three modified test files + `test_step_generate_static_figures.py`: 115/115 pass, no regressions
- [x] `ruff check src/sleap_roots_analyze` (CI's scope): clean
- [x] `black --check src/sleap_roots_analyze tests`: clean
- [x] mypy vs. frozen baseline: 0 new errors
- [ ] **Full ~1939-test suite**: not run locally — four attempts (background and foreground, with explicit long timeouts) failed to complete in this environment without producing usable output, which looks like a local tooling/environment limitation rather than a test failure, since the same approach reliably completes for smaller scoped runs. CI runs this exact suite (`pytest -m "not integration" tests/`) across Ubuntu/Windows/macOS and is the authoritative full-suite gate here — flagging this explicitly rather than claiming untested coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
