### PR TITLE
fix(#110): OOM in exploratory analysis for large genotype/trait counts

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -113,6 +113,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (PR #193 review).
 
 ### Fixed
+- `ExploratoryAnalysisStep.execute()` and `GenerateStaticFiguresStep` no longer accumulate every
+  step-4/static figure in memory before saving any of them — an OOM (`bad allocation`) on large
+  experiments with many genotypes and traits (#110). Peak concurrently-open figures dropped from
+  45/40 (measured on a 480-genotype x 300-trait fixture) to 4/5. Both steps now save and close each
+  figure immediately after it's produced, via new private generator functions
+  (`_generate_trait_histogram_batches`, `_generate_trait_boxplot_batches`) that the existing public
+  `create_trait_histograms_batched()`/`create_trait_boxplots_by_genotype_batched()` now wrap.
+  Additionally, `create_trait_boxplots_by_genotype()`'s horizontal-orientation branch — previously
+  unbounded, unlike the vertical branch's existing 20" width cap — now caps subplot height at 20"
+  (`max_subplot_height`, mirroring the vertical cap), and
+  `create_trait_boxplots_by_genotype_batched()` gains genotype pagination
+  (`max_genotypes_per_page`, auto-derived from the height cap: ~66 genotypes/page horizontal, ~40
+  vertical): datasets with more genotypes than fit in one readable, capped figure are split across
+  multiple pages instead of producing one memory-safe-but-illegible chart. Visual output changes
+  (capped height, more boxplot figures for very high genotype counts) are intentional, not a
+  regression.
 - `PCAAnalysisStep` now updates `metadata["trait_names"]`/`valid_trait_names`
   to the zero-variance-filtered feature set after PCA, instead of leaving
   them as the pre-filter list while only recording

--- a/openspec/changes/fix-110-oom-exploratory-analysis/design.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/design.md
@@ -1,0 +1,260 @@
+## Context
+
+Two independent memory defects compound in `ExploratoryAnalysisStep.execute()`:
+
+1. Every figure the step generates — summary plots, EDA plots, the full correlation heatmap, and
+   every batched histogram/boxplot — is accumulated into one `all_figures` dict before any of them
+   is saved or closed. Peak memory is the sum of every figure held at once.
+2. `create_trait_boxplots_by_genotype_batched()`'s horizontal-orientation branch has no cap on
+   subplot height, so a single figure can itself be large enough to fail to allocate, independent
+   of (1).
+
+Review of this proposal surfaced a third, related site: `GenerateStaticFiguresStep`
+(`pipeline/steps/generate_static_figures.py:607-664`) calls the same
+`create_trait_histograms_batched()` / `create_trait_boxplots_by_genotype_batched()` and has the
+identical accumulate-then-close pattern (the full batch list is built and held before the first
+`plt.close()` runs). Per explicit user decision, this is bundled into the same change rather than
+filed as a separate follow-up, since it is fixed by consuming the same new generator functions
+introduced for (1) — see Decision 1.
+
+A prior, non-TDD session in this same working tree drafted a fix for (1) and (2) (now stashed, not
+applied, on this branch — `git stash show -p` on `stash@{0}` if it needs to be inspected). Its
+shape is used as a starting point for the design questions below, but every claim here is
+independently re-derived, and the implementation itself will be written test-first via `/tdd`, not
+copied from the stash. In particular, the stash's approach to (2) — adding a cap parameter only to
+`create_trait_boxplots_by_genotype_batched()` — is not sufficient; see Decision 2's correctness
+finding below.
+
+## Decision 1: How to make the batched-figure loops save+close incrementally
+
+**Problem**: `create_trait_histograms_batched()` and `create_trait_boxplots_by_genotype_batched()`
+build and return a full `List[Figure]` internally — by the time a caller gets the list back, all
+batches for that call already coexist in memory. Simply moving the caller's save+close loop
+earlier (right after the `create_*_batched()` call, instead of at the very end) does **not** fix
+this — the expensive accumulation already happened inside the creator function before it returned.
+This is true for both current callers: `ExploratoryAnalysisStep.execute()` (accumulates into
+`all_figures` before any save) and `GenerateStaticFiguresStep` (saves+closes one at a time in a
+loop, but only after the full list already exists in memory).
+
+**Decision**: Split each batched creator into:
+- A private generator (`_generate_trait_histogram_batches`, `_generate_trait_boxplot_batches`) that
+  `yield`s one figure at a time as it's built.
+- The existing public function becomes a thin `list(...)` wrapper over the generator, so any
+  external caller relying on the current list-returning signature is unaffected.
+
+Both `ExploratoryAnalysisStep.execute()` and `GenerateStaticFiguresStep` are updated to iterate the
+generators directly and save+close each figure as it's yielded, so at most one batch figure of a
+given kind is ever open at once (down from up to 57 in the #110 repro). `GenerateStaticFiguresStep`
+keeps its existing periodic `gc.collect()` calls (harmless, now redundant safety margin rather than
+the only defense).
+
+**Alternative considered**: keep the list-returning functions and just have each caller close
+figures "as soon as possible" after the call returns. Rejected — by construction, the whole list
+already exists in memory by the time the function returns, so this doesn't change peak memory at
+all for the batched-figure case, which is the dominant contributor in #110's own memory table (57
+boxplot batches ≈ 4.1 GB of the ~6.5 GB total).
+
+For the smaller, non-batched figures in `ExploratoryAnalysisStep` (summary plots, EDA plots,
+correlation heatmap — a handful of figures, not dozens), `execute()` saves and closes each one
+immediately after creation rather than merging into `all_figures` first.
+
+## Decision 2: Where the horizontal boxplot subplot height cap must actually live
+
+**Problem**: horizontal orientation's `subplot_height = max(subplot_size[1], n_genotypes *
+height_per_genotype)` has no upper bound in either place it's computed. The vertical branch already
+caps its analogous growing dimension (subplot width) at 20 inches.
+
+**Correctness finding (verified directly against the code, not assumed)**: it is not enough to cap
+`batch_figsize` inside `create_trait_boxplots_by_genotype_batched()` (`visualization.py:398-412`)
+alone. That function passes `figsize=batch_figsize` into `create_trait_boxplots_by_genotype()`
+(`visualization.py:416-424`) — but that inner function's own horizontal-orientation branch
+(`visualization.py:188-194`, reached because the batched wrapper never passes `adaptive_config`)
+**unconditionally recomputes and overwrites** `figsize` with the same uncapped formula:
+
+```python
+elif actual_orientation == "horizontal":
+    n_rows = (n_traits + n_cols - 1) // n_cols
+    height_per_genotype = 0.3
+    min_subplot_height = max(4, n_genotypes * height_per_genotype)
+    figsize = (figsize[0], min_subplot_height * n_rows)   # discards the caller's figsize height
+```
+
+Contrast with the vertical branch (`visualization.py:195-203`), which only *conditionally* widens
+(`if adaptive_subplot_width > current_subplot_width`) — a no-op once the caller already applied the
+same cap, which is why the vertical cap actually works end-to-end today. A cap added only to the
+batched wrapper's local variable would be silently discarded before the figure is actually rendered
+— the fix would look correct in isolation (the batched wrapper's own `batch_figsize` variable is
+capped) but have zero effect on the real output.
+
+This inner function is also called directly by `create_exploratory_summary_plots()`
+(`visualization.py:593-597`, used in `ExploratoryAnalysisStep.execute()`'s step 2, unconditionally
+on every run) — but that call site passes `adaptive_config`, so when adaptive sizing is enabled
+(true for the real MO Soybean config that hit this failure) it takes the `adaptive_config is not
+None` branch instead, which is already bounded by `adaptive_config.max_height`. It is only unbounded
+when adaptive sizing is disabled. The batched-boxplot path is unbounded unconditionally, since
+`create_trait_boxplots_by_genotype_batched()` has no `adaptive_config` parameter at all and never
+passes one through.
+
+**Decision**: add `max_subplot_height: float = 20.0` to `create_trait_boxplots_by_genotype()`
+itself, and apply it in that function's horizontal-orientation branch:
+
+```python
+elif actual_orientation == "horizontal":
+    n_rows = (n_traits + n_cols - 1) // n_cols
+    height_per_genotype = 0.3
+    min_subplot_height = min(max_subplot_height, max(4, n_genotypes * height_per_genotype))
+    figsize = (figsize[0], min_subplot_height * n_rows)
+```
+
+`create_trait_boxplots_by_genotype_batched()` (and its new generator counterpart) also gains the
+same `max_subplot_height: float = 20.0` parameter, uses it consistently in its own `batch_figsize`
+precomputation for the `figsize is not None` scaling path, and passes it through to the inner
+`create_trait_boxplots_by_genotype()` call — so the cap holds regardless of which code path a
+caller exercises, and a direct caller of `create_trait_boxplots_by_genotype()` (not just the
+batched wrapper) is protected too.
+
+**Cap value: 20.0 inches**, matching the vertical branch's existing width cap, not a different
+value:
+- It is the direct mirror of the existing, already-reviewed vertical cap (same role: bound the
+  dimension that scales with genotype count), keeping the two branches consistent instead of
+  introducing a second unexplained magic number.
+- At `n_rows` (typically ≤ 4 for a 16-trait batch in a 4-column grid) subplots stacked vertically,
+  a 20" per-subplot cap bounds total figure height at ≤ 80", matching the vertical branch's ≤ 80"
+  total-width bound under the same batch geometry. `GenerateStaticFiguresStep`'s adaptive batch
+  sizing can push `n_rows` up to 9 (batch_size up to 36), giving ≤ 180" — at 300 DPI that is
+  54,000 px, still comfortably under the Agg backend's ~65,536 px per-dimension ceiling, though it
+  uses most of that margin; this is a pre-existing batch-size choice, not something this change
+  alters.
+- The discarded draft used `max_subplot_height=40.0` (2× the vertical cap) without a stated
+  rationale. Doubling the cap does not meaningfully improve readability at the genotype counts
+  where the cap actually binds (at 489 genotypes, 20" ÷ 489 ≈ 0.041"/genotype vs. 40" ÷ 489 ≈
+  0.082"/genotype — both are far below any legible tick-label spacing), so it only buys back
+  memory risk with no real readability benefit. 20.0 is used instead.
+
+**Readability at extreme genotype counts is not solved by the cap alone**: at 489 genotypes
+squeezed into a fixed 20" axis, that's ~0.041"/genotype — far below any legible tick-label spacing,
+regardless of cap value. Per explicit user decision during proposal review, this change adds a
+basic pagination safeguard (Decision 3) rather than deferring readability entirely to a follow-up
+issue.
+
+## Decision 3: Genotype pagination for readability at high genotype counts
+
+**Problem**: the height cap (Decision 2) stops the crash but, by itself, produces an illegible
+chart once genotype count is high enough that the per-genotype spacing that already looks fine
+below the cap (`0.3"/genotype` horizontal, `0.5"/genotype` vertical) no longer fits within
+`max_subplot_height`. That crossover point is itself computable: `max_subplot_height /
+per_genotype_size` — 20 / 0.3 ≈ 66 genotypes (horizontal), 20 / 0.5 = 40 genotypes (vertical).
+
+**Decision**: when `n_genotypes` exceeds that per-page capacity, split genotypes into consecutive
+pages of at most `max_genotypes_per_page` genotypes each (sorted the same way the horizontal
+renderer already sorts them: `sorted(df[genotype_col].unique())`), and render one figure per
+(trait batch, genotype page) combination instead of one figure per trait batch. Every genotype
+still appears, in some output figure, at the same readable per-genotype spacing used today below
+the cap — completeness is preserved (no genotype is silently dropped/sampled out), just spread
+across more files. This is intentionally the simple option: alphabetical paging, not smart
+sampling/clustering — "basic safeguard," not a new visualization feature.
+
+- New parameter `max_genotypes_per_page: Optional[int] = None` on
+  `create_trait_boxplots_by_genotype_batched()` / `_generate_trait_boxplot_batches()`. When `None`,
+  auto-derived from the cap and the orientation actually in effect:
+  `max(1, int(max_subplot_height // per_genotype_size))` where `per_genotype_size` is 0.3
+  (horizontal) or 0.5 (vertical) — so the default is self-consistent with Decision 2's cap rather
+  than a second independent magic number.
+- Because each page's genotype count is bounded by construction (`≤ max_genotypes_per_page`), the
+  per-figure height computed for that page is always `≤ max_subplot_height` — the Decision 2 cap
+  never actually needs to engage in the paginated path. The cap remains a defense-in-depth backstop
+  (protects a direct call to `create_trait_boxplots_by_genotype()` that bypasses pagination, or a
+  bug in the pagination math), while pagination is the mechanism that actually keeps charts
+  readable.
+- Where it lives: `create_trait_boxplots_by_genotype()` itself stays simple — it always renders
+  "every genotype present in the DataFrame it's given." Pagination is the batched wrapper's
+  responsibility: it computes genotype pages, filters the DataFrame to each page's genotype values,
+  and calls the unchanged single-figure renderer once per page.
+- Naming/discoverability: figures stay flatly, sequentially numbered
+  (`04_trait_boxplots_batch_{i+1}`), matching the existing convention where descriptive detail
+  (trait range) lives in the figure's `suptitle`, not the filename. The `suptitle` gains a
+  `" | Genotypes {start}-{end} of {n_genotypes}"` segment whenever more than one genotype page
+  exists, so an opened figure is self-describing.
+- Orientation coupling: since `orientation="auto"` already switches to horizontal above
+  `horizontal_threshold` (default 8), and pagination only meaningfully engages above ~40-66
+  genotypes, the common case (default auto orientation, high genotype count) always pages using the
+  horizontal per-genotype size. An explicit `orientation="vertical"` override with very high genotype
+  counts is handled by the same logic using the vertical per-genotype size (0.5) — a rarer path,
+  still covered, not left as a gap.
+- **Orientation consistency across pages**: `actual_orientation` (resolved once from the *full*
+  dataset's genotype count, before pagination) must be passed explicitly to each per-page call into
+  `create_trait_boxplots_by_genotype()` — not the original possibly-`"auto"` `orientation` argument.
+  Otherwise a small last page (e.g. 3 leftover genotypes after several full pages of 66) could
+  independently re-resolve `"auto"` to vertical for that one page based on its own small count,
+  producing an orientation that's inconsistent with the rest of the same trait batch's pages. This
+  is a genuine gap in the *current* code today (harmless today only because, pre-pagination, every
+  batch already always sees the full dataset's genotype count, so the inner re-resolution always
+  agrees with the outer one) that pagination would otherwise reintroduce; fixed by always passing
+  the pre-resolved `actual_orientation` through, for every page.
+- **Missing-column and NaN safety (round-2 review finding, verified against the code)**: the
+  existing per-genotype rendering path only ever sorts a `.dropna()`'d subset
+  (`visualization.py:217,224`), and only guards `genotype_col in df.columns` in one place
+  (`visualization.py:370`, the `n_genotypes` computation) — there is no existing precedent for an
+  unconditional, unguarded `df[genotype_col].unique()` call. Pagination's genotype-list
+  construction must not introduce one: it SHALL (a) guard `genotype_col in df.columns` before
+  accessing it at all — if absent, pagination is a no-op (single page, matching today's "0
+  genotypes" behavior) rather than raising `KeyError`; (b) drop NaN genotype values before sorting
+  (`df[genotype_col].dropna().unique()`) — sorting a mixed NaN/string array raises `TypeError` in
+  Python, and a NaN "page" would be meaningless anyway.
+
+**Explicitly still out of scope**: `create_exploratory_summary_plots()`'s call into
+`create_trait_boxplots_by_genotype()` (used in `ExploratoryAnalysisStep.execute()`'s step 2,
+`"trait_ranges_by_genotype"`) passes `adaptive_config` when adaptive sizing is enabled, which takes
+a separate code path (`calculate_barplot_size` + `AdaptiveSizingConfig.max_height`, default 16.0") —
+already bounded, unrelated to the horizontal-branch cap/pagination this change adds, and not
+paginated. At very high genotype counts that single combined-genotype figure is still memory-safe
+(bounded at 16") but not addressed for readability by this change; left as-is since it's a
+pre-existing, independently-configured, already-safe code path, not part of the crash this change
+fixes.
+
+## Decision 4: Regression test shape
+
+A synthetic fixture (no proprietary data needed) with a pinned size of **480 genotypes × 300 trait
+columns** (chosen to be in the "hundreds of genotypes" real-failure range while keeping test
+runtime and memory bounded, using the existing low-DPI test convention of `dpi=100`) reproduces the
+shape of the real failure. Properties asserted:
+
+1. **Bounded figure size**: for `n_genotypes` in the hundreds, the horizontal-orientation figure's
+   subplot height stays at or under the cap (20") regardless of genotype count — asserted through
+   the actual rendered `fig.get_size_inches()` of the figure produced by
+   `create_trait_boxplots_by_genotype()` and by `create_trait_boxplots_by_genotype_batched()`, not
+   just an internal local variable, since Decision 2's finding shows those can disagree.
+2. **Cap boundary and override behavior**: exact-equality at the cap boundary
+   (`n_genotypes * 0.3 == max_subplot_height`), and a custom `max_subplot_height` value is honored
+   (not just the default).
+3. **Generator/list parity**: `list(_generate_trait_boxplot_batches(...))` and
+   `create_trait_boxplots_by_genotype_batched(...)` (and the histogram equivalents) produce the
+   same number of figures with the same sizes, and the generator is confirmed to yield lazily (one
+   figure existing at a time), not just be generator syntax around eager work.
+4. **Bounded concurrency**: during `ExploratoryAnalysisStep.execute()` and
+   `GenerateStaticFiguresStep`, the peak number of simultaneously-open matplotlib figures never
+   scales with the total number of figures generated. Measured by tracking `plt.get_fignums()` at
+   **both** figure-creation time and close time (not close time alone — sampling only at close
+   would miss a figure that's created but never explicitly closed, silently undercounting a real
+   leak). The exact small constant this pins to (expected to be a single-digit number, not on the
+   order of dozens) is determined and locked in during the `/tdd` red/green cycle rather than
+   guessed here.
+5. **Empty-input safety**: zero genotypes and zero traits are handled without error for both the
+   capped function and its batched/generator wrappers.
+6. **Pagination correctness**: at 480 genotypes (default `max_genotypes_per_page=66` for
+   horizontal), the batched boxplot output contains multiple genotype pages per trait batch; every
+   one of the 480 genotypes appears in exactly one page's rendered figure (no genotype dropped or
+   duplicated across pages); each individual page's figure height stays at the pre-cap "readable"
+   size (`page_genotype_count * 0.3`, not the 20" cap, since pages are sized to never need it); the
+   `suptitle` of a multi-page batch includes the genotype range; and a genotype count at or below
+   the auto-derived page capacity produces exactly one page (no behavior change from before this
+   decision). Pagination tests use a small, fixed trait count (not the full 300-trait fixture) —
+   pagination is a property of the genotype axis, not the trait axis, and keeping the trait count
+   small keeps these tests fast and keeps a single trait batch unambiguous (needed for tests that
+   check "every genotype appears across pages of the same batch").
+7. **CI runtime budget for the end-to-end test (Task 5)**: with pagination active, the 480x300
+   fixture produces roughly `n_trait_batches × n_genotype_pages` figures (≈8 genotype pages ×
+   ~19 trait batches at `batch_size=16` ≈ 150 small figures). Each is cheap once capped/paginated,
+   but Task 5 must measure actual wall-clock time when first implemented and reduce the trait count
+   if it meaningfully slows the non-integration CI suite — do not assume the estimate above without
+   measuring.

--- a/openspec/changes/fix-110-oom-exploratory-analysis/design.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/design.md
@@ -261,16 +261,28 @@ shape of the real failure. Properties asserted:
 
    **Update after measuring in CI, not just locally**: the 480x300 fixture (and the analogous
    480x30 fixture used for `GenerateStaticFiguresStep`'s equivalent test) ran fine standalone
-   locally (~170-180s each), which read as an acceptable, budgeted cost. It was not acceptable in
-   practice: combined with the rest of the suite, it pushed CI's 30-minute `tests` job timeout on
-   Ubuntu and Windows (confirmed via an actual CI run on the opened PR — both failed at the
-   identical 30m16s mark, mid-suite, not from a real test failure). Reduced both fixtures to
-   100 genotypes x 40 traits (`ExploratoryAnalysisStep`) and 100 genotypes x 12 traits
-   (`GenerateStaticFiguresStep`) — still large enough to trigger genotype pagination (2 pages) and
-   multiple trait batches, still large enough to clearly distinguish a bounded (~4 peak) from an
-   unbounded (near-total-figure-count peak) implementation, at roughly 1/12th the runtime (~15s
-   each). Lesson: for a regression test meant to run in CI's shared job budget, a local-only
-   wall-clock measurement is not sufficient evidence of CI feasibility — the fixture size needs to
-   be validated against an actual CI run, since CI's aggregate job budget (the whole test suite
-   sharing one 30-minute window) is a stricter constraint than "is this one test fast enough on its
-   own."
+   locally (~170-180s each on the implementer's Windows dev machine), which read as an acceptable,
+   budgeted cost. It was not acceptable in practice: combined with the rest of the suite, it pushed
+   CI's 30-minute `tests` job timeout on Ubuntu and Windows (confirmed via an actual CI run on the
+   opened PR — both failed at the identical 30m16s mark, mid-suite, not from a real test failure).
+   Reduced both fixtures to 100 genotypes x 40 traits (`ExploratoryAnalysisStep`) and 100 genotypes
+   x 12 traits (`GenerateStaticFiguresStep`) — still large enough to trigger genotype pagination (2
+   pages) and multiple trait batches, still large enough to clearly distinguish a bounded (~4 peak)
+   from an unbounded (near-total-figure-count peak) implementation.
+
+   **The reduction numbers themselves needed re-measuring in CI, not just locally, too** — an
+   ironic near-repeat of the same mistake. The first draft of this note cited local timing
+   (~170-180s → ~15s, "~12x") as the before/after. Pulled from the actual CI logs of both PR runs
+   instead (per-test durations, Windows job, the three tests these two fixtures drive):
+   `test_peak_concurrent_figures_bounded_during_static_figures` 278.15s → 24.72s (11.2x),
+   `test_execute_completes_and_produces_figures_for_large_dataset` 126.09s → 24.74s (5.1x),
+   `test_peak_concurrent_figures_bounded_during_execute` 123.99s → 24.72s (5.0x). Directionally the
+   same conclusion (a large, decisive reduction that fixed the timeout), but the exact factor is
+   5-11x, not a uniform "~12x," and CI's absolute per-test time (~25s) is noticeably higher than
+   local's (~15s) even after the fix. Lesson, stated more carefully this time: for a regression test
+   meant to run in CI's shared job budget, neither the pass/fail feasibility judgment NOR the
+   specific timing numbers used to justify it should be asserted from local measurement alone —
+   both need to be checked against an actual CI run, since CI's aggregate job budget (the whole test
+   suite sharing one 30-minute window, on hardware that measurably runs slower than a local dev
+   machine for this workload) is a stricter and different constraint than "is this one test fast
+   enough on my machine."

--- a/openspec/changes/fix-110-oom-exploratory-analysis/design.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/design.md
@@ -258,3 +258,19 @@ shape of the real failure. Properties asserted:
    but Task 5 must measure actual wall-clock time when first implemented and reduce the trait count
    if it meaningfully slows the non-integration CI suite — do not assume the estimate above without
    measuring.
+
+   **Update after measuring in CI, not just locally**: the 480x300 fixture (and the analogous
+   480x30 fixture used for `GenerateStaticFiguresStep`'s equivalent test) ran fine standalone
+   locally (~170-180s each), which read as an acceptable, budgeted cost. It was not acceptable in
+   practice: combined with the rest of the suite, it pushed CI's 30-minute `tests` job timeout on
+   Ubuntu and Windows (confirmed via an actual CI run on the opened PR — both failed at the
+   identical 30m16s mark, mid-suite, not from a real test failure). Reduced both fixtures to
+   100 genotypes x 40 traits (`ExploratoryAnalysisStep`) and 100 genotypes x 12 traits
+   (`GenerateStaticFiguresStep`) — still large enough to trigger genotype pagination (2 pages) and
+   multiple trait batches, still large enough to clearly distinguish a bounded (~4 peak) from an
+   unbounded (near-total-figure-count peak) implementation, at roughly 1/12th the runtime (~15s
+   each). Lesson: for a regression test meant to run in CI's shared job budget, a local-only
+   wall-clock measurement is not sufficient evidence of CI feasibility — the fixture size needs to
+   be validated against an actual CI run, since CI's aggregate job budget (the whole test suite
+   sharing one 30-minute window) is a stricter constraint than "is this one test fast enough on its
+   own."

--- a/openspec/changes/fix-110-oom-exploratory-analysis/proposal.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/proposal.md
@@ -1,0 +1,123 @@
+## Why
+
+`ExploratoryAnalysisStep.execute()` (`src/sleap_roots_analyze/pipeline/steps/exploratory_analysis.py`)
+generates all step-4 figures — summary plots, EDA plots, the full correlation heatmap, and every
+batched histogram/boxplot — into a single `all_figures` dict, and only saves+closes them in one
+final loop at the end. Peak memory is the **sum** of every figure held at once, not the size of the
+single largest one.
+
+GitHub Issue #110's own repro (478 samples × 904 traits × 94 genotypes, TTC-SALK soybean) hit
+`bad allocation` after ~455s, with an estimated ~6.5 GB peak dominated by 57 batched boxplot figures
+(94 genotypes × 0.3"/genotype × 4 rows = 112.8" tall each, ~72 MB apiece).
+
+This is not hypothetical: `configs/active/qc/mo_soybean_2021_grouped.yaml` (MO Soybean 2021
+Diversity Screen) hit the identical `"not enough free memory for image buffer"` failure at step
+`04_exploratory_analysis` after ~1858s, with the system down to ~210 MB free RAM out of 32 GB. That
+dataset — 2,675 samples × up to ~1,061 columns × **489 unique genotypes** — is over 5× the
+genotype count of #110's own repro case, confirmed by direct inspection of the run's
+`pipeline_summary.json` (`status: "failed"`) and the underlying data. It is a real, currently-blocked
+scientist-facing experiment, not a synthetic stress test.
+
+A second, related defect compounds this: the horizontal-orientation boxplot sizing (used in both
+`create_trait_boxplots_by_genotype()` and its batched wrapper
+`create_trait_boxplots_by_genotype_batched()` in `src/sleap_roots_analyze/visualization.py`) has no
+cap on subplot height, unlike the vertical-orientation branch, which already caps adaptive subplot
+width at 20 inches (`min(20.0, max(subplot_size[0], n_genotypes * 0.5))`). The horizontal branch —
+which is what actually runs once `n_genotypes > horizontal_threshold` (default 8, so true for
+essentially any real multi-genotype screen) — computes
+`subplot_height = max(subplot_size[1], n_genotypes * height_per_genotype)` with no upper bound. At
+489 genotypes × 0.3"/genotype, that is ~147" per subplot, large enough to fail to allocate **on its
+own**, independent of the accumulation bug above. Issue #110 itself flags this under its P1
+suggestions ("cap subplot height ... when genotypes > 50"). The cap must be applied inside
+`create_trait_boxplots_by_genotype()` itself (not only in the batched wrapper's local size
+calculation) — see `design.md` Decision 2 for why a cap applied only in the batched wrapper would be
+silently discarded before the figure is rendered.
+
+A third site with the identical accumulate-then-close pattern as the P0 defect was found during
+review: `GenerateStaticFiguresStep` (`src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py`)
+calls the same batched creator functions and holds the full batch list in memory before closing
+anything, one batch at a time, in a loop. Per explicit scoping decision, this is fixed in the same
+change rather than filed separately, since the fix reuses the exact generator functions introduced
+for `ExploratoryAnalysisStep` — see `design.md` Decision 1.
+
+GitHub Issue: #110
+
+## What Changes
+
+- **Incremental save+close (P0, from #110 directly)**: both `ExploratoryAnalysisStep.execute()` and
+  `GenerateStaticFiguresStep` save and close each figure immediately after it is produced, instead
+  of accumulating every figure (either explicitly, via `all_figures`, or implicitly, via a fully-
+  materialized batch list) before saving any of them. Peak concurrently-open figures of a given kind
+  drops from "every figure/batch generated" to a small constant. Both steps consume new private
+  generator functions (`_generate_trait_histogram_batches`, `_generate_trait_boxplot_batches`) that
+  yield one batch figure at a time; the existing public list-returning functions become thin
+  wrappers over these generators, so external callers of the public API are unaffected.
+- **Cap horizontal boxplot subplot height (P1, from real-world reproduction)**: add a
+  `max_subplot_height` cap (default 20.0", mirroring the vertical branch's existing width cap) to
+  `create_trait_boxplots_by_genotype()`'s horizontal-orientation branch — the actual point where
+  figsize is finalized before rendering — and thread the same parameter through
+  `create_trait_boxplots_by_genotype_batched()` so both entry points are protected consistently. See
+  `design.md` Decision 2 for why the cap must live there rather than only in the batched wrapper.
+- **Genotype pagination for readability (added per explicit user decision)**: the height cap alone
+  keeps high-genotype-count figures memory-safe but not readable — 489 genotype labels squeezed
+  into a fixed 20" axis is ~0.041"/genotype, illegible regardless of cap value. Per explicit user
+  decision, `create_trait_boxplots_by_genotype_batched()` (and its generator) gain a
+  `max_genotypes_per_page` parameter (auto-derived from the cap when not set: ~66 genotypes/page
+  horizontal, ~40 vertical). When genotype count exceeds that page capacity, genotypes are split
+  into consecutive alphabetically-sorted pages and rendered as separate figures per (trait batch,
+  genotype page) — every genotype still appears, at the same readable per-genotype spacing used
+  today below the cap, just across more output files. See `design.md` Decision 3.
+- **Regression test fixture**: a synthetic DataFrame with a pinned shape (480 genotypes × 300 trait
+  columns) is added to assert (a) the rendered boxplot figure's subplot height stays bounded at high
+  genotype counts, for both the direct and batched entry points, (b) the cap boundary and a custom
+  override are respected, (c) the new generators are lazy and produce output equivalent to the
+  current list-returning functions, (d) the peak number of concurrently-open matplotlib figures
+  during `execute()` and `GenerateStaticFiguresStep`'s figure generation never scales with the total
+  number of figures generated, and (e) genotype pagination covers every genotype exactly once across
+  pages and preserves the pre-cap readable spacing within each page.
+
+## Out of Scope (raise separately if warranted)
+
+- `create_correlation_heatmap`'s existing 60" figsize cap and #110's P2 suggestion (300→150 DPI for
+  step-4-only diagnostic plots) are not touched by this change. They are independent memory
+  reductions that can be evaluated on their own merits in a follow-up change; bundling them here
+  would widen this change's blast radius beyond the two root causes above.
+- Issue #202 (`feature_selection_strategy` silently ignored in two visualization functions) is a
+  different bug in the same file and is explicitly not part of this change.
+- `create_exploratory_summary_plots()`'s single combined-genotype boxplot (step 2 of
+  `ExploratoryAnalysisStep.execute()`, `"trait_ranges_by_genotype"`) is bounded by a separate,
+  pre-existing, already-safe code path (`AdaptiveSizingConfig.max_height`, default 16") when
+  adaptive sizing is enabled, and is not paginated by this change — see `design.md` Decision 3's
+  final note.
+- Smarter-than-alphabetical genotype pagination (e.g. clustering similar genotypes onto the same
+  page, or a sampling strategy that shows a representative subset instead of every genotype) is
+  out of scope — this change does the simplest thing that preserves completeness (every genotype
+  appears somewhere) and readability (fixed per-genotype spacing per page); a smarter strategy can
+  be a follow-up if the basic pagination proves insufficient in practice.
+
+## Impact
+
+- Affected specs: `visualization-pipeline` (figure generation / memory-safety requirements,
+  boxplot genotype label readability)
+- Affected code:
+  - `src/sleap_roots_analyze/pipeline/steps/exploratory_analysis.py` (incremental save+close)
+  - `src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py` (incremental save+close,
+    bundled per explicit scoping decision)
+  - `src/sleap_roots_analyze/visualization.py` (boxplot batch generation, height cap, new private
+    generator functions)
+  - `tests/test_step_exploratory_analysis.py`, `tests/test_step_generate_static_figures.py`,
+    `tests/test_visualization.py` (new regression tests)
+  - `docs/CHANGELOG.md` (new `[Unreleased]` entry under `### Fixed`)
+- No breaking changes to the public API: `create_trait_histograms_batched()` and
+  `create_trait_boxplots_by_genotype_batched()` keep their existing signatures and list-returning
+  behavior for any external callers; `max_subplot_height` and `max_genotypes_per_page` are new
+  optional parameters (the former also added to `create_trait_boxplots_by_genotype()`) with
+  defaults that only change behavior for `n_genotypes` high enough to have hit the uncapped case
+  (i.e., callers who were already at risk of the OOM this fixes).
+- Visual output changes for high genotype counts: previously-uncapped horizontal subplot height is
+  now capped, and datasets above the per-page genotype capacity (~66 horizontal / ~40 vertical by
+  default) now produce more boxplot figures than before (one per genotype page, not one total) —
+  both are intentional, documented changes, not regressions. `create_trait_boxplots_by_genotype_batched()`'s
+  return value (a flat `List[Figure]`) can therefore be longer than before for high-genotype-count
+  inputs; this is a behavior change worth calling out to any external caller, though not a signature
+  break.

--- a/openspec/changes/fix-110-oom-exploratory-analysis/specs/visualization-pipeline/spec.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/specs/visualization-pipeline/spec.md
@@ -1,0 +1,150 @@
+## MODIFIED Requirements
+
+### Requirement: Memory-Safe Figure Generation
+The visualization pipeline SHALL manage matplotlib figure memory to prevent freezing or crashes
+during batch generation.
+
+#### Scenario: Generating 50+ figures sequentially
+- **WHEN** the pipeline generates 50+ batch figures (histograms, boxplots) in sequence
+- **THEN** each figure SHALL be closed via `plt.close()` after saving
+- **AND** memory SHALL be reclaimed periodically via garbage collection
+- **AND** the pipeline SHALL NOT accumulate figures in memory
+
+#### Scenario: Batched figures are saved and closed incrementally in ExploratoryAnalysisStep
+- **WHEN** `ExploratoryAnalysisStep.execute()` generates batched histogram or boxplot figures for a
+  dataset with many traits (enough to trigger `enable_batched_plots`)
+- **THEN** each batch figure SHALL be saved and closed before the next batch figure is generated
+- **AND** the peak number of simultaneously-open matplotlib figures during the step SHALL NOT scale
+  with the total number of batches generated
+
+#### Scenario: Non-batched figures are saved and closed incrementally in ExploratoryAnalysisStep
+- **WHEN** `ExploratoryAnalysisStep.execute()` generates summary plots, EDA plots, or the full
+  correlation heatmap
+- **THEN** each figure SHALL be saved and closed before the next figure is generated
+- **AND** no `all_figures`-style accumulation of not-yet-saved figures SHALL occur
+
+#### Scenario: Batched figures are saved and closed incrementally in GenerateStaticFiguresStep
+- **WHEN** `GenerateStaticFiguresStep` generates batched histogram or boxplot figures for a dataset
+  with many traits
+- **THEN** each batch figure SHALL be saved and closed before the next batch figure is generated
+  (via the same underlying generator functions `ExploratoryAnalysisStep` uses)
+- **AND** the peak number of simultaneously-open matplotlib figures during figure generation SHALL
+  NOT scale with the total number of batches generated
+
+### Requirement: Boxplot Genotype Label Readability
+Trait boxplots grouped by genotype SHALL produce readable, non-overlapping genotype labels regardless of genotype count or label length. Both vertical and horizontal orientations SHALL use a consistent visual style: unfilled outline boxes with blue outlines, green median lines, and gridlines enabled.
+
+#### Scenario: Vertical boxplots with 10+ genotypes switch to horizontal
+- **WHEN** generating trait boxplots with more than 8 genotypes
+- **AND** orientation is set to "auto" (default)
+- **THEN** the boxplots SHALL use horizontal orientation
+- **AND** genotype names SHALL be displayed as y-axis labels (no rotation needed)
+- **AND** boxes SHALL use unfilled outline style (matching vertical orientation)
+
+#### Scenario: Vertical boxplots with 7 or fewer genotypes
+- **WHEN** generating trait boxplots with 7 or fewer genotypes
+- **AND** orientation is set to "auto" (default)
+- **THEN** the boxplots SHALL use vertical orientation
+- **AND** x-axis labels SHALL be rotated 90 degrees
+
+#### Scenario: Consistent box style across orientations
+- **WHEN** generating trait boxplots in either vertical or horizontal orientation
+- **THEN** boxes SHALL use unfilled outline style (no fill color)
+- **AND** box and whisker outlines SHALL be blue (`#1f77b4`)
+- **AND** median lines SHALL be green (`#2ca02c`)
+- **AND** gridlines SHALL be enabled
+- **AND** the visual appearance SHALL be consistent regardless of orientation
+
+#### Scenario: Subplot width scales with genotype count
+- **WHEN** generating vertical trait boxplots with many genotypes
+- **THEN** subplot width SHALL scale with the number of genotypes
+- **AND** minimum subplot width SHALL be 4.0 inches
+- **AND** width per genotype SHALL be at least 0.5 inches
+
+#### Scenario: Subplot height scales with genotype count in horizontal orientation, bounded by a cap
+- **WHEN** generating horizontal-orientation trait boxplots (`n_genotypes` above
+  `horizontal_threshold`) via `create_trait_boxplots_by_genotype()` or
+  `create_trait_boxplots_by_genotype_batched()`
+- **THEN** subplot height SHALL scale with the number of genotypes at 0.3 inches per genotype,
+  with a minimum of 4.0 inches
+- **AND** subplot height SHALL NOT exceed 20.0 inches, regardless of genotype count
+- **AND** this cap SHALL take effect at the point the figure is actually rendered (i.e. it SHALL
+  NOT be silently discarded by an inner sizing recomputation)
+
+#### Scenario: Horizontal subplot height is unaffected below the cap
+- **WHEN** generating horizontal-orientation trait boxplots whose `n_genotypes * 0.3` is below
+  20.0 inches
+- **THEN** subplot height SHALL be computed exactly as before this change
+  (`max(4.0, n_genotypes * 0.3)`), unchanged from current behavior
+
+#### Scenario: Batched boxplots suptitle does not overlap subplots
+- **WHEN** generating batched trait boxplots via `create_trait_boxplots_by_genotype_batched()`
+- **THEN** the batch title (suptitle) SHALL NOT overlap the top row of subplots
+- **AND** `tight_layout()` SHALL be called AFTER suptitle is set (not before)
+
+#### Scenario: Label font size adapts to genotype count
+- **WHEN** generating trait boxplots with many genotypes (>10)
+- **THEN** x-axis tick label font size SHALL decrease to maintain readability
+- **AND** font size SHALL not go below 6pt
+
+#### Scenario: Backward compatibility with few genotypes
+- **WHEN** generating trait boxplots with 5 or fewer genotypes
+- **THEN** the plot appearance SHALL be visually similar to current behavior
+- **AND** no layout changes SHALL be noticeable
+
+#### Scenario: Zero genotypes or zero traits
+- **WHEN** generating trait boxplots (batched or non-batched) with zero genotypes or an empty
+  `trait_cols` list
+- **THEN** the function SHALL return without error (an empty list for batched, a placeholder
+  "no data"/"no traits" figure for non-batched)
+- **AND** no cap or sizing calculation SHALL raise an exception on this input
+
+## ADDED Requirements
+
+### Requirement: Boxplot Genotype Pagination
+`create_trait_boxplots_by_genotype_batched()` SHALL split genotypes across multiple figures when
+the genotype count exceeds what fits in one `max_subplot_height`-capped figure while remaining
+readable at the standard per-genotype spacing (0.3"/genotype horizontal, 0.5"/genotype vertical),
+rather than relying on the height cap alone, which is memory-safe but not necessarily readable at
+extreme genotype counts.
+
+#### Scenario: Genotypes are paginated across multiple figures when they exceed page capacity
+- **WHEN** `create_trait_boxplots_by_genotype_batched()` generates boxplots for a genotype count
+  above the per-page capacity (auto-derived from `max_subplot_height` and the per-genotype size for
+  the resolved `actual_orientation`: `max_subplot_height // 0.3` ≈ 66 for horizontal,
+  `max_subplot_height // 0.5` = 40 for vertical, unless `max_genotypes_per_page` is explicitly set)
+- **THEN** genotypes SHALL be split into consecutive, alphabetically-sorted pages of at most
+  `max_genotypes_per_page` genotypes each
+- **AND** one figure SHALL be rendered per (trait batch, genotype page) combination
+- **AND** every genotype SHALL appear in exactly one page's figure (no genotype dropped or
+  duplicated across pages)
+- **AND** each page's rendered subplot height SHALL use the pre-cap readable spacing
+  (`page_genotype_count * per_genotype_size`), not the `max_subplot_height` cap, since pages are
+  sized to stay under it by construction
+
+#### Scenario: Pagination is a no-op at or below page capacity
+- **WHEN** `create_trait_boxplots_by_genotype_batched()` generates boxplots for a genotype count at
+  or below the per-page capacity (≤ 66 genotypes for horizontal orientation, ≤ 40 for vertical, by
+  default)
+- **THEN** exactly one genotype page SHALL be produced per trait batch (no behavior change from
+  before pagination was introduced)
+
+#### Scenario: Multi-page batch suptitle identifies the genotype range
+- **WHEN** a trait batch is split into more than one genotype page
+- **THEN** each page's figure `suptitle` SHALL include the genotype range and total genotype count
+  for that page (e.g. "Genotypes 1-66 of 489"), in addition to the existing trait-range text
+
+#### Scenario: Pagination orientation is consistent across all pages of a batch
+- **WHEN** genotype pagination produces a small final page (e.g. below `horizontal_threshold`)
+  alongside larger preceding pages within the same trait batch
+- **THEN** every page SHALL use the same resolved orientation (derived from the full dataset's
+  genotype count), not an orientation independently re-resolved from that page's own, possibly much
+  smaller, genotype count
+
+#### Scenario: Pagination handles a missing genotype column or NaN genotype values safely
+- **WHEN** the DataFrame passed to `create_trait_boxplots_by_genotype_batched()` either has no
+  `genotype_col` column, or has some rows with a NaN genotype value
+- **THEN** pagination SHALL NOT raise an exception
+- **AND** if `genotype_col` is absent, pagination SHALL be a no-op (one page per trait batch)
+- **AND** if NaN genotype values are present, they SHALL be excluded from page assignment (dropped
+  before sorting/paging), and every non-NaN genotype SHALL still appear in exactly one page

--- a/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
@@ -114,59 +114,68 @@ boundary.
 
 ## Task 3: Generator refactor + incremental save/close in ExploratoryAnalysisStep (TDD Red -> Green)
 *Commit 3: `fix(#110): incrementally save+close figures in ExploratoryAnalysisStep.execute()`*
-- [ ] 3.1 In `tests/test_visualization.py`, add tests for generator/list parity:
+- [x] 3.1 In `tests/test_visualization.py`, add tests for generator/list parity:
       `test_histogram_generator_matches_list_wrapper_output` and
       `test_boxplot_generator_matches_list_wrapper_output` -- `list(_generate_trait_*_batches(...))`
       produces the same count and sizes (including paginated output) as the existing public
       function's output
-- [ ] 3.2 Add `test_boxplot_generator_yields_lazily` -- confirm a figure is not created until the
+- [x] 3.2 Add `test_boxplot_generator_yields_lazily` -- confirm a figure is not created until the
       generator is advanced (e.g. via a counter/spy), demonstrating genuine laziness rather than
       generator syntax wrapping already-eager work
-- [ ] 3.3 Run tests, confirm FAIL (generators do not exist yet)
-- [ ] 3.4 In `tests/test_step_exploratory_analysis.py`, add a fixture producing a synthetic
+- [x] 3.3 Run tests, confirm FAIL (generators do not exist yet)
+- [x] 3.4 In `tests/test_step_exploratory_analysis.py`, add a fixture producing a synthetic
       DataFrame pinned at 480 genotypes x 300 trait columns (dpi=100, matching this file's existing
       low-DPI test convention) -- no proprietary data
-- [ ] 3.5 Add `test_peak_concurrent_figures_bounded_during_execute` -- instrument figure lifecycle
+- [x] 3.5 Add `test_peak_concurrent_figures_bounded_during_execute` -- instrument figure lifecycle
       by monkeypatching both figure-creation (e.g. wrap `plt.subplots`/`plt.figure`) and
       `matplotlib.pyplot.close`, recording `len(plt.get_fignums())` at both points (sampling only at
       close time can miss a figure that's created but never explicitly closed -- see review
       finding). Assert the peak recorded value is far below the total number of figures the step
       would generate (e.g. `< 10`); pin the exact constant once Task 3.9 is green.
-- [ ] 3.6 Decide and record whether this test needs `@pytest.mark.integration` -- CI's `tests` job
+- [x] 3.6 Decide and record whether this test needs `@pytest.mark.integration` -- CI's `tests` job
       runs `-m "not integration"` on all 3 OSes, so if marked integration this regression proof
       never runs in CI. Given the DataFrame is synthetic and runtime is expected to be seconds, do
       NOT mark it integration; keep it in the default CI-run test set.
-- [ ] 3.7 Run test, confirm FAIL on current code (all figures accumulate before any close)
-- [ ] 3.8 In `src/sleap_roots_analyze/visualization.py`, add `_generate_trait_histogram_batches()`
+- [x] 3.7 Run test, confirm FAIL on current code (all figures accumulate before any close)
+- [x] 3.8 In `src/sleap_roots_analyze/visualization.py`, add `_generate_trait_histogram_batches()`
       as a generator version of `create_trait_histograms_batched()`; make the existing function a
       `list(...)` wrapper over it. Add `_generate_trait_boxplot_batches()` as a generator version of
       `create_trait_boxplots_by_genotype_batched()` (including Task 1's height cap and Task 2's
       pagination); make the existing function a `list(...)` wrapper over it.
-- [ ] 3.9 In `ExploratoryAnalysisStep.execute()`, remove the `all_figures` dict. Save and close each
+- [x] 3.9 In `ExploratoryAnalysisStep.execute()`, remove the `all_figures` dict. Save and close each
       summary/EDA figure and the correlation heatmap immediately after creation, and iterate the two
       batch generators directly, saving and closing each batch figure as it's yielded. Update
       `execute()`'s metadata construction (`figures_generated`, `figure_names`) to track figures via
       the save+close calls instead of `all_figures.keys()`.
-- [ ] 3.10 Run Task 3 tests, confirm PASS (green); pin the exact peak-figure-count constant Task 3.5
-      asserts based on the real measured value
-- [ ] 3.11 Run the full existing `TestExploratoryAnalysisStepBasic`,
+- [x] 3.10 Run Task 3 tests, confirm PASS (green); pin the exact peak-figure-count constant Task 3.5
+      asserts based on the real measured value (measured 4, previously 45; asserted `<= 5`)
+- [x] 3.11 Run the full existing `TestExploratoryAnalysisStepBasic`,
       `TestExploratoryAnalysisStatistics`, `TestExploratoryAnalysisFigures`,
       `TestExploratoryAnalysisEdgeCases`, and `TestExploratoryAnalysisMetadataPropagation` classes,
       confirm no regressions
 
 ## Task 4: Incremental save/close in GenerateStaticFiguresStep (TDD Red -> Green)
 *Commit 4: `fix(#110): incrementally save+close figures in GenerateStaticFiguresStep`*
-- [ ] 4.1 In `tests/test_step_generate_static_figures.py`, add the same 480-genotype x 300-trait
-      fixture (or reuse a shared fixture factored out of Task 3.4 if convenient) and a
+- [x] 4.1 In `tests/test_step_generate_static_figures.py`, add a 480-genotype fixture and a
       `test_peak_concurrent_figures_bounded_during_static_figures` test using the same
-      creation+close instrumentation as Task 3.5
-- [ ] 4.2 Run test, confirm FAIL on current code (full batch list materializes before any close)
-- [ ] 4.3 Update `GenerateStaticFiguresStep` to iterate `_generate_trait_histogram_batches()` /
+      creation+close instrumentation as Task 3.5. Used 30 traits (not the full 300) and disabled
+      PCA/heritability/correlation/genotype-comparison plot types via `static_viz_config_enabled`,
+      since this step generates many more figure types than `ExploratoryAnalysisStep` when fully
+      enabled -- keeping the test scoped to trait-distribution figures (the code path this task
+      actually changes) keeps runtime reasonable, per the CI-cost budgeting note in `design.md`
+      Decision 4 point 7.
+- [x] 4.2 Run test, confirm FAIL on current code (full batch list materializes before any close)
+- [x] 4.3 Update `GenerateStaticFiguresStep` to iterate `_generate_trait_histogram_batches()` /
       `_generate_trait_boxplot_batches()` directly instead of calling the list-returning public
       wrappers; keep the existing periodic `gc.collect()` calls (now an extra safety margin, not
-      the only defense)
-- [ ] 4.4 Run Task 4 test, confirm PASS (green)
-- [ ] 4.5 Run the full existing static-figures test suite, confirm no regressions
+      the only defense). Also updated two pre-existing tests
+      (`TestAdaptiveBatchSize::test_adaptive_batch_size_increases_for_many_traits` and
+      `test_cylinder_scale_generates_reasonable_batch_count`) that patched the old public function
+      names directly in this module's namespace -- they now patch the new private generator names.
+- [x] 4.4 Run Task 4 test, confirm PASS (green) -- verified with an explicit red/green cycle
+      (temporarily reverted the fix via `git stash`, confirmed the test fails at peak=40, restored
+      via `git stash pop`, confirmed it passes)
+- [x] 4.5 Run the full existing static-figures test suite, confirm no regressions (70 passed)
 
 ## Task 5: End-to-end regression test against the real failure shape
 *Commit 5: `test(#110): add end-to-end OOM regression test at real failure scale`*

--- a/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
@@ -178,17 +178,20 @@ boundary.
 - [x] 4.5 Run the full existing static-figures test suite, confirm no regressions (70 passed)
 
 ## Task 5: End-to-end regression test against the real failure shape
-*Commit 5: `test(#110): add end-to-end OOM regression test at real failure scale`*
-- [ ] 5.1 Add an integration-style test (not marked `@pytest.mark.integration`, per Task 3.6's
-      reasoning) running `ExploratoryAnalysisStep.execute()` end-to-end against the 480x300
-      synthetic fixture, with `enable_batched_plots=True`
-- [ ] 5.2 Assert the step completes without raising and produces the expected figure files on disk,
-      including multiple genotype-paginated boxplot batches
-- [ ] 5.3 Assert peak concurrent figures stays bounded (reuse the Task 3.5 instrumentation)
+- [x] 5.1 Already satisfied by Task 3's `TestExploratoryAnalysisMemoryBounds` (no separate commit
+      needed): `test_execute_completes_and_produces_figures_for_large_dataset` runs
+      `ExploratoryAnalysisStep.execute()` end-to-end against the 480x300 synthetic fixture with
+      `enable_batched_plots=True` (the `VisualizationConfig` default)
+- [x] 5.2 Covered by the same test: asserts the step completes without raising, produces PNG figure
+      files on disk, and produces multiple genotype-paginated boxplot batches (`box_batches > 1`)
+- [x] 5.3 Covered by the sibling test in the same class,
+      `test_peak_concurrent_figures_bounded_during_execute`, using the Task 3.5 instrumentation
+      against the identical fixture -- splitting "completes and produces correct output" from "peak
+      memory stays bounded" into two focused tests rather than one combined test
 
 ## Task 6: Documentation and finalization
-*Commit 6: `chore(#110): changelog entry`* (or fold into Commit 5 if trivial)
-- [ ] 6.1 Add a `### Fixed` entry to `docs/CHANGELOG.md` under `[Unreleased]` for #110: incremental
+*Commit 5: `docs(#110): changelog entry`*
+- [x] 6.1 Add a `### Fixed` entry to `docs/CHANGELOG.md` under `[Unreleased]` for #110: incremental
       figure save/close in `ExploratoryAnalysisStep` and `GenerateStaticFiguresStep` (fixes OOM on
       large genotype counts); the new `max_subplot_height` cap (default 20.0") on
       `create_trait_boxplots_by_genotype()` / `create_trait_boxplots_by_genotype_batched()`'s

--- a/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
@@ -200,16 +200,21 @@ boundary.
       height) for previously-uncapped/unpaginated high-genotype-count datasets
 
 ## Task 7: Verify no regressions and finalize
-- [ ] 7.1 Full test suite passes (`uv run pytest`)
-- [ ] 7.2 Linting and formatting pass (`uv run ruff check`, `uv run black --check .`)
-- [ ] 7.3 Type checking passes (`uv run mypy src/sleap_roots_analyze | uv run mypy-baseline filter
+- [x] 7.1 Full test suite passes (`uv run pytest`) -- 2863 passed, 37 skipped, 0 failed
+      (46m32s)
+- [x] 7.2 Linting and formatting pass (`uv run ruff check`, `uv run black --check .`) -- clean on
+      all files this change touches (pre-existing lint debt in unrelated files left as-is, out of
+      scope)
+- [x] 7.3 Type checking passes (`uv run mypy src/sleap_roots_analyze | uv run mypy-baseline filter
       --baseline-path .mypy-baseline.txt`, matching CI's `type-check` job) -- new generator
-      functions need correct `Iterator[plt.Figure]`-style annotations
-- [ ] 7.4 `openspec validate fix-110-oom-exploratory-analysis --strict` passes
-- [ ] 7.5 Drop the reference-only stash (Task 0.2) once superseded
+      functions need correct `Iterator[plt.Figure]`-style annotations -- found and fixed one new
+      error (`genotype_pages` needed an explicit `List[Optional[List[Any]]]` annotation); confirmed
+      `new: 0` / exit 0 after the fix
+- [x] 7.4 `openspec validate fix-110-oom-exploratory-analysis --strict` passes
+- [x] 7.5 Drop the reference-only stash (Task 0.2) once superseded -- dropped
 - [ ] 7.6 Note in the PR description that #202, the correlation-heatmap figsize cap, #110's P2
       DPI-reduction suggestion, and `create_exploratory_summary_plots()`'s separate
       adaptive-sizing-bounded boxplot are explicitly out of scope for this change
-- [ ] 7.7 Visual QA: generate boxplot figures for a genotype count that triggers pagination (e.g.
+- [x] 7.7 Visual QA: generate boxplot figures for a genotype count that triggers pagination (e.g.
       120 genotypes, 2 pages) and open the PNGs with the Read tool to visually confirm labels are
       readable within each page and the suptitle correctly identifies the genotype range

--- a/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
@@ -1,0 +1,203 @@
+# Tasks: fix-110-oom-exploratory-analysis
+
+Commit boundaries below fold each red+green pair into a single commit (this repo has no
+precedent for standalone failing-test commits and `main` has no per-commit CI gate — see
+`git log` history) — treat the red/green split as a local TDD iteration loop, not a commit
+boundary.
+
+## Task 0: Dispose of the prior non-TDD draft
+- [ ] 0.1 Confirm the prior uncommitted draft is stashed (not applied) on this branch and is not
+      silently merged into any implementation below (its cap value, fix location, and lack of any
+      pagination were all superseded by `design.md` Decisions 2 and 3)
+- [ ] 0.2 Drop the stash (`git stash drop`) once Task 7 confirms all tests pass and the draft has
+      been fully superseded
+
+## Task 1: Height cap -- write failing tests, then implement (TDD Red -> Green)
+*Commit 1: `fix(#110): cap horizontal boxplot subplot height`*
+- [ ] 1.1 In `tests/test_visualization.py`, add `TestBoxplotHorizontalHeightCap` with a synthetic
+      DataFrame fixture pinned at 480 genotypes (horizontal orientation triggered) and a small
+      trait count
+- [ ] 1.2 `test_direct_call_horizontal_height_capped` -- call `create_trait_boxplots_by_genotype()`
+      directly (not via the batched wrapper) with 480 genotypes, horizontal orientation; assert
+      `fig.get_size_inches()` height stays at or under the cap. This specifically catches the
+      "cap applied only to the batched wrapper's local variable, silently discarded by the inner
+      function" bug identified in `design.md` Decision 2.
+- [ ] 1.3 `test_batched_call_horizontal_height_capped` -- same assertion via
+      `create_trait_boxplots_by_genotype_batched()`
+- [ ] 1.4 `test_horizontal_height_cap_boundary` -- `n_genotypes` chosen so
+      `n_genotypes * 0.3 == max_subplot_height` exactly; assert no off-by-one/float issue in the
+      `min()` cap
+- [ ] 1.5 `test_horizontal_height_unchanged_below_cap` -- genotype count low enough that
+      `n_genotypes * 0.3` is below the cap; assert height matches the existing uncapped formula
+      exactly (`max(4.0, n_genotypes * 0.3)`) -- no regression for the common case
+- [ ] 1.6 `test_custom_max_subplot_height_respected` -- pass a non-default `max_subplot_height`
+      (e.g. 10.0) and confirm it, not the 20.0 default, is what bounds the output
+- [ ] 1.7 `test_horizontal_boxplots_zero_genotypes_and_zero_traits` -- empty-input edge cases
+      (0 genotypes, empty `trait_cols`) do not raise
+- [ ] 1.8 Run tests, confirm FAIL on current code
+- [ ] 1.9 Add `max_subplot_height: float = 20.0` parameter to `create_trait_boxplots_by_genotype()`
+      (`visualization.py`); apply cap in the horizontal-orientation branch:
+      `min_subplot_height = min(max_subplot_height, max(4, n_genotypes * height_per_genotype))`.
+      Update its Google-style docstring `Args:` section.
+- [ ] 1.10 Add the same `max_subplot_height: float = 20.0` parameter to
+      `create_trait_boxplots_by_genotype_batched()`; use it in its own `batch_figsize`
+      precomputation and pass it through to the inner `create_trait_boxplots_by_genotype()` call.
+      Update its docstring `Args:` section.
+- [ ] 1.11 Run Task 1 tests, confirm PASS (green)
+- [ ] 1.12 Run the full existing `TestTraitBoxplotsAdaptiveSizing` and
+      `TestBoxplotLabelOverlapFixes` classes, confirm no regressions
+
+## Task 2: Genotype pagination for readability (TDD Red -> Green)
+*Commit 2: `feat(#110): paginate boxplots by genotype when count exceeds readable page capacity`*
+- [ ] 2.1 In `tests/test_visualization.py`, add `TestBoxplotGenotypePagination`. Use a small, fixed
+      trait count for these tests (e.g. exactly 1 trait, so `n_traits <= batch_size` guarantees a
+      single trait batch and every figure the test sees belongs to it unambiguously) -- pagination
+      is a property of the genotype axis, not the trait axis, so reuse Task 1's 480-genotype
+      fixture but do NOT reuse the full 300-trait fixture here (keeps these tests fast; see
+      `design.md` Decision 4 point 6)
+- [ ] 2.2 `test_pagination_splits_genotypes_at_default_capacity` -- 480 genotypes, default
+      `max_genotypes_per_page` (auto-derived, ~66 for horizontal); assert
+      `create_trait_boxplots_by_genotype_batched()` returns more figures than trait-batch count
+      alone would produce (i.e. `n_trait_batches * n_genotype_pages`, `n_genotype_pages > 1`)
+- [ ] 2.3 `test_pagination_covers_every_genotype_exactly_once` -- with the single-trait-batch fixture
+      from 2.1, every returned figure belongs to that one trait batch; collect the genotype tick
+      labels rendered in each figure (via `ax.get_yticklabels()` for horizontal orientation,
+      matching the existing pattern at `tests/test_visualization.py:303,4033`) and assert their
+      union equals the full 480-genotype set with no duplicates across figures
+- [ ] 2.4 `test_pagination_noop_at_or_below_capacity` -- genotype count at or below the auto-derived
+      page capacity; assert exactly one genotype page per trait batch (no behavior change)
+- [ ] 2.5 `test_pagination_page_height_uses_readable_spacing_not_cap` -- a paginated figure's height
+      reflects `page_genotype_count * 0.3` (the pre-cap readable formula), not the 20" cap, since
+      pages are sized to stay under it by construction
+- [ ] 2.6 `test_pagination_custom_max_genotypes_per_page_respected` -- explicit
+      `max_genotypes_per_page` override changes the number of pages produced
+- [ ] 2.7 `test_pagination_suptitle_includes_genotype_range` -- a multi-page batch's figures each
+      have a `suptitle` containing the genotype range and total (e.g. "Genotypes 1-66 of 489")
+- [ ] 2.8 `test_pagination_last_page_orientation_matches_other_pages` -- use 469 genotypes with the
+      default page capacity of 66 (`469 = 66*7 + 7`, leaving a 7-genotype final page, correctly
+      below `horizontal_threshold=8` -- verify this arithmetic when implementing, a prior draft of
+      this task miscalculated it as 483); assert every page's rendered orientation matches the
+      orientation resolved from the *full* dataset, not one independently re-resolved from the
+      small page's own count (see `design.md` Decision 3's orientation-consistency note)
+- [ ] 2.9 `test_pagination_missing_genotype_column_is_noop` -- a DataFrame that does not contain
+      `genotype_col` at all; assert `create_trait_boxplots_by_genotype_batched()` does not raise
+      and produces one figure per trait batch (matching today's existing "0 genotypes" behavior),
+      not a `KeyError`
+- [ ] 2.10 `test_pagination_with_nan_genotype_values` -- a DataFrame with some rows having a NaN
+      genotype value alongside 480+ real genotype values; assert pagination does not raise
+      (`sorted()` on a mixed NaN/string array raises `TypeError`) and every non-NaN genotype still
+      appears in exactly one page
+- [ ] 2.11 `test_pagination_with_partial_trait_batch_and_partial_genotype_page` -- e.g. 20 traits
+      with `batch_size=16` (batches of 16 + 4) crossed with 100 genotypes at the default page
+      capacity of 66 (pages of 66 + 34); assert figure count equals
+      `n_trait_batches * n_genotype_pages` and each figure's figsize matches the per-page formula
+      for its actual (possibly partial) trait and genotype counts
+- [ ] 2.12 Run tests, confirm FAIL on current code (no pagination exists yet)
+- [ ] 2.13 In `create_trait_boxplots_by_genotype_batched()`, add `max_genotypes_per_page:
+      Optional[int] = None` parameter; when `None`, derive as `max(1, int(max_subplot_height //
+      per_genotype_size))` using 0.3 (horizontal) or 0.5 (vertical) based on `actual_orientation`.
+      Guard `genotype_col in df.columns` before accessing it for pagination purposes -- if absent,
+      pagination is a no-op (single page), matching today's existing "0 genotypes" behavior rather
+      than raising `KeyError`. When present, compute genotype pages from
+      `sorted(df[genotype_col].dropna().unique())` (dropping NaN before sorting, matching the
+      existing per-trait rendering path's convention of only ever sorting a `.dropna()`'d subset),
+      chunked into pages. For each (trait batch, genotype page) combination, filter the DataFrame to
+      that page's genotypes and render one figure (reusing the existing per-batch trait/sizing
+      logic, now driven by the page's genotype count rather than the full dataset's). Pass the
+      already-resolved `actual_orientation` (not the original, possibly-`"auto"`, `orientation`
+      argument) into each per-page call so every page of a batch uses a consistent orientation
+      regardless of that page's own genotype count. Append the genotype range to the `suptitle`
+      when more than one page exists. Update the docstring `Args:` section.
+- [ ] 2.14 Run Task 2 tests, confirm PASS (green)
+- [ ] 2.15 Run the full existing `TestTraitBoxplotsAdaptiveSizing`, `TestBoxplotLabelOverlapFixes`,
+      and Task 1's height-cap tests, confirm no regressions
+
+## Task 3: Generator refactor + incremental save/close in ExploratoryAnalysisStep (TDD Red -> Green)
+*Commit 3: `fix(#110): incrementally save+close figures in ExploratoryAnalysisStep.execute()`*
+- [ ] 3.1 In `tests/test_visualization.py`, add tests for generator/list parity:
+      `test_histogram_generator_matches_list_wrapper_output` and
+      `test_boxplot_generator_matches_list_wrapper_output` -- `list(_generate_trait_*_batches(...))`
+      produces the same count and sizes (including paginated output) as the existing public
+      function's output
+- [ ] 3.2 Add `test_boxplot_generator_yields_lazily` -- confirm a figure is not created until the
+      generator is advanced (e.g. via a counter/spy), demonstrating genuine laziness rather than
+      generator syntax wrapping already-eager work
+- [ ] 3.3 Run tests, confirm FAIL (generators do not exist yet)
+- [ ] 3.4 In `tests/test_step_exploratory_analysis.py`, add a fixture producing a synthetic
+      DataFrame pinned at 480 genotypes x 300 trait columns (dpi=100, matching this file's existing
+      low-DPI test convention) -- no proprietary data
+- [ ] 3.5 Add `test_peak_concurrent_figures_bounded_during_execute` -- instrument figure lifecycle
+      by monkeypatching both figure-creation (e.g. wrap `plt.subplots`/`plt.figure`) and
+      `matplotlib.pyplot.close`, recording `len(plt.get_fignums())` at both points (sampling only at
+      close time can miss a figure that's created but never explicitly closed -- see review
+      finding). Assert the peak recorded value is far below the total number of figures the step
+      would generate (e.g. `< 10`); pin the exact constant once Task 3.9 is green.
+- [ ] 3.6 Decide and record whether this test needs `@pytest.mark.integration` -- CI's `tests` job
+      runs `-m "not integration"` on all 3 OSes, so if marked integration this regression proof
+      never runs in CI. Given the DataFrame is synthetic and runtime is expected to be seconds, do
+      NOT mark it integration; keep it in the default CI-run test set.
+- [ ] 3.7 Run test, confirm FAIL on current code (all figures accumulate before any close)
+- [ ] 3.8 In `src/sleap_roots_analyze/visualization.py`, add `_generate_trait_histogram_batches()`
+      as a generator version of `create_trait_histograms_batched()`; make the existing function a
+      `list(...)` wrapper over it. Add `_generate_trait_boxplot_batches()` as a generator version of
+      `create_trait_boxplots_by_genotype_batched()` (including Task 1's height cap and Task 2's
+      pagination); make the existing function a `list(...)` wrapper over it.
+- [ ] 3.9 In `ExploratoryAnalysisStep.execute()`, remove the `all_figures` dict. Save and close each
+      summary/EDA figure and the correlation heatmap immediately after creation, and iterate the two
+      batch generators directly, saving and closing each batch figure as it's yielded. Update
+      `execute()`'s metadata construction (`figures_generated`, `figure_names`) to track figures via
+      the save+close calls instead of `all_figures.keys()`.
+- [ ] 3.10 Run Task 3 tests, confirm PASS (green); pin the exact peak-figure-count constant Task 3.5
+      asserts based on the real measured value
+- [ ] 3.11 Run the full existing `TestExploratoryAnalysisStepBasic`,
+      `TestExploratoryAnalysisStatistics`, `TestExploratoryAnalysisFigures`,
+      `TestExploratoryAnalysisEdgeCases`, and `TestExploratoryAnalysisMetadataPropagation` classes,
+      confirm no regressions
+
+## Task 4: Incremental save/close in GenerateStaticFiguresStep (TDD Red -> Green)
+*Commit 4: `fix(#110): incrementally save+close figures in GenerateStaticFiguresStep`*
+- [ ] 4.1 In `tests/test_step_generate_static_figures.py`, add the same 480-genotype x 300-trait
+      fixture (or reuse a shared fixture factored out of Task 3.4 if convenient) and a
+      `test_peak_concurrent_figures_bounded_during_static_figures` test using the same
+      creation+close instrumentation as Task 3.5
+- [ ] 4.2 Run test, confirm FAIL on current code (full batch list materializes before any close)
+- [ ] 4.3 Update `GenerateStaticFiguresStep` to iterate `_generate_trait_histogram_batches()` /
+      `_generate_trait_boxplot_batches()` directly instead of calling the list-returning public
+      wrappers; keep the existing periodic `gc.collect()` calls (now an extra safety margin, not
+      the only defense)
+- [ ] 4.4 Run Task 4 test, confirm PASS (green)
+- [ ] 4.5 Run the full existing static-figures test suite, confirm no regressions
+
+## Task 5: End-to-end regression test against the real failure shape
+*Commit 5: `test(#110): add end-to-end OOM regression test at real failure scale`*
+- [ ] 5.1 Add an integration-style test (not marked `@pytest.mark.integration`, per Task 3.6's
+      reasoning) running `ExploratoryAnalysisStep.execute()` end-to-end against the 480x300
+      synthetic fixture, with `enable_batched_plots=True`
+- [ ] 5.2 Assert the step completes without raising and produces the expected figure files on disk,
+      including multiple genotype-paginated boxplot batches
+- [ ] 5.3 Assert peak concurrent figures stays bounded (reuse the Task 3.5 instrumentation)
+
+## Task 6: Documentation and finalization
+*Commit 6: `chore(#110): changelog entry`* (or fold into Commit 5 if trivial)
+- [ ] 6.1 Add a `### Fixed` entry to `docs/CHANGELOG.md` under `[Unreleased]` for #110: incremental
+      figure save/close in `ExploratoryAnalysisStep` and `GenerateStaticFiguresStep` (fixes OOM on
+      large genotype counts); the new `max_subplot_height` cap (default 20.0") on
+      `create_trait_boxplots_by_genotype()` / `create_trait_boxplots_by_genotype_batched()`'s
+      horizontal branch; and the new `max_genotypes_per_page` pagination that keeps high-genotype-
+      count boxplots readable — noting the visual-output change (more boxplot figures, capped
+      height) for previously-uncapped/unpaginated high-genotype-count datasets
+
+## Task 7: Verify no regressions and finalize
+- [ ] 7.1 Full test suite passes (`uv run pytest`)
+- [ ] 7.2 Linting and formatting pass (`uv run ruff check`, `uv run black --check .`)
+- [ ] 7.3 Type checking passes (`uv run mypy src/sleap_roots_analyze | uv run mypy-baseline filter
+      --baseline-path .mypy-baseline.txt`, matching CI's `type-check` job) -- new generator
+      functions need correct `Iterator[plt.Figure]`-style annotations
+- [ ] 7.4 `openspec validate fix-110-oom-exploratory-analysis --strict` passes
+- [ ] 7.5 Drop the reference-only stash (Task 0.2) once superseded
+- [ ] 7.6 Note in the PR description that #202, the correlation-heatmap figsize cap, #110's P2
+      DPI-reduction suggestion, and `create_exploratory_summary_plots()`'s separate
+      adaptive-sizing-bounded boxplot are explicitly out of scope for this change
+- [ ] 7.7 Visual QA: generate boxplot figures for a genotype count that triggers pagination (e.g.
+      120 genotypes, 2 pages) and open the PNGs with the Read tool to visually confirm labels are
+      readable within each page and the suptitle correctly identifies the genotype range

--- a/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
@@ -129,9 +129,12 @@ boundary.
       production failure scale directly; **reduced to 100 genotypes x 40 traits after an actual CI
       run on the opened PR showed the larger size pushed CI's 30-minute `tests` job timeout on
       Ubuntu/Windows** (both failed at the identical 30m16s mark mid-suite -- a timeout, not a test
-      failure) even though it ran fine standalone locally (~170-180s). The smaller fixture still
-      triggers genotype pagination (2 pages) and multiple trait batches, runs in ~15s (see
-      `design.md` Decision 4 point 7's post-hoc update).
+      failure) even though it ran fine standalone locally (~170-180s locally; the actual CI,
+      per-test duration was higher, ~124-126s on Windows -- see `design.md` Decision 4 point 7's
+      post-hoc update on why local timing undercounted this). The smaller fixture still triggers
+      genotype pagination (2 pages) and multiple trait batches; measured ~24.7s on Windows CI after
+      the reduction (~5x, not the ~12x a first, local-only estimate suggested -- see the same
+      design.md update).
 - [x] 3.5 Add `test_peak_concurrent_figures_bounded_during_execute` -- instrument figure lifecycle
       by monkeypatching both figure-creation (e.g. wrap `plt.subplots`/`plt.figure`) and
       `matplotlib.pyplot.close`, recording `len(plt.get_fignums())` at both points (sampling only at
@@ -171,7 +174,8 @@ boundary.
       failure scale; **reduced to 100 genotypes x 12 traits after an actual CI run on the opened PR
       showed the larger size contributed to CI's 30-minute `tests` job timeout on Ubuntu/Windows**
       (see Task 3.4's note and `design.md` Decision 4 point 7's post-hoc update) -- still triggers
-      genotype pagination and multiple trait batches, runs in ~14s instead of ~180s.
+      genotype pagination and multiple trait batches; measured ~24.7s on Windows CI after the
+      reduction, down from 278.15s (~11x, per actual CI logs, not local-only timing).
 - [x] 4.2 Run test, confirm FAIL on current code (full batch list materializes before any close)
 - [x] 4.3 Update `GenerateStaticFiguresStep` to iterate `_generate_trait_histogram_batches()` /
       `_generate_trait_boxplot_batches()` directly instead of calling the list-returning public
@@ -243,9 +247,34 @@ boundary.
 - [x] 8.2 Reduced both fixtures (100 genotypes x 40 traits for `ExploratoryAnalysisStep`, 100 x 12
       for `GenerateStaticFiguresStep`) -- still large enough to trigger genotype pagination and
       multiple trait batches, still large enough to clearly distinguish a bounded (~4 peak) from an
-      unbounded (near-total-figure-count peak) implementation. Runtime dropped from ~170-180s each
-      to ~15s each (~12x). Updated `design.md` Decision 4 point 7 and this file's Task 3.4/4.1/5.1
-      entries to document the correction and why.
+      unbounded (near-total-figure-count peak) implementation. Pushed a fix commit and re-ran CI;
+      it passed. First wrote up the improvement using LOCAL timing (~170-180s -> ~15s, "~12x") --
+      caught by a third review round that this repeated the exact mistake this section warns
+      against. Pulled actual per-test durations from both CI runs' logs instead: on Windows,
+      278.15s/126.09s/123.99s (pre-fix) -> 24.72s/24.74s/24.72s (post-fix) -- a 5-11x reduction, not
+      a uniform 12x, and ~25s absolute per test in CI vs. ~15s locally. Updated `design.md`
+      Decision 4 point 7 and this file's Task 3.4/4.1/5.1 entries with the CI-verified numbers.
 - [x] 8.3 Re-verified: `tests/test_step_exploratory_analysis.py` +
       `tests/test_step_generate_static_figures.py` full files (86 passed), ruff/black clean,
       `openspec validate --strict` passes.
+
+## Post-PR: third review round on commits since the pre-merge review
+- [x] 8.4 A third adversarial review (scoped to commits 63ca343..89d46e7, i.e. everything since
+      the pre-merge 5-subagent review) found one real code bug and one doc-accuracy issue, both
+      fixed:
+      - **Bug**: the `key=str` fix for the mixed-dtype-genotype `TypeError` (Task 7's pre-merge
+        fixes) was applied unconditionally, silently changing sort order for a *homogeneous*
+        numeric genotype column from natural numeric order (1, 2, 10, 20) to lexicographic string
+        order ("1", "10", "2", "20") -- a real, if narrow, behavior regression for a plausible
+        input shape, not just a defensive no-op. Fixed with a new `_sort_genotypes_safely()`
+        helper: try a natural `sorted()` first, fall back to `sorted(..., key=str)` only on the
+        `TypeError` a genuinely mixed-dtype column raises. Added
+        `test_pagination_preserves_natural_order_for_numeric_genotypes` (12 numeric genotype IDs,
+        asserts rendered y-tick order is 1..12, not lexicographic).
+      - **Doc accuracy**: Task 8.2's write-up of the fixture-shrink improvement cited local-only
+        timing numbers (~170-180s -> ~15s, "~12x") -- an ironic near-repeat of the exact mistake
+        that section itself warns against. Corrected using actual per-test durations pulled from
+        both CI runs' logs (see Task 8.2's updated text and `design.md` Decision 4 point 7).
+- [x] 8.5 Re-verified after the `_sort_genotypes_safely()` fix: `TestBoxplotGenotypePagination` +
+      `TestBoxplotHorizontalHeightCap` + `TestBatchedFigureGenerators` (23 passed, including the
+      new natural-order test), ruff/black/mypy-baseline clean.

--- a/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
@@ -124,8 +124,14 @@ boundary.
       generator syntax wrapping already-eager work
 - [x] 3.3 Run tests, confirm FAIL (generators do not exist yet)
 - [x] 3.4 In `tests/test_step_exploratory_analysis.py`, add a fixture producing a synthetic
-      DataFrame pinned at 480 genotypes x 300 trait columns (dpi=100, matching this file's existing
-      low-DPI test convention) -- no proprietary data
+      DataFrame (dpi=100, matching this file's existing low-DPI test convention) -- no proprietary
+      data. Originally pinned at 480 genotypes x 300 trait columns to mirror the real #110/
+      production failure scale directly; **reduced to 100 genotypes x 40 traits after an actual CI
+      run on the opened PR showed the larger size pushed CI's 30-minute `tests` job timeout on
+      Ubuntu/Windows** (both failed at the identical 30m16s mark mid-suite -- a timeout, not a test
+      failure) even though it ran fine standalone locally (~170-180s). The smaller fixture still
+      triggers genotype pagination (2 pages) and multiple trait batches, runs in ~15s (see
+      `design.md` Decision 4 point 7's post-hoc update).
 - [x] 3.5 Add `test_peak_concurrent_figures_bounded_during_execute` -- instrument figure lifecycle
       by monkeypatching both figure-creation (e.g. wrap `plt.subplots`/`plt.figure`) and
       `matplotlib.pyplot.close`, recording `len(plt.get_fignums())` at both points (sampling only at
@@ -156,14 +162,16 @@ boundary.
 
 ## Task 4: Incremental save/close in GenerateStaticFiguresStep (TDD Red -> Green)
 *Commit 4: `fix(#110): incrementally save+close figures in GenerateStaticFiguresStep`*
-- [x] 4.1 In `tests/test_step_generate_static_figures.py`, add a 480-genotype fixture and a
-      `test_peak_concurrent_figures_bounded_during_static_figures` test using the same
-      creation+close instrumentation as Task 3.5. Used 30 traits (not the full 300) and disabled
+- [x] 4.1 In `tests/test_step_generate_static_figures.py`, add a `test_peak_concurrent_figures_bounded_during_static_figures`
+      test using the same creation+close instrumentation as Task 3.5, and disabled
       PCA/heritability/correlation/genotype-comparison plot types via `static_viz_config_enabled`,
       since this step generates many more figure types than `ExploratoryAnalysisStep` when fully
       enabled -- keeping the test scoped to trait-distribution figures (the code path this task
-      actually changes) keeps runtime reasonable, per the CI-cost budgeting note in `design.md`
-      Decision 4 point 7.
+      actually changes). Originally pinned at 480 genotypes x 30 traits, matching the real-world
+      failure scale; **reduced to 100 genotypes x 12 traits after an actual CI run on the opened PR
+      showed the larger size contributed to CI's 30-minute `tests` job timeout on Ubuntu/Windows**
+      (see Task 3.4's note and `design.md` Decision 4 point 7's post-hoc update) -- still triggers
+      genotype pagination and multiple trait batches, runs in ~14s instead of ~180s.
 - [x] 4.2 Run test, confirm FAIL on current code (full batch list materializes before any close)
 - [x] 4.3 Update `GenerateStaticFiguresStep` to iterate `_generate_trait_histogram_batches()` /
       `_generate_trait_boxplot_batches()` directly instead of calling the list-returning public
@@ -180,8 +188,9 @@ boundary.
 ## Task 5: End-to-end regression test against the real failure shape
 - [x] 5.1 Already satisfied by Task 3's `TestExploratoryAnalysisMemoryBounds` (no separate commit
       needed): `test_execute_completes_and_produces_figures_for_large_dataset` runs
-      `ExploratoryAnalysisStep.execute()` end-to-end against the 480x300 synthetic fixture with
-      `enable_batched_plots=True` (the `VisualizationConfig` default)
+      `ExploratoryAnalysisStep.execute()` end-to-end against the synthetic fixture (100 genotypes x
+      40 traits, reduced from an original 480x300 per Task 3.4's note) with `enable_batched_plots=True`
+      (the `VisualizationConfig` default)
 - [x] 5.2 Covered by the same test: asserts the step completes without raising, produces PNG figure
       files on disk, and produces multiple genotype-paginated boxplot batches (`box_batches > 1`)
 - [x] 5.3 Covered by the sibling test in the same class,
@@ -221,3 +230,22 @@ boundary.
 - [x] 7.7 Visual QA: generate boxplot figures for a genotype count that triggers pagination (e.g.
       120 genotypes, 2 pages) and open the PNGs with the Read tool to visually confirm labels are
       readable within each page and the suptitle correctly identifies the genotype range
+
+## Post-PR: CI-only timeout discovered and fixed
+- [x] 8.1 PR #210 opened; CI's `Tests (ubuntu, Python 3.11)` and `Tests (windows, Python 3.11)`
+      jobs both failed at the identical 30m16s mark (`##[error]The operation was canceled.`
+      mid-suite at 94% completion, no test failures visible) -- a 30-minute job timeout
+      (`.github/workflows/ci.yml` `timeout-minutes: 30`), not a real test failure. `macos` passed in
+      16m46s. Root cause: Task 3.4/4.1's 480-genotype fixtures ran fine standalone locally
+      (~170-180s each, which read as an acceptable budgeted cost per Decision 4 point 7) but pushed
+      the shared CI job over budget once combined with the rest of the ~2900-test suite --
+      standalone local timing is not sufficient evidence of CI feasibility for a shared-budget job.
+- [x] 8.2 Reduced both fixtures (100 genotypes x 40 traits for `ExploratoryAnalysisStep`, 100 x 12
+      for `GenerateStaticFiguresStep`) -- still large enough to trigger genotype pagination and
+      multiple trait batches, still large enough to clearly distinguish a bounded (~4 peak) from an
+      unbounded (near-total-figure-count peak) implementation. Runtime dropped from ~170-180s each
+      to ~15s each (~12x). Updated `design.md` Decision 4 point 7 and this file's Task 3.4/4.1/5.1
+      entries to document the correction and why.
+- [x] 8.3 Re-verified: `tests/test_step_exploratory_analysis.py` +
+      `tests/test_step_generate_static_figures.py` full files (86 passed), ruff/black clean,
+      `openspec validate --strict` passes.

--- a/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
@@ -14,37 +14,37 @@ boundary.
 
 ## Task 1: Height cap -- write failing tests, then implement (TDD Red -> Green)
 *Commit 1: `fix(#110): cap horizontal boxplot subplot height`*
-- [ ] 1.1 In `tests/test_visualization.py`, add `TestBoxplotHorizontalHeightCap` with a synthetic
+- [x] 1.1 In `tests/test_visualization.py`, add `TestBoxplotHorizontalHeightCap` with a synthetic
       DataFrame fixture pinned at 480 genotypes (horizontal orientation triggered) and a small
       trait count
-- [ ] 1.2 `test_direct_call_horizontal_height_capped` -- call `create_trait_boxplots_by_genotype()`
+- [x] 1.2 `test_direct_call_horizontal_height_capped` -- call `create_trait_boxplots_by_genotype()`
       directly (not via the batched wrapper) with 480 genotypes, horizontal orientation; assert
       `fig.get_size_inches()` height stays at or under the cap. This specifically catches the
       "cap applied only to the batched wrapper's local variable, silently discarded by the inner
       function" bug identified in `design.md` Decision 2.
-- [ ] 1.3 `test_batched_call_horizontal_height_capped` -- same assertion via
+- [x] 1.3 `test_batched_call_horizontal_height_capped` -- same assertion via
       `create_trait_boxplots_by_genotype_batched()`
-- [ ] 1.4 `test_horizontal_height_cap_boundary` -- `n_genotypes` chosen so
+- [x] 1.4 `test_horizontal_height_cap_boundary` -- `n_genotypes` chosen so
       `n_genotypes * 0.3 == max_subplot_height` exactly; assert no off-by-one/float issue in the
       `min()` cap
-- [ ] 1.5 `test_horizontal_height_unchanged_below_cap` -- genotype count low enough that
+- [x] 1.5 `test_horizontal_height_unchanged_below_cap` -- genotype count low enough that
       `n_genotypes * 0.3` is below the cap; assert height matches the existing uncapped formula
       exactly (`max(4.0, n_genotypes * 0.3)`) -- no regression for the common case
-- [ ] 1.6 `test_custom_max_subplot_height_respected` -- pass a non-default `max_subplot_height`
+- [x] 1.6 `test_custom_max_subplot_height_respected` -- pass a non-default `max_subplot_height`
       (e.g. 10.0) and confirm it, not the 20.0 default, is what bounds the output
-- [ ] 1.7 `test_horizontal_boxplots_zero_genotypes_and_zero_traits` -- empty-input edge cases
+- [x] 1.7 `test_horizontal_boxplots_zero_genotypes_and_zero_traits` -- empty-input edge cases
       (0 genotypes, empty `trait_cols`) do not raise
-- [ ] 1.8 Run tests, confirm FAIL on current code
-- [ ] 1.9 Add `max_subplot_height: float = 20.0` parameter to `create_trait_boxplots_by_genotype()`
+- [x] 1.8 Run tests, confirm FAIL on current code
+- [x] 1.9 Add `max_subplot_height: float = 20.0` parameter to `create_trait_boxplots_by_genotype()`
       (`visualization.py`); apply cap in the horizontal-orientation branch:
       `min_subplot_height = min(max_subplot_height, max(4, n_genotypes * height_per_genotype))`.
       Update its Google-style docstring `Args:` section.
-- [ ] 1.10 Add the same `max_subplot_height: float = 20.0` parameter to
+- [x] 1.10 Add the same `max_subplot_height: float = 20.0` parameter to
       `create_trait_boxplots_by_genotype_batched()`; use it in its own `batch_figsize`
       precomputation and pass it through to the inner `create_trait_boxplots_by_genotype()` call.
       Update its docstring `Args:` section.
-- [ ] 1.11 Run Task 1 tests, confirm PASS (green)
-- [ ] 1.12 Run the full existing `TestTraitBoxplotsAdaptiveSizing` and
+- [x] 1.11 Run Task 1 tests, confirm PASS (green)
+- [x] 1.12 Run the full existing `TestTraitBoxplotsAdaptiveSizing` and
       `TestBoxplotLabelOverlapFixes` classes, confirm no regressions
 
 ## Task 2: Genotype pagination for readability (TDD Red -> Green)

--- a/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
@@ -6,10 +6,10 @@ precedent for standalone failing-test commits and `main` has no per-commit CI ga
 boundary.
 
 ## Task 0: Dispose of the prior non-TDD draft
-- [ ] 0.1 Confirm the prior uncommitted draft is stashed (not applied) on this branch and is not
+- [x] 0.1 Confirm the prior uncommitted draft is stashed (not applied) on this branch and is not
       silently merged into any implementation below (its cap value, fix location, and lack of any
       pagination were all superseded by `design.md` Decisions 2 and 3)
-- [ ] 0.2 Drop the stash (`git stash drop`) once Task 7 confirms all tests pass and the draft has
+- [x] 0.2 Drop the stash (`git stash drop`) once Task 7 confirms all tests pass and the draft has
       been fully superseded
 
 ## Task 1: Height cap -- write failing tests, then implement (TDD Red -> Green)
@@ -212,9 +212,12 @@ boundary.
       `new: 0` / exit 0 after the fix
 - [x] 7.4 `openspec validate fix-110-oom-exploratory-analysis --strict` passes
 - [x] 7.5 Drop the reference-only stash (Task 0.2) once superseded -- dropped
-- [ ] 7.6 Note in the PR description that #202, the correlation-heatmap figsize cap, #110's P2
+- [x] 7.6 Note in the PR description that #202, the correlation-heatmap figsize cap, #110's P2
       DPI-reduction suggestion, and `create_exploratory_summary_plots()`'s separate
-      adaptive-sizing-bounded boxplot are explicitly out of scope for this change
+      adaptive-sizing-bounded boxplot are explicitly out of scope for this change -- included in
+      the "Out of scope" section of the PR body. Also ran a full pre-merge-check: fresh full-suite
+      coverage run (2866 passed, 37 skipped, 0 failed, 89% coverage) and a 5-subagent pre-PR review
+      (no blocking findings; all IMPORTANT findings fixed in a follow-up commit and re-verified)
 - [x] 7.7 Visual QA: generate boxplot figures for a genotype count that triggers pagination (e.g.
       120 genotypes, 2 pages) and open the PNGs with the Read tool to visually confirm labels are
       readable within each page and the suptitle correctly identifies the genotype range

--- a/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
+++ b/openspec/changes/fix-110-oom-exploratory-analysis/tasks.md
@@ -49,51 +49,51 @@ boundary.
 
 ## Task 2: Genotype pagination for readability (TDD Red -> Green)
 *Commit 2: `feat(#110): paginate boxplots by genotype when count exceeds readable page capacity`*
-- [ ] 2.1 In `tests/test_visualization.py`, add `TestBoxplotGenotypePagination`. Use a small, fixed
+- [x] 2.1 In `tests/test_visualization.py`, add `TestBoxplotGenotypePagination`. Use a small, fixed
       trait count for these tests (e.g. exactly 1 trait, so `n_traits <= batch_size` guarantees a
       single trait batch and every figure the test sees belongs to it unambiguously) -- pagination
       is a property of the genotype axis, not the trait axis, so reuse Task 1's 480-genotype
       fixture but do NOT reuse the full 300-trait fixture here (keeps these tests fast; see
       `design.md` Decision 4 point 6)
-- [ ] 2.2 `test_pagination_splits_genotypes_at_default_capacity` -- 480 genotypes, default
+- [x] 2.2 `test_pagination_splits_genotypes_at_default_capacity` -- 480 genotypes, default
       `max_genotypes_per_page` (auto-derived, ~66 for horizontal); assert
       `create_trait_boxplots_by_genotype_batched()` returns more figures than trait-batch count
       alone would produce (i.e. `n_trait_batches * n_genotype_pages`, `n_genotype_pages > 1`)
-- [ ] 2.3 `test_pagination_covers_every_genotype_exactly_once` -- with the single-trait-batch fixture
+- [x] 2.3 `test_pagination_covers_every_genotype_exactly_once` -- with the single-trait-batch fixture
       from 2.1, every returned figure belongs to that one trait batch; collect the genotype tick
       labels rendered in each figure (via `ax.get_yticklabels()` for horizontal orientation,
       matching the existing pattern at `tests/test_visualization.py:303,4033`) and assert their
       union equals the full 480-genotype set with no duplicates across figures
-- [ ] 2.4 `test_pagination_noop_at_or_below_capacity` -- genotype count at or below the auto-derived
+- [x] 2.4 `test_pagination_noop_at_or_below_capacity` -- genotype count at or below the auto-derived
       page capacity; assert exactly one genotype page per trait batch (no behavior change)
-- [ ] 2.5 `test_pagination_page_height_uses_readable_spacing_not_cap` -- a paginated figure's height
+- [x] 2.5 `test_pagination_page_height_uses_readable_spacing_not_cap` -- a paginated figure's height
       reflects `page_genotype_count * 0.3` (the pre-cap readable formula), not the 20" cap, since
       pages are sized to stay under it by construction
-- [ ] 2.6 `test_pagination_custom_max_genotypes_per_page_respected` -- explicit
+- [x] 2.6 `test_pagination_custom_max_genotypes_per_page_respected` -- explicit
       `max_genotypes_per_page` override changes the number of pages produced
-- [ ] 2.7 `test_pagination_suptitle_includes_genotype_range` -- a multi-page batch's figures each
+- [x] 2.7 `test_pagination_suptitle_includes_genotype_range` -- a multi-page batch's figures each
       have a `suptitle` containing the genotype range and total (e.g. "Genotypes 1-66 of 489")
-- [ ] 2.8 `test_pagination_last_page_orientation_matches_other_pages` -- use 469 genotypes with the
+- [x] 2.8 `test_pagination_last_page_orientation_matches_other_pages` -- use 469 genotypes with the
       default page capacity of 66 (`469 = 66*7 + 7`, leaving a 7-genotype final page, correctly
       below `horizontal_threshold=8` -- verify this arithmetic when implementing, a prior draft of
       this task miscalculated it as 483); assert every page's rendered orientation matches the
       orientation resolved from the *full* dataset, not one independently re-resolved from the
       small page's own count (see `design.md` Decision 3's orientation-consistency note)
-- [ ] 2.9 `test_pagination_missing_genotype_column_is_noop` -- a DataFrame that does not contain
+- [x] 2.9 `test_pagination_missing_genotype_column_is_noop` -- a DataFrame that does not contain
       `genotype_col` at all; assert `create_trait_boxplots_by_genotype_batched()` does not raise
       and produces one figure per trait batch (matching today's existing "0 genotypes" behavior),
       not a `KeyError`
-- [ ] 2.10 `test_pagination_with_nan_genotype_values` -- a DataFrame with some rows having a NaN
+- [x] 2.10 `test_pagination_with_nan_genotype_values` -- a DataFrame with some rows having a NaN
       genotype value alongside 480+ real genotype values; assert pagination does not raise
       (`sorted()` on a mixed NaN/string array raises `TypeError`) and every non-NaN genotype still
       appears in exactly one page
-- [ ] 2.11 `test_pagination_with_partial_trait_batch_and_partial_genotype_page` -- e.g. 20 traits
+- [x] 2.11 `test_pagination_with_partial_trait_batch_and_partial_genotype_page` -- e.g. 20 traits
       with `batch_size=16` (batches of 16 + 4) crossed with 100 genotypes at the default page
       capacity of 66 (pages of 66 + 34); assert figure count equals
       `n_trait_batches * n_genotype_pages` and each figure's figsize matches the per-page formula
       for its actual (possibly partial) trait and genotype counts
-- [ ] 2.12 Run tests, confirm FAIL on current code (no pagination exists yet)
-- [ ] 2.13 In `create_trait_boxplots_by_genotype_batched()`, add `max_genotypes_per_page:
+- [x] 2.12 Run tests, confirm FAIL on current code (no pagination exists yet)
+- [x] 2.13 In `create_trait_boxplots_by_genotype_batched()`, add `max_genotypes_per_page:
       Optional[int] = None` parameter; when `None`, derive as `max(1, int(max_subplot_height //
       per_genotype_size))` using 0.3 (horizontal) or 0.5 (vertical) based on `actual_orientation`.
       Guard `genotype_col in df.columns` before accessing it for pagination purposes -- if absent,
@@ -108,8 +108,8 @@ boundary.
       argument) into each per-page call so every page of a batch uses a consistent orientation
       regardless of that page's own genotype count. Append the genotype range to the `suptitle`
       when more than one page exists. Update the docstring `Args:` section.
-- [ ] 2.14 Run Task 2 tests, confirm PASS (green)
-- [ ] 2.15 Run the full existing `TestTraitBoxplotsAdaptiveSizing`, `TestBoxplotLabelOverlapFixes`,
+- [x] 2.14 Run Task 2 tests, confirm PASS (green)
+- [x] 2.15 Run the full existing `TestTraitBoxplotsAdaptiveSizing`, `TestBoxplotLabelOverlapFixes`,
       and Task 1's height-cap tests, confirm no regressions
 
 ## Task 3: Generator refactor + incremental save/close in ExploratoryAnalysisStep (TDD Red -> Green)

--- a/src/sleap_roots_analyze/pipeline/steps/exploratory_analysis.py
+++ b/src/sleap_roots_analyze/pipeline/steps/exploratory_analysis.py
@@ -95,15 +95,20 @@ class ExploratoryAnalysisStep(BaseStep):
 
         def _save_and_close(name: str, fig: plt.Figure) -> None:
             fig_path = figures_dir / f"{name}.{config.visualization.figure_format}"
-            fig.savefig(
-                fig_path,
-                dpi=config.visualization.dpi,
-                bbox_inches=config.visualization.bbox_inches,
-                facecolor=config.visualization.facecolor,
-                edgecolor=config.visualization.edgecolor,
-                transparent=config.visualization.transparent,
-            )
-            plt.close(fig)
+            try:
+                fig.savefig(
+                    fig_path,
+                    dpi=config.visualization.dpi,
+                    bbox_inches=config.visualization.bbox_inches,
+                    facecolor=config.visualization.facecolor,
+                    edgecolor=config.visualization.edgecolor,
+                    transparent=config.visualization.transparent,
+                )
+            finally:
+                # Always close, even if savefig raises, so a save failure
+                # can't leak the figure back into the unbounded-accumulation
+                # pattern this step exists to avoid (Issue #110).
+                plt.close(fig)
             files.append(fig_path)
             figure_names.append(name)
 

--- a/src/sleap_roots_analyze/pipeline/steps/exploratory_analysis.py
+++ b/src/sleap_roots_analyze/pipeline/steps/exploratory_analysis.py
@@ -9,11 +9,11 @@ import matplotlib.pyplot as plt
 
 from sleap_roots_analyze.statistics import calculate_trait_statistics
 from sleap_roots_analyze.visualization import (
+    _generate_trait_boxplot_batches,
+    _generate_trait_histogram_batches,
     create_correlation_heatmap,
     create_exploratory_summary_plots,
-    create_trait_boxplots_by_genotype_batched,
     create_trait_eda_plots,
-    create_trait_histograms_batched,
 )
 from sleap_roots_analyze.viz_utils import calculate_correlation_matrix_size
 from sleap_roots_analyze.pipeline.core import BaseStep, StepResult
@@ -84,6 +84,29 @@ class ExploratoryAnalysisStep(BaseStep):
         # 1. Calculate trait statistics
         stats = calculate_trait_statistics(df=df, trait_cols=trait_cols)
 
+        # Save and close each figure as soon as it's produced instead of
+        # accumulating every figure in memory before saving any of them
+        # (Issue #110: peak memory was the sum of every figure generated in
+        # this step -- e.g. dozens of batched boxplot figures, a full
+        # correlation heatmap, and histograms all held simultaneously --
+        # rather than the size of the single largest one).
+        files: list[Path] = []
+        figure_names: list[str] = []
+
+        def _save_and_close(name: str, fig: plt.Figure) -> None:
+            fig_path = figures_dir / f"{name}.{config.visualization.figure_format}"
+            fig.savefig(
+                fig_path,
+                dpi=config.visualization.dpi,
+                bbox_inches=config.visualization.bbox_inches,
+                facecolor=config.visualization.facecolor,
+                edgecolor=config.visualization.edgecolor,
+                transparent=config.visualization.transparent,
+            )
+            plt.close(fig)
+            files.append(fig_path)
+            figure_names.append(name)
+
         # 2. Create exploratory summary plots
         # Pass adaptive config if enabled
         adaptive_cfg = (
@@ -95,6 +118,8 @@ class ExploratoryAnalysisStep(BaseStep):
             genotype_col=genotype_col,
             adaptive_config=adaptive_cfg,
         )
+        for fig_name, fig in summary_figures.items():
+            _save_and_close(fig_name, fig)
 
         # 3. Create detailed EDA plots with cleanup thresholds
         thresholds = {
@@ -110,9 +135,8 @@ class ExploratoryAnalysisStep(BaseStep):
             cleanup_log=cleanup_log,
             min_samples_per_trait=config.cleanup.min_samples_per_trait,
         )
-
-        # Combine all figures
-        all_figures = {**summary_figures, **eda_figures}
+        for fig_name, fig in eda_figures.items():
+            _save_and_close(fig_name, fig)
 
         # 3.5. Add full correlation heatmap (separate from summary plots)
         # Use adaptive sizing if enabled
@@ -128,46 +152,33 @@ class ExploratoryAnalysisStep(BaseStep):
             trait_cols=trait_cols,
             figsize=corr_figsize,
         )
-        all_figures["full_correlation_heatmap"] = full_corr_fig
+        _save_and_close("full_correlation_heatmap", full_corr_fig)
 
-        # 4. Add batched trait visualizations if enabled and threshold exceeded
+        # 4. Add batched trait visualizations if enabled and threshold exceeded.
+        # Generate, save, and close one batch at a time (rather than collecting
+        # the full list first) so at most one batch figure exists at a time.
         if (
             config.visualization.enable_batched_plots
             and len(trait_cols) > config.visualization.batched_plot_threshold
         ):
-            # Batched histograms
-            hist_figs = create_trait_histograms_batched(
-                df=df,
-                trait_cols=trait_cols,
-                batch_size=config.visualization.batch_size,
-            )
-            for i, fig in enumerate(hist_figs):
-                all_figures[f"04_trait_histograms_batch_{i + 1}"] = fig
+            for i, fig in enumerate(
+                _generate_trait_histogram_batches(
+                    df=df,
+                    trait_cols=trait_cols,
+                    batch_size=config.visualization.batch_size,
+                )
+            ):
+                _save_and_close(f"04_trait_histograms_batch_{i + 1}", fig)
 
-            # Batched boxplots by genotype
-            box_figs = create_trait_boxplots_by_genotype_batched(
-                df=df,
-                trait_cols=trait_cols,
-                genotype_col=genotype_col,
-                batch_size=config.visualization.batch_size,
-            )
-            for i, fig in enumerate(box_figs):
-                all_figures[f"04_trait_boxplots_batch_{i + 1}"] = fig
-
-        # Save all figures
-        files = []
-        for fig_name, fig in all_figures.items():
-            fig_path = figures_dir / f"{fig_name}.{config.visualization.figure_format}"
-            fig.savefig(
-                fig_path,
-                dpi=config.visualization.dpi,
-                bbox_inches=config.visualization.bbox_inches,
-                facecolor=config.visualization.facecolor,
-                edgecolor=config.visualization.edgecolor,
-                transparent=config.visualization.transparent,
-            )
-            plt.close(fig)  # Close to free memory
-            files.append(fig_path)
+            for i, fig in enumerate(
+                _generate_trait_boxplot_batches(
+                    df=df,
+                    trait_cols=trait_cols,
+                    genotype_col=genotype_col,
+                    batch_size=config.visualization.batch_size,
+                )
+            ):
+                _save_and_close(f"04_trait_boxplots_batch_{i + 1}", fig)
 
         # Save statistics
         stats_path = self.save_json(stats, "trait_statistics.json", run_dir)
@@ -177,8 +188,8 @@ class ExploratoryAnalysisStep(BaseStep):
         metadata = {
             "samples": len(df),
             "traits": len(trait_cols),
-            "figures_generated": len(all_figures),
-            "figure_names": list(all_figures.keys()),
+            "figures_generated": len(figure_names),
+            "figure_names": figure_names,
             "statistics": stats,
             "trait_names": trait_cols,  # Primary key (standardized)
             "valid_trait_names": trait_cols,  # For consistency

--- a/src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py
+++ b/src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py
@@ -612,18 +612,22 @@ class GenerateStaticFiguresStep(BaseStep):
                 df, trait_cols, batch_size=histogram_batch_size
             )
         ):
-            files.extend(
-                self._save_figure(
-                    subfig,
-                    f"trait_histograms_batch{i + 1}",
-                    histograms_dir,
-                    formats,
-                    dpi,
-                    bbox_inches=config.static_viz.bbox_inches,
-                    transparent=config.static_viz.transparent,
+            try:
+                files.extend(
+                    self._save_figure(
+                        subfig,
+                        f"trait_histograms_batch{i + 1}",
+                        histograms_dir,
+                        formats,
+                        dpi,
+                        bbox_inches=config.static_viz.bbox_inches,
+                        transparent=config.static_viz.transparent,
+                    )
                 )
-            )
-            plt.close(subfig)
+            finally:
+                # Always close, even if saving raises, so a save failure
+                # can't leak the figure (Issue #110).
+                plt.close(subfig)
             # Periodically reclaim memory during large batch generation
             if (i + 1) % 10 == 0:
                 gc.collect()
@@ -652,18 +656,22 @@ class GenerateStaticFiguresStep(BaseStep):
                     **boxplot_kwargs,
                 )
             ):
-                files.extend(
-                    self._save_figure(
-                        subfig,
-                        f"trait_boxplots_batch{i + 1}",
-                        boxplots_dir,
-                        formats,
-                        dpi,
-                        bbox_inches=config.static_viz.bbox_inches,
-                        transparent=config.static_viz.transparent,
+                try:
+                    files.extend(
+                        self._save_figure(
+                            subfig,
+                            f"trait_boxplots_batch{i + 1}",
+                            boxplots_dir,
+                            formats,
+                            dpi,
+                            bbox_inches=config.static_viz.bbox_inches,
+                            transparent=config.static_viz.transparent,
+                        )
                     )
-                )
-                plt.close(subfig)
+                finally:
+                    # Always close, even if saving raises, so a save failure
+                    # can't leak the figure (Issue #110).
+                    plt.close(subfig)
                 # Periodically reclaim memory during large batch generation
                 if (i + 1) % 10 == 0:
                     gc.collect()

--- a/src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py
+++ b/src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py
@@ -13,6 +13,8 @@ import pandas as pd
 
 from sleap_roots_analyze.pipeline.core import BaseStep, StepResult
 from sleap_roots_analyze.visualization import (
+    _generate_trait_boxplot_batches,
+    _generate_trait_histogram_batches,
     create_correlation_heatmap,
     create_feature_contribution_heatmap,
     create_feature_contribution_plot,
@@ -23,8 +25,6 @@ from sleap_roots_analyze.visualization import (
     create_pca_scree_plot,
     create_phenotype_variation_plot,
     create_regression_plot,
-    create_trait_boxplots_by_genotype_batched,
-    create_trait_histograms_batched,
     create_umap_colored_by_top_traits,
     identify_extreme_genotypes_by_pc,
 )
@@ -604,10 +604,14 @@ class GenerateStaticFiguresStep(BaseStep):
             )
 
         # Histograms (batched) - saved to figures/trait_histograms/
-        fig = create_trait_histograms_batched(
-            df, trait_cols, batch_size=histogram_batch_size
-        )
-        for i, subfig in enumerate(fig):
+        # Iterate the generator directly (rather than materializing the full
+        # batch list first) so at most one batch figure is held in memory at
+        # a time (Issue #110).
+        for i, subfig in enumerate(
+            _generate_trait_histogram_batches(
+                df, trait_cols, batch_size=histogram_batch_size
+            )
+        ):
             files.extend(
                 self._save_figure(
                     subfig,
@@ -641,12 +645,13 @@ class GenerateStaticFiguresStep(BaseStep):
                     sizing.height_per_item,
                 )
 
-            fig = create_trait_boxplots_by_genotype_batched(
-                df,
-                trait_cols,
-                **boxplot_kwargs,
-            )
-            for i, subfig in enumerate(fig):
+            for i, subfig in enumerate(
+                _generate_trait_boxplot_batches(
+                    df,
+                    trait_cols,
+                    **boxplot_kwargs,
+                )
+            ):
                 files.extend(
                     self._save_figure(
                         subfig,

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -403,9 +403,7 @@ def _generate_trait_boxplot_batches(
         max_genotypes_per_page = max(1, int(max_subplot_height // per_genotype_size))
 
     all_genotypes = (
-        sorted(df[genotype_col].dropna().unique())
-        if genotype_col in df.columns
-        else []
+        sorted(df[genotype_col].dropna().unique()) if genotype_col in df.columns else []
     )
     if all_genotypes and len(all_genotypes) > max_genotypes_per_page:
         genotype_pages = [

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -105,6 +105,23 @@ def create_trait_histograms(
     return fig
 
 
+def _sort_genotypes_safely(values: Any) -> List[Any]:
+    """Sort genotype values, tolerating a mixed-dtype column.
+
+    Tries a natural sort first, so a homogeneous column (all strings, or
+    all numeric) keeps its natural order (e.g. numeric genotype IDs sort as
+    1, 2, 10, 20 -- not lexicographically as "1", "10", "2", "20"). Falls
+    back to sorting by `str()` only if the natural sort raises `TypeError`,
+    which happens for a genuinely mixed-dtype column (e.g. some
+    numeric-looking genotype IDs alongside string ones in unsanitized CSV
+    input).
+    """
+    try:
+        return sorted(values)
+    except TypeError:
+        return sorted(values, key=str)
+
+
 def create_trait_boxplots_by_genotype(
     df: pd.DataFrame,
     trait_cols: List[str],
@@ -230,7 +247,9 @@ def create_trait_boxplots_by_genotype(
                     # Use matplotlib boxplot for horizontal orientation
                     # Style matches df.boxplot() vertical: blue boxes, green
                     # medians, gridlines, unfilled outline
-                    genotype_order = sorted(df_plot[genotype_col].unique(), key=str)
+                    genotype_order = _sort_genotypes_safely(
+                        df_plot[genotype_col].unique()
+                    )
                     grouped_data = [
                         df_plot.loc[df_plot[genotype_col] == g, trait].values
                         for g in genotype_order
@@ -403,7 +422,7 @@ def _generate_trait_boxplot_batches(
         max_genotypes_per_page = max(1, int(max_subplot_height // per_genotype_size))
 
     all_genotypes = (
-        sorted(df[genotype_col].dropna().unique(), key=str)
+        _sort_genotypes_safely(df[genotype_col].dropna().unique())
         if genotype_col in df.columns
         else []
     )

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -405,6 +405,7 @@ def _generate_trait_boxplot_batches(
     all_genotypes = (
         sorted(df[genotype_col].dropna().unique()) if genotype_col in df.columns else []
     )
+    genotype_pages: List[Optional[List[Any]]]
     if all_genotypes and len(all_genotypes) > max_genotypes_per_page:
         genotype_pages = [
             all_genotypes[p : p + max_genotypes_per_page]

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -11,7 +11,7 @@ This module provides basic static visualization functions including:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, Iterator, List, Optional, Tuple, Union
 import numpy as np
 import pandas as pd
 import matplotlib.pyplot as plt
@@ -285,30 +285,24 @@ def create_trait_boxplots_by_genotype(
     return fig
 
 
-def create_trait_histograms_batched(
+def _generate_trait_histogram_batches(
     df: pd.DataFrame,
     trait_cols: List[str],
     batch_size: int = 16,
     n_cols: int = 4,
     figsize: Tuple[int, int] = (16, 16),
-) -> List[plt.Figure]:
-    """Create batched histogram plots for traits (multiple figures for many traits).
+) -> Iterator[plt.Figure]:
+    """Yield batched histogram figures one at a time.
 
-    Args:
-        df: DataFrame with trait data
-        trait_cols: List of trait column names
-        batch_size: Number of traits per figure (default: 16)
-        n_cols: Number of columns in subplot grid
-        figsize: Figure size for FULL batches (default: (16, 16))
-
-    Returns:
-        List of matplotlib figure objects (one per batch)
+    Generator form of `create_trait_histograms_batched`, so a caller can
+    save+close each batch immediately instead of holding every batch figure
+    in memory simultaneously (Issue #110: peak memory was the sum of every
+    batch figure generated, not the size of the single largest one).
     """
     n_traits = len(trait_cols)
     if n_traits == 0:
-        return []
+        return
 
-    figures = []
     for batch_start in range(0, n_traits, batch_size):
         batch_end = min(batch_start + batch_size, n_traits)
         batch_traits = trait_cols[batch_start:batch_end]
@@ -335,12 +329,39 @@ def create_trait_histograms_batched(
             fontsize=14,
             y=0.995,
         )
-        figures.append(fig)
-
-    return figures
+        yield fig
 
 
-def create_trait_boxplots_by_genotype_batched(
+def create_trait_histograms_batched(
+    df: pd.DataFrame,
+    trait_cols: List[str],
+    batch_size: int = 16,
+    n_cols: int = 4,
+    figsize: Tuple[int, int] = (16, 16),
+) -> List[plt.Figure]:
+    """Create batched histogram plots for traits (multiple figures for many traits).
+
+    Args:
+        df: DataFrame with trait data
+        trait_cols: List of trait column names
+        batch_size: Number of traits per figure (default: 16)
+        n_cols: Number of columns in subplot grid
+        figsize: Figure size for FULL batches (default: (16, 16))
+
+    Returns:
+        List of matplotlib figure objects (one per batch)
+
+    Note:
+        Holds every batch figure in memory at once. For many traits, prefer
+        iterating `_generate_trait_histogram_batches` directly and
+        saving+closing each figure as it's produced.
+    """
+    return list(
+        _generate_trait_histogram_batches(df, trait_cols, batch_size, n_cols, figsize)
+    )
+
+
+def _generate_trait_boxplot_batches(
     df: pd.DataFrame,
     trait_cols: List[str],
     genotype_col: str = "geno",
@@ -352,43 +373,17 @@ def create_trait_boxplots_by_genotype_batched(
     horizontal_threshold: int = 8,
     max_subplot_height: float = 20.0,
     max_genotypes_per_page: Optional[int] = None,
-) -> List[plt.Figure]:
-    """Create batched boxplot plots by genotype (multiple figures for many traits).
+) -> Iterator[plt.Figure]:
+    """Yield batched genotype-boxplot figures one at a time.
 
-    Args:
-        df: DataFrame with trait data
-        trait_cols: List of trait column names
-        genotype_col: Column name for genotype grouping
-        batch_size: Number of traits per figure (default: 16)
-        n_cols: Number of columns in subplot grid
-        figsize: Optional explicit figure size. If None (default), calculated adaptively
-            based on n_cols, batch_size, and subplot_size.
-        subplot_size: Size of each subplot (width, height) in inches when figsize is None.
-            Default (4.0, 4.0) for square subplots.
-        orientation: Boxplot orientation - "vertical", "horizontal", or "auto".
-            "auto" switches to horizontal when n_genotypes > horizontal_threshold.
-        horizontal_threshold: Number of genotypes above which auto orientation
-            switches to horizontal (default: 8).
-        max_subplot_height: Maximum height in inches per subplot in horizontal
-            orientation (default: 20.0), mirroring the vertical orientation's
-            existing per-subplot width cap. Passed through to the underlying
-            single-figure renderer, which is where the cap actually takes
-            effect (Issue #110).
-        max_genotypes_per_page: Maximum number of genotypes rendered in a single
-            figure. When the dataset has more genotypes than this, genotypes are
-            split into consecutive alphabetically-sorted pages and one figure is
-            rendered per (trait batch, genotype page) combination, keeping every
-            page at the same readable per-genotype spacing used below the height
-            cap. Defaults to `None`, which auto-derives a value from
-            `max_subplot_height` and the per-genotype size for the orientation in
-            effect (~66 for horizontal, ~40 for vertical, at default settings).
-
-    Returns:
-        List of matplotlib figure objects (one per batch per genotype page)
+    Generator form of `create_trait_boxplots_by_genotype_batched`, so a
+    caller can save+close each batch immediately instead of holding every
+    batch figure in memory simultaneously (Issue #110). Includes the
+    horizontal-orientation height cap and genotype pagination.
     """
     n_traits = len(trait_cols)
     if n_traits == 0:
-        return []
+        return
 
     # Determine actual orientation for sizing calculations
     n_genotypes = df[genotype_col].nunique() if genotype_col in df.columns else 0
@@ -423,7 +418,6 @@ def create_trait_boxplots_by_genotype_batched(
         genotype_pages = [None]
     n_pages = len(genotype_pages)
 
-    figures = []
     for batch_start in range(0, n_traits, batch_size):
         batch_end = min(batch_start + batch_size, n_traits)
         batch_traits = trait_cols[batch_start:batch_end]
@@ -504,9 +498,75 @@ def create_trait_boxplots_by_genotype_batched(
                 y=0.995,
             )
             fig.tight_layout(rect=[0, 0, 1, 0.96])
-            figures.append(fig)
+            yield fig
 
-    return figures
+
+def create_trait_boxplots_by_genotype_batched(
+    df: pd.DataFrame,
+    trait_cols: List[str],
+    genotype_col: str = "geno",
+    batch_size: int = 16,
+    n_cols: int = 4,
+    figsize: Optional[Tuple[int, int]] = None,
+    subplot_size: Tuple[float, float] = (4.0, 4.0),
+    orientation: str = "auto",
+    horizontal_threshold: int = 8,
+    max_subplot_height: float = 20.0,
+    max_genotypes_per_page: Optional[int] = None,
+) -> List[plt.Figure]:
+    """Create batched boxplot plots by genotype (multiple figures for many traits).
+
+    Args:
+        df: DataFrame with trait data
+        trait_cols: List of trait column names
+        genotype_col: Column name for genotype grouping
+        batch_size: Number of traits per figure (default: 16)
+        n_cols: Number of columns in subplot grid
+        figsize: Optional explicit figure size. If None (default), calculated adaptively
+            based on n_cols, batch_size, and subplot_size.
+        subplot_size: Size of each subplot (width, height) in inches when figsize is None.
+            Default (4.0, 4.0) for square subplots.
+        orientation: Boxplot orientation - "vertical", "horizontal", or "auto".
+            "auto" switches to horizontal when n_genotypes > horizontal_threshold.
+        horizontal_threshold: Number of genotypes above which auto orientation
+            switches to horizontal (default: 8).
+        max_subplot_height: Maximum height in inches per subplot in horizontal
+            orientation (default: 20.0), mirroring the vertical orientation's
+            existing per-subplot width cap. Passed through to the underlying
+            single-figure renderer, which is where the cap actually takes
+            effect (Issue #110).
+        max_genotypes_per_page: Maximum number of genotypes rendered in a single
+            figure. When the dataset has more genotypes than this, genotypes are
+            split into consecutive alphabetically-sorted pages and one figure is
+            rendered per (trait batch, genotype page) combination, keeping every
+            page at the same readable per-genotype spacing used below the height
+            cap. Defaults to `None`, which auto-derives a value from
+            `max_subplot_height` and the per-genotype size for the orientation in
+            effect (~66 for horizontal, ~40 for vertical, at default settings).
+
+    Returns:
+        List of matplotlib figure objects (one per batch per genotype page)
+
+    Note:
+        Holds every batch figure in memory at once. For many traits or many
+        genotypes, prefer iterating `_generate_trait_boxplot_batches` directly
+        and saving+closing each figure as it's produced.
+    """
+    return list(
+        _generate_trait_boxplot_batches(
+            df,
+            trait_cols,
+            genotype_col,
+            batch_size,
+            n_cols,
+            figsize,
+            subplot_size,
+            orientation,
+            horizontal_threshold,
+            max_subplot_height,
+            max_genotypes_per_page,
+        )
+    )
 
 
 def create_correlation_heatmap(

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -230,7 +230,7 @@ def create_trait_boxplots_by_genotype(
                     # Use matplotlib boxplot for horizontal orientation
                     # Style matches df.boxplot() vertical: blue boxes, green
                     # medians, gridlines, unfilled outline
-                    genotype_order = sorted(df_plot[genotype_col].unique())
+                    genotype_order = sorted(df_plot[genotype_col].unique(), key=str)
                     grouped_data = [
                         df_plot.loc[df_plot[genotype_col] == g, trait].values
                         for g in genotype_order
@@ -403,7 +403,9 @@ def _generate_trait_boxplot_batches(
         max_genotypes_per_page = max(1, int(max_subplot_height // per_genotype_size))
 
     all_genotypes = (
-        sorted(df[genotype_col].dropna().unique()) if genotype_col in df.columns else []
+        sorted(df[genotype_col].dropna().unique(), key=str)
+        if genotype_col in df.columns
+        else []
     )
     genotype_pages: List[Optional[List[Any]]]
     if all_genotypes and len(all_genotypes) > max_genotypes_per_page:
@@ -417,6 +419,14 @@ def _generate_trait_boxplot_batches(
         genotype_pages = [None]
     n_pages = len(genotype_pages)
 
+    # Precompute each page's filtered DataFrame once, since it depends only on
+    # the genotype page (not the trait batch) -- avoids redundant isin()
+    # filtering on every (trait batch, genotype page) combination below.
+    page_dfs: List[pd.DataFrame] = [
+        df[df[genotype_col].isin(page_genotypes)] if page_genotypes is not None else df
+        for page_genotypes in genotype_pages
+    ]
+
     for batch_start in range(0, n_traits, batch_size):
         batch_end = min(batch_start + batch_size, n_traits)
         batch_traits = trait_cols[batch_start:batch_end]
@@ -429,12 +439,10 @@ def _generate_trait_boxplot_batches(
         actual_cols = min(n_cols, n_traits_in_batch)
 
         for page_idx, page_genotypes in enumerate(genotype_pages):
-            if page_genotypes is not None:
-                page_df = df[df[genotype_col].isin(page_genotypes)]
-                n_genotypes_page = len(page_genotypes)
-            else:
-                page_df = df
-                n_genotypes_page = n_genotypes
+            page_df = page_dfs[page_idx]
+            n_genotypes_page = (
+                len(page_genotypes) if page_genotypes is not None else n_genotypes
+            )
 
             if figsize is not None:
                 # Explicit figsize provided - scale both dimensions for partial batches

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -351,6 +351,7 @@ def create_trait_boxplots_by_genotype_batched(
     orientation: str = "auto",
     horizontal_threshold: int = 8,
     max_subplot_height: float = 20.0,
+    max_genotypes_per_page: Optional[int] = None,
 ) -> List[plt.Figure]:
     """Create batched boxplot plots by genotype (multiple figures for many traits).
 
@@ -373,9 +374,17 @@ def create_trait_boxplots_by_genotype_batched(
             existing per-subplot width cap. Passed through to the underlying
             single-figure renderer, which is where the cap actually takes
             effect (Issue #110).
+        max_genotypes_per_page: Maximum number of genotypes rendered in a single
+            figure. When the dataset has more genotypes than this, genotypes are
+            split into consecutive alphabetically-sorted pages and one figure is
+            rendered per (trait batch, genotype page) combination, keeping every
+            page at the same readable per-genotype spacing used below the height
+            cap. Defaults to `None`, which auto-derives a value from
+            `max_subplot_height` and the per-genotype size for the orientation in
+            effect (~66 for horizontal, ~40 for vertical, at default settings).
 
     Returns:
-        List of matplotlib figure objects (one per batch)
+        List of matplotlib figure objects (one per batch per genotype page)
     """
     n_traits = len(trait_cols)
     if n_traits == 0:
@@ -390,6 +399,30 @@ def create_trait_boxplots_by_genotype_batched(
     else:
         actual_orientation = orientation
 
+    # Determine genotype pagination (Issue #110: readability at high genotype
+    # counts). NaN genotype values are dropped before sorting, matching the
+    # single-figure renderer's own convention of only ever sorting/plotting a
+    # dropna()'d subset.
+    if max_genotypes_per_page is None:
+        per_genotype_size = 0.3 if actual_orientation == "horizontal" else 0.5
+        max_genotypes_per_page = max(1, int(max_subplot_height // per_genotype_size))
+
+    all_genotypes = (
+        sorted(df[genotype_col].dropna().unique())
+        if genotype_col in df.columns
+        else []
+    )
+    if all_genotypes and len(all_genotypes) > max_genotypes_per_page:
+        genotype_pages = [
+            all_genotypes[p : p + max_genotypes_per_page]
+            for p in range(0, len(all_genotypes), max_genotypes_per_page)
+        ]
+    else:
+        # No pagination needed: a single page using the unfiltered DataFrame,
+        # matching pre-pagination behavior exactly.
+        genotype_pages = [None]
+    n_pages = len(genotype_pages)
+
     figures = []
     for batch_start in range(0, n_traits, batch_size):
         batch_end = min(batch_start + batch_size, n_traits)
@@ -402,53 +435,76 @@ def create_trait_boxplots_by_genotype_batched(
         # Calculate actual columns used in this batch (may be fewer than n_cols)
         actual_cols = min(n_cols, n_traits_in_batch)
 
-        if figsize is not None:
-            # Explicit figsize provided - scale both dimensions for partial batches
-            full_n_rows = (batch_size + n_cols - 1) // n_cols
-            width_scale = actual_cols / n_cols
-            height_scale = n_rows / full_n_rows
-            batch_figsize = (figsize[0] * width_scale, figsize[1] * height_scale)
-        else:
-            # Adaptive sizing: calculate based on actual layout
-            if actual_orientation == "horizontal":
-                # For horizontal, height scales with genotype count, capped to
-                # prevent extremely large figures (Issue #110)
-                height_per_genotype = 0.3
-                subplot_height = min(
-                    max_subplot_height,
-                    max(subplot_size[1], n_genotypes * height_per_genotype),
-                )
-                batch_figsize = (actual_cols * subplot_size[0], n_rows * subplot_height)
+        for page_idx, page_genotypes in enumerate(genotype_pages):
+            if page_genotypes is not None:
+                page_df = df[df[genotype_col].isin(page_genotypes)]
+                n_genotypes_page = len(page_genotypes)
             else:
-                # For vertical, scale subplot width with genotype count
-                # Cap at 20 inches per subplot to prevent extremely large figures
-                adaptive_subplot_width = min(
-                    20.0, max(subplot_size[0], n_genotypes * 0.5)
-                )
-                batch_figsize = (
-                    actual_cols * adaptive_subplot_width,
-                    n_rows * subplot_size[1],
-                )
+                page_df = df
+                n_genotypes_page = n_genotypes
 
-        # Create figure for this batch
-        # Use actual_cols so the subplot grid matches the computed figsize
-        fig = create_trait_boxplots_by_genotype(
-            df,
-            batch_traits,
-            genotype_col=genotype_col,
-            n_cols=actual_cols,
-            figsize=batch_figsize,
-            orientation=orientation,
-            horizontal_threshold=horizontal_threshold,
-            max_subplot_height=max_subplot_height,
-        )
-        fig.suptitle(
-            f"Trait Boxplots by Genotype (Traits {batch_start + 1}-{batch_end} of {n_traits})",
-            fontsize=14,
-            y=0.995,
-        )
-        fig.tight_layout(rect=[0, 0, 1, 0.96])
-        figures.append(fig)
+            if figsize is not None:
+                # Explicit figsize provided - scale both dimensions for partial batches
+                full_n_rows = (batch_size + n_cols - 1) // n_cols
+                width_scale = actual_cols / n_cols
+                height_scale = n_rows / full_n_rows
+                batch_figsize = (figsize[0] * width_scale, figsize[1] * height_scale)
+            else:
+                # Adaptive sizing: calculate based on actual layout, driven by
+                # this page's genotype count (bounded by max_genotypes_per_page
+                # by construction, so the height/width cap is a backstop here,
+                # not the primary mechanism)
+                if actual_orientation == "horizontal":
+                    height_per_genotype = 0.3
+                    subplot_height = min(
+                        max_subplot_height,
+                        max(subplot_size[1], n_genotypes_page * height_per_genotype),
+                    )
+                    batch_figsize = (
+                        actual_cols * subplot_size[0],
+                        n_rows * subplot_height,
+                    )
+                else:
+                    # For vertical, scale subplot width with genotype count
+                    # Cap at 20 inches per subplot to prevent extremely large figures
+                    adaptive_subplot_width = min(
+                        20.0, max(subplot_size[0], n_genotypes_page * 0.5)
+                    )
+                    batch_figsize = (
+                        actual_cols * adaptive_subplot_width,
+                        n_rows * subplot_size[1],
+                    )
+
+            # Create figure for this batch/page
+            # Use actual_cols so the subplot grid matches the computed figsize
+            # Pass the already-resolved actual_orientation (not the original,
+            # possibly-"auto", orientation) so every page of a batch uses a
+            # consistent orientation regardless of that page's own genotype count
+            fig = create_trait_boxplots_by_genotype(
+                page_df,
+                batch_traits,
+                genotype_col=genotype_col,
+                n_cols=actual_cols,
+                figsize=batch_figsize,
+                orientation=actual_orientation,
+                horizontal_threshold=horizontal_threshold,
+                max_subplot_height=max_subplot_height,
+            )
+            title = (
+                f"Trait Boxplots by Genotype (Traits {batch_start + 1}-{batch_end} "
+                f"of {n_traits})"
+            )
+            if n_pages > 1:
+                page_start = page_idx * max_genotypes_per_page
+                page_end = page_start + n_genotypes_page
+                title += f" | Genotypes {page_start + 1}-{page_end} of {n_genotypes}"
+            fig.suptitle(
+                title,
+                fontsize=14,
+                y=0.995,
+            )
+            fig.tight_layout(rect=[0, 0, 1, 0.96])
+            figures.append(fig)
 
     return figures
 

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -114,6 +114,7 @@ def create_trait_boxplots_by_genotype(
     adaptive_config: Optional[Any] = None,
     orientation: str = "auto",
     horizontal_threshold: int = 8,
+    max_subplot_height: float = 20.0,
 ) -> plt.Figure:
     """Create boxplots for traits grouped by genotype.
 
@@ -129,6 +130,11 @@ def create_trait_boxplots_by_genotype(
             "auto" switches to horizontal when n_genotypes > horizontal_threshold.
         horizontal_threshold: Number of genotypes above which auto orientation
             switches to horizontal (default: 8).
+        max_subplot_height: Maximum height in inches per subplot in horizontal
+            orientation (default: 20.0), mirroring the vertical orientation's
+            existing per-subplot width cap. Prevents datasets with very high
+            genotype counts from producing a figure large enough to fail to
+            allocate (Issue #110).
 
     Returns:
         Matplotlib figure object. Callers are responsible for calling
@@ -187,10 +193,13 @@ def create_trait_boxplots_by_genotype(
         figsize = (fig_width, fig_height)
     elif actual_orientation == "horizontal":
         # For horizontal orientation, adjust figsize for readability
-        # Height needs to scale with number of genotypes
+        # Height needs to scale with number of genotypes, capped to prevent
+        # extremely large figures (Issue #110)
         n_rows = (n_traits + n_cols - 1) // n_cols
         height_per_genotype = 0.3  # inches per genotype
-        min_subplot_height = max(4, n_genotypes * height_per_genotype)
+        min_subplot_height = min(
+            max_subplot_height, max(4, n_genotypes * height_per_genotype)
+        )
         figsize = (figsize[0], min_subplot_height * n_rows)
     elif actual_orientation == "vertical" and n_genotypes > 0:
         # For vertical orientation, scale subplot width with genotype count
@@ -341,6 +350,7 @@ def create_trait_boxplots_by_genotype_batched(
     subplot_size: Tuple[float, float] = (4.0, 4.0),
     orientation: str = "auto",
     horizontal_threshold: int = 8,
+    max_subplot_height: float = 20.0,
 ) -> List[plt.Figure]:
     """Create batched boxplot plots by genotype (multiple figures for many traits).
 
@@ -358,6 +368,11 @@ def create_trait_boxplots_by_genotype_batched(
             "auto" switches to horizontal when n_genotypes > horizontal_threshold.
         horizontal_threshold: Number of genotypes above which auto orientation
             switches to horizontal (default: 8).
+        max_subplot_height: Maximum height in inches per subplot in horizontal
+            orientation (default: 20.0), mirroring the vertical orientation's
+            existing per-subplot width cap. Passed through to the underlying
+            single-figure renderer, which is where the cap actually takes
+            effect (Issue #110).
 
     Returns:
         List of matplotlib figure objects (one per batch)
@@ -396,9 +411,13 @@ def create_trait_boxplots_by_genotype_batched(
         else:
             # Adaptive sizing: calculate based on actual layout
             if actual_orientation == "horizontal":
-                # For horizontal, height scales with genotype count
+                # For horizontal, height scales with genotype count, capped to
+                # prevent extremely large figures (Issue #110)
                 height_per_genotype = 0.3
-                subplot_height = max(subplot_size[1], n_genotypes * height_per_genotype)
+                subplot_height = min(
+                    max_subplot_height,
+                    max(subplot_size[1], n_genotypes * height_per_genotype),
+                )
                 batch_figsize = (actual_cols * subplot_size[0], n_rows * subplot_height)
             else:
                 # For vertical, scale subplot width with genotype count
@@ -421,6 +440,7 @@ def create_trait_boxplots_by_genotype_batched(
             figsize=batch_figsize,
             orientation=orientation,
             horizontal_threshold=horizontal_threshold,
+            max_subplot_height=max_subplot_height,
         )
         fig.suptitle(
             f"Trait Boxplots by Genotype (Traits {batch_start + 1}-{batch_end} of {n_traits})",

--- a/tests/test_step_exploratory_analysis.py
+++ b/tests/test_step_exploratory_analysis.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from unittest.mock import patch
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -428,3 +429,137 @@ class TestExploratoryAnalysisMetadataPropagation:
         )
 
         assert result.metadata["samples"] == 30
+
+
+@pytest.fixture
+def large_genotype_data():
+    """Synthetic DataFrame shaped like the real #110 failure: many genotypes,
+    many traits (480 genotypes x 300 traits) -- no proprietary data needed."""
+    np.random.seed(42)
+    n_genotypes = 480
+    n_traits = 300
+    samples_per_geno = 2
+    n_samples = n_genotypes * samples_per_geno
+    data = {
+        "Barcode": [f"plant{i}" for i in range(n_samples)],
+        "geno": [f"Genotype_{i:03d}" for i in range(n_genotypes)] * samples_per_geno,
+        "rep": [1, 2] * n_genotypes,
+    }
+    for i in range(n_traits):
+        data[f"trait{i + 1}"] = np.random.randn(n_samples) * 10 + 50
+    return pd.DataFrame(data)
+
+
+@pytest.fixture
+def large_config():
+    """Config with low DPI for fast test rendering of many figures."""
+    return QCPipelineConfig(
+        pipeline_name="test_qc_large",
+        columns=ColumnConfig(barcode="Barcode", genotype="geno", replicate="rep"),
+        data=DataConfig(csv_path="dummy.csv"),
+        cleanup=CleanupConfig(
+            max_zeros_per_trait=0.5,
+            max_nans_per_trait=0.3,
+            min_samples_per_trait=2,
+        ),
+        visualization=VisualizationConfig(dpi=100),
+    )
+
+
+@pytest.fixture
+def large_prev_result(large_genotype_data):
+    """Mock previous step result for the large-genotype fixture."""
+    trait_cols = [f"trait{i + 1}" for i in range(300)]
+    return StepResult(
+        data=large_genotype_data,
+        metadata={
+            "valid_trait_names": trait_cols,
+            "trait_names": trait_cols,
+            "samples": len(large_genotype_data),
+            "cleanup_log": {},
+        },
+        files_generated=[],
+    )
+
+
+class TestExploratoryAnalysisMemoryBounds:
+    """Tests for bounded peak concurrent figures during execute() (Issue #110).
+
+    ExploratoryAnalysisStep.execute() previously accumulated every generated
+    figure into an all_figures dict before saving/closing any of them --- peak
+    memory was the sum of every figure held at once, not the size of the
+    single largest one. These tests instrument figure lifecycle to assert the
+    peak number of simultaneously-open figures stays a small constant, not on
+    the order of the total figures the step generates.
+    """
+
+    def test_peak_concurrent_figures_bounded_during_execute(
+        self, large_genotype_data, large_config, large_prev_result, tmp_path
+    ):
+        """Peak concurrently-open figures during execute() stays small.
+
+        Sampled at both figure-creation time (plt.subplots) and close time
+        (plt.close) -- sampling only at close time could miss a figure that's
+        created but never explicitly closed, silently undercounting a leak.
+        """
+        peak_fignums = 0
+        original_close = plt.close
+        original_subplots = plt.subplots
+
+        def tracking_close(*args, **kwargs):
+            nonlocal peak_fignums
+            peak_fignums = max(peak_fignums, len(plt.get_fignums()))
+            return original_close(*args, **kwargs)
+
+        def tracking_subplots(*args, **kwargs):
+            result = original_subplots(*args, **kwargs)
+            nonlocal peak_fignums
+            peak_fignums = max(peak_fignums, len(plt.get_fignums()))
+            return result
+
+        step = ExploratoryAnalysisStep()
+
+        with (
+            patch("matplotlib.pyplot.close", side_effect=tracking_close),
+            patch("matplotlib.pyplot.subplots", side_effect=tracking_subplots),
+        ):
+            step.execute(
+                data=large_genotype_data,
+                config=large_config,
+                run_dir=tmp_path,
+                prev_result=large_prev_result,
+            )
+
+        # Measured peak with the incremental save/close implementation is 4
+        # (one in-flight figure at a time, plus a small margin for overlap
+        # between a figure's creation and its close). Before this fix, the
+        # same fixture measured a peak of 45 (all_figures accumulation).
+        assert peak_fignums <= 5, (
+            f"Peak concurrently-open figures was {peak_fignums}, expected a "
+            "small constant (measured 4 with incremental save/close), not "
+            "scaling with the total number of figures generated (45 before "
+            "this fix)"
+        )
+
+    def test_execute_completes_and_produces_figures_for_large_dataset(
+        self, large_genotype_data, large_config, large_prev_result, tmp_path
+    ):
+        """execute() completes without raising and produces expected output files."""
+        step = ExploratoryAnalysisStep()
+
+        result = step.execute(
+            data=large_genotype_data,
+            config=large_config,
+            run_dir=tmp_path,
+            prev_result=large_prev_result,
+        )
+
+        figures_dir = tmp_path / "figures"
+        png_files = list(figures_dir.glob("*.png"))
+        assert len(png_files) > 0
+
+        # Batched boxplots should be paginated (many genotype pages) for 480 genotypes
+        box_batches = [
+            name for name in result.metadata["figure_names"] if "boxplots_batch" in name
+        ]
+        assert len(box_batches) > 1

--- a/tests/test_step_exploratory_analysis.py
+++ b/tests/test_step_exploratory_analysis.py
@@ -504,8 +504,12 @@ class TestExploratoryAnalysisMemoryBounds:
         Sampled at both figure-creation time (plt.subplots) and close time
         (plt.close) -- sampling only at close time could miss a figure that's
         created but never explicitly closed, silently undercounting a leak.
+        Compares against a baseline captured just before `execute()` runs
+        (not an absolute count), so a figure left open by an unrelated test
+        earlier in the same pytest session can't inflate this test's result.
         """
-        peak_fignums = 0
+        baseline_fignums = len(plt.get_fignums())
+        peak_fignums = baseline_fignums
         original_close = plt.close
         original_subplots = plt.subplots
 
@@ -533,15 +537,17 @@ class TestExploratoryAnalysisMemoryBounds:
                 prev_result=large_prev_result,
             )
 
-        # Measured peak with the incremental save/close implementation is 4
-        # (one in-flight figure at a time, plus a small margin for overlap
-        # between a figure's creation and its close). Before this fix, the
-        # same fixture measured a peak of 45 (all_figures accumulation).
-        assert peak_fignums <= 5, (
-            f"Peak concurrently-open figures was {peak_fignums}, expected a "
-            "small constant (measured 4 with incremental save/close), not "
-            "scaling with the total number of figures generated (45 before "
-            "this fix)"
+        # Measured peak delta above baseline with the incremental save/close
+        # implementation is 4 (one in-flight figure at a time, plus a small
+        # margin for overlap between a figure's creation and its close).
+        # Before this fix, the same fixture measured a peak delta of 45
+        # (all_figures accumulation).
+        peak_delta = peak_fignums - baseline_fignums
+        assert peak_delta <= 5, (
+            f"Peak concurrently-open figures above baseline was {peak_delta}, "
+            "expected a small constant (measured 4 with incremental "
+            "save/close), not scaling with the total number of figures "
+            "generated (45 before this fix)"
         )
 
     def test_execute_completes_and_produces_figures_for_large_dataset(

--- a/tests/test_step_exploratory_analysis.py
+++ b/tests/test_step_exploratory_analysis.py
@@ -433,8 +433,11 @@ class TestExploratoryAnalysisMetadataPropagation:
 
 @pytest.fixture
 def large_genotype_data():
-    """Synthetic DataFrame shaped like the real #110 failure: many genotypes,
-    many traits (480 genotypes x 300 traits) -- no proprietary data needed."""
+    """Synthetic DataFrame shaped like the real #110 failure.
+
+    Many genotypes, many traits (480 genotypes x 300 traits) -- no
+    proprietary data needed.
+    """
     np.random.seed(42)
     n_genotypes = 480
     n_traits = 300

--- a/tests/test_step_exploratory_analysis.py
+++ b/tests/test_step_exploratory_analysis.py
@@ -433,14 +433,26 @@ class TestExploratoryAnalysisMetadataPropagation:
 
 @pytest.fixture
 def large_genotype_data():
-    """Synthetic DataFrame shaped like the real #110 failure.
+    """Synthetic DataFrame shaped like the real #110 failure, scaled for CI.
 
-    Many genotypes, many traits (480 genotypes x 300 traits) -- no
-    proprietary data needed.
+    100 genotypes (above the ~66/page pagination threshold, giving a
+    partial second page) x 40 traits (above the 16-trait batching
+    threshold, giving multiple trait batches) -- no proprietary data
+    needed. The real #110 repro and the MO Soybean production failure
+    both involved far more genotypes/traits (94-489, 300-1061 columns);
+    this fixture was originally pinned at 480x300 to mirror that scale
+    directly, but that size measurably pushed CI's 30-minute `tests` job
+    timeout on Ubuntu/Windows once combined with the rest of the suite
+    (confirmed via an actual CI run, not assumed) even though it ran fine
+    standalone locally. 100x40 still exercises every code path this
+    fixture exists to cover -- the generator refactor, genotype
+    pagination with a partial last page, and a peak-figure-count large
+    enough to clearly distinguish a bounded vs. unbounded implementation
+    -- at a small fraction of the runtime.
     """
     np.random.seed(42)
-    n_genotypes = 480
-    n_traits = 300
+    n_genotypes = 100
+    n_traits = 40
     samples_per_geno = 2
     n_samples = n_genotypes * samples_per_geno
     data = {
@@ -472,7 +484,7 @@ def large_config():
 @pytest.fixture
 def large_prev_result(large_genotype_data):
     """Mock previous step result for the large-genotype fixture."""
-    trait_cols = [f"trait{i + 1}" for i in range(300)]
+    trait_cols = [f"trait{i + 1}" for i in range(40)]
     return StepResult(
         data=large_genotype_data,
         metadata={
@@ -538,16 +550,21 @@ class TestExploratoryAnalysisMemoryBounds:
             )
 
         # Measured peak delta above baseline with the incremental save/close
-        # implementation is 4 (one in-flight figure at a time, plus a small
-        # margin for overlap between a figure's creation and its close).
-        # Before this fix, the same fixture measured a peak delta of 45
-        # (all_figures accumulation).
+        # implementation is 4 on this fixture (one in-flight figure at a
+        # time, plus a small margin for overlap between a figure's creation
+        # and its close) out of 13 total figures generated -- an unbounded
+        # (all_figures-accumulation) implementation would peak near the total
+        # figure count instead. Originally validated against a
+        # production-scale 480-genotype x 300-trait fixture (peak delta 4 out
+        # of ~150 figures there too), but that size measurably pushed CI's
+        # 30-minute test-job timeout once combined with the rest of the
+        # suite; this smaller fixture still exercises the same code paths.
         peak_delta = peak_fignums - baseline_fignums
         assert peak_delta <= 5, (
             f"Peak concurrently-open figures above baseline was {peak_delta}, "
             "expected a small constant (measured 4 with incremental "
             "save/close), not scaling with the total number of figures "
-            "generated (45 before this fix)"
+            "generated"
         )
 
     def test_execute_completes_and_produces_figures_for_large_dataset(
@@ -567,7 +584,7 @@ class TestExploratoryAnalysisMemoryBounds:
         png_files = list(figures_dir.glob("*.png"))
         assert len(png_files) > 0
 
-        # Batched boxplots should be paginated (many genotype pages) for 480 genotypes
+        # Batched boxplots should be paginated (multiple genotype pages)
         box_batches = [
             name for name in result.metadata["figure_names"] if "boxplots_batch" in name
         ]

--- a/tests/test_step_generate_static_figures.py
+++ b/tests/test_step_generate_static_figures.py
@@ -1315,7 +1315,8 @@ class TestMemoryManagement:
         config.static_viz.create_trait_correlations = False
         config.static_viz.create_genotype_comparisons = False
 
-        peak_fignums = 0
+        baseline_fignums = len(plt.get_fignums())
+        peak_fignums = baseline_fignums
         original_close = plt.close
         original_subplots = plt.subplots
 
@@ -1343,10 +1344,14 @@ class TestMemoryManagement:
                 prev_result=prev_result,
             )
 
-        assert peak_fignums <= 5, (
-            f"Peak concurrently-open figures was {peak_fignums}, expected a "
-            "small constant, not scaling with the total number of figures "
-            "generated"
+        # Compared against a baseline captured just before execute() runs
+        # (not an absolute count), so a figure left open by an unrelated test
+        # earlier in the same pytest session can't inflate this result.
+        peak_delta = peak_fignums - baseline_fignums
+        assert peak_delta <= 5, (
+            f"Peak concurrently-open figures above baseline was {peak_delta}, "
+            "expected a small constant, not scaling with the total number of "
+            "figures generated"
         )
 
 

--- a/tests/test_step_generate_static_figures.py
+++ b/tests/test_step_generate_static_figures.py
@@ -1267,6 +1267,88 @@ class TestMemoryManagement:
             f"Expected <= {max_allowed_accumulation}"
         )
 
+    def test_peak_concurrent_figures_bounded_during_static_figures(
+        self,
+        static_viz_config_enabled,
+        tmp_path,
+    ):
+        """Peak concurrently-open figures stays small even with many genotypes.
+
+        GenerateStaticFiguresStep previously materialized the full batch list
+        (via create_trait_histograms_batched/create_trait_boxplots_by_genotype_batched)
+        before closing any figure -- peak memory was the sum of every batch
+        figure, not the size of the single largest one (Issue #110). Sampled
+        at both figure-creation time (plt.subplots) and close time (plt.close)
+        -- sampling only at close time could miss a figure that's created but
+        never explicitly closed, silently undercounting a leak.
+        """
+        import matplotlib.pyplot as plt
+        import numpy as np
+        import pandas as pd
+        from unittest.mock import patch
+
+        setup_matplotlib_backend()
+
+        np.random.seed(42)
+        n_genotypes = 480
+        n_traits = 30
+        samples_per_geno = 2
+        n_samples = n_genotypes * samples_per_geno
+        data = {
+            "Barcode": [f"sample_{i}" for i in range(n_samples)],
+            "Genotype": [f"geno_{i:03d}" for i in range(n_genotypes)]
+            * samples_per_geno,
+        }
+        for i in range(n_traits):
+            data[f"trait_{i}"] = np.random.randn(n_samples)
+        df = pd.DataFrame(data)
+        trait_cols = [f"trait_{i}" for i in range(n_traits)]
+
+        prev_result = StepResult(
+            data=df,
+            metadata={"valid_trait_names": trait_cols},
+        )
+
+        config = static_viz_config_enabled
+        config.static_viz.create_pca_plots = False
+        config.static_viz.create_heritability_plots = False
+        config.static_viz.create_trait_correlations = False
+        config.static_viz.create_genotype_comparisons = False
+
+        peak_fignums = 0
+        original_close = plt.close
+        original_subplots = plt.subplots
+
+        def tracking_close(*args, **kwargs):
+            nonlocal peak_fignums
+            peak_fignums = max(peak_fignums, len(plt.get_fignums()))
+            return original_close(*args, **kwargs)
+
+        def tracking_subplots(*args, **kwargs):
+            result = original_subplots(*args, **kwargs)
+            nonlocal peak_fignums
+            peak_fignums = max(peak_fignums, len(plt.get_fignums()))
+            return result
+
+        step = GenerateStaticFiguresStep()
+
+        with (
+            patch("matplotlib.pyplot.close", side_effect=tracking_close),
+            patch("matplotlib.pyplot.subplots", side_effect=tracking_subplots),
+        ):
+            step.execute(
+                data=df,
+                config=config,
+                run_dir=tmp_path,
+                prev_result=prev_result,
+            )
+
+        assert peak_fignums <= 5, (
+            f"Peak concurrently-open figures was {peak_fignums}, expected a "
+            "small constant, not scaling with the total number of figures "
+            "generated"
+        )
+
 
 class TestBatchFileReduction:
     """Tests for Section 8: Batch File Reduction."""
@@ -2658,10 +2740,10 @@ class TestAdaptiveBatchSize:
 
         with (
             patch(
-                "sleap_roots_analyze.pipeline.steps.generate_static_figures.create_trait_histograms_batched"
+                "sleap_roots_analyze.pipeline.steps.generate_static_figures._generate_trait_histogram_batches"
             ) as mock_histograms,
             patch(
-                "sleap_roots_analyze.pipeline.steps.generate_static_figures.create_trait_boxplots_by_genotype_batched"
+                "sleap_roots_analyze.pipeline.steps.generate_static_figures._generate_trait_boxplot_batches"
             ) as mock_boxplots,
         ):
             mock_histograms.return_value = [plt.figure() for _ in range(5)]
@@ -2733,10 +2815,10 @@ class TestAdaptiveBatchSize:
 
         with (
             patch(
-                "sleap_roots_analyze.pipeline.steps.generate_static_figures.create_trait_histograms_batched"
+                "sleap_roots_analyze.pipeline.steps.generate_static_figures._generate_trait_histogram_batches"
             ) as mock_histograms,
             patch(
-                "sleap_roots_analyze.pipeline.steps.generate_static_figures.create_trait_boxplots_by_genotype_batched"
+                "sleap_roots_analyze.pipeline.steps.generate_static_figures._generate_trait_boxplot_batches"
             ) as mock_boxplots,
         ):
             # Calculate expected batch counts based on adaptive sizing

--- a/tests/test_step_generate_static_figures.py
+++ b/tests/test_step_generate_static_figures.py
@@ -1281,6 +1281,14 @@ class TestMemoryManagement:
         at both figure-creation time (plt.subplots) and close time (plt.close)
         -- sampling only at close time could miss a figure that's created but
         never explicitly closed, silently undercounting a leak.
+
+        Fixture size (100 genotypes x 12 traits): originally validated
+        against 480 genotypes x 30 traits, matching the real #110/production
+        failure scale directly, but that size measurably pushed CI's
+        30-minute `tests` job timeout on Ubuntu/Windows once combined with
+        the rest of the suite (confirmed via an actual CI run). 100x12 still
+        triggers genotype pagination (2 pages) and multiple trait batches at
+        this step's default batch sizes, at a small fraction of the runtime.
         """
         import matplotlib.pyplot as plt
         import numpy as np
@@ -1290,8 +1298,8 @@ class TestMemoryManagement:
         setup_matplotlib_backend()
 
         np.random.seed(42)
-        n_genotypes = 480
-        n_traits = 30
+        n_genotypes = 100
+        n_traits = 12
         samples_per_geno = 2
         n_samples = n_genotypes * samples_per_geno
         data = {

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -4404,3 +4404,186 @@ class TestBoxplotHorizontalHeightCap:
             df_with_genotype, []
         )
         assert figures_empty_traits == []
+
+
+class TestBoxplotGenotypePagination:
+    """Tests for genotype pagination in create_trait_boxplots_by_genotype_batched (Issue #110).
+
+    The height cap alone keeps high-genotype-count figures memory-safe but not
+    readable -- hundreds of genotype labels squeezed into a fixed-height axis
+    are illegible regardless of cap value. Pagination splits genotypes across
+    multiple figures so every genotype stays at the same readable per-genotype
+    spacing used below the cap.
+
+    These tests use a small, fixed trait count (not the full 300-trait
+    fixture used elsewhere) since pagination is a property of the genotype
+    axis, not the trait axis -- this keeps a single trait batch unambiguous
+    and keeps tests fast.
+    """
+
+    def _make_df(self, n_genotypes, n_traits=1, samples_per_geno=2):
+        """Helper to create a DataFrame with the given number of genotypes."""
+        np.random.seed(42)
+        n_samples = n_genotypes * samples_per_geno
+        data = {f"trait_{i}": np.random.randn(n_samples) for i in range(n_traits)}
+        data["geno"] = [
+            f"Genotype_{i:03d}" for i in range(n_genotypes)
+        ] * samples_per_geno
+        return pd.DataFrame(data)
+
+    def test_pagination_splits_genotypes_at_default_capacity(self):
+        """480 genotypes at the default ~66/page capacity produce multiple pages."""
+        df = self._make_df(480)
+        trait_cols = ["trait_0"]
+
+        figures = create_trait_boxplots_by_genotype_batched(df, trait_cols)
+
+        # 1 trait -> 1 trait batch; multiple genotype pages expected
+        assert len(figures) > 1, (
+            f"Expected multiple genotype pages for 480 genotypes, got {len(figures)}"
+        )
+        for fig in figures:
+            plt.close(fig)
+
+    def test_pagination_covers_every_genotype_exactly_once(self):
+        """Every genotype appears in exactly one page's figure, none dropped/duplicated."""
+        n_genotypes = 480
+        df = self._make_df(n_genotypes)
+        trait_cols = ["trait_0"]
+
+        figures = create_trait_boxplots_by_genotype_batched(df, trait_cols)
+
+        seen = []
+        for fig in figures:
+            ax = [a for a in fig.get_axes() if a.get_visible()][0]
+            labels = [
+                label.get_text() for label in ax.get_yticklabels() if label.get_text()
+            ]
+            seen.extend(labels)
+
+        expected = {f"Genotype_{i:03d}" for i in range(n_genotypes)}
+        assert set(seen) == expected, "Union of all pages should cover every genotype"
+        assert len(seen) == len(
+            set(seen)
+        ), "No genotype should appear on more than one page"
+
+        for fig in figures:
+            plt.close(fig)
+
+    def test_pagination_noop_at_or_below_capacity(self):
+        """Genotype count at or below page capacity produces exactly one page."""
+        df = self._make_df(50)  # well below the ~66 default horizontal capacity
+        trait_cols = ["trait_0"]
+
+        figures = create_trait_boxplots_by_genotype_batched(df, trait_cols)
+
+        assert len(figures) == 1
+        plt.close(figures[0])
+
+    def test_pagination_page_height_uses_readable_spacing_not_cap(self):
+        """A paginated figure's height reflects the pre-cap readable formula."""
+        df = self._make_df(480)
+        trait_cols = ["trait_0"]
+
+        figures = create_trait_boxplots_by_genotype_batched(df, trait_cols)
+
+        for fig in figures:
+            _, height = fig.get_size_inches()
+            # Every page should be well under the 20.0 cap, since pages are
+            # sized to avoid needing it
+            assert height < 20.0
+
+        for fig in figures:
+            plt.close(fig)
+
+    def test_pagination_custom_max_genotypes_per_page_respected(self):
+        """An explicit max_genotypes_per_page overrides the auto-derived default."""
+        df = self._make_df(100)
+        trait_cols = ["trait_0"]
+
+        figures_default = create_trait_boxplots_by_genotype_batched(df, trait_cols)
+        figures_custom = create_trait_boxplots_by_genotype_batched(
+            df, trait_cols, max_genotypes_per_page=20
+        )
+
+        assert len(figures_custom) > len(figures_default)
+
+        for fig in figures_default:
+            plt.close(fig)
+        for fig in figures_custom:
+            plt.close(fig)
+
+    def test_pagination_suptitle_includes_genotype_range(self):
+        """A multi-page batch's figures each include the genotype range in suptitle."""
+        df = self._make_df(480)
+        trait_cols = ["trait_0"]
+
+        figures = create_trait_boxplots_by_genotype_batched(df, trait_cols)
+
+        assert len(figures) > 1
+        for fig in figures:
+            assert "Genotypes" in fig.get_suptitle()
+
+        for fig in figures:
+            plt.close(fig)
+
+    def test_pagination_last_page_orientation_matches_other_pages(self):
+        """A small last page uses the same orientation as the rest of the batch."""
+        # 469 = 66*7 + 7, leaving a 7-genotype final page (below horizontal_threshold=8)
+        n_genotypes = 469
+        df = self._make_df(n_genotypes)
+        trait_cols = ["trait_0"]
+
+        figures = create_trait_boxplots_by_genotype_batched(df, trait_cols)
+        assert len(figures) > 1
+
+        last_fig = figures[-1]
+        ax = [a for a in last_fig.get_axes() if a.get_visible()][0]
+        y_labels = [l.get_text() for l in ax.get_yticklabels() if l.get_text()]
+        assert any("Genotype_" in l for l in y_labels), (
+            "Last (small) page should still use horizontal orientation, matching "
+            "the rest of the batch, not independently re-resolve to vertical "
+            "based on its own small genotype count"
+        )
+
+        for fig in figures:
+            plt.close(fig)
+
+    def test_pagination_missing_genotype_column_is_noop(self):
+        """Pagination does not raise when genotype_col is entirely absent."""
+        df = pd.DataFrame({"trait_0": np.random.randn(20)})
+
+        figures = create_trait_boxplots_by_genotype_batched(df, ["trait_0"])
+
+        assert len(figures) == 1
+        plt.close(figures[0])
+
+    def test_pagination_with_nan_genotype_values(self):
+        """Pagination does not raise when some genotype values are NaN."""
+        df = self._make_df(480)
+        # Introduce NaNs into a handful of rows' genotype values
+        df.loc[df.index[:5], "geno"] = np.nan
+
+        figures = create_trait_boxplots_by_genotype_batched(df, ["trait_0"])
+
+        assert len(figures) >= 1
+        for fig in figures:
+            plt.close(fig)
+
+    def test_pagination_with_partial_trait_batch_and_partial_genotype_page(self):
+        """Partial trait batch and partial genotype page combine correctly."""
+        n_traits = 20
+        n_genotypes = 100
+        df = self._make_df(n_genotypes, n_traits=n_traits)
+        trait_cols = [f"trait_{i}" for i in range(n_traits)]
+
+        figures = create_trait_boxplots_by_genotype_batched(
+            df, trait_cols, batch_size=16, max_genotypes_per_page=66
+        )
+
+        # 20 traits / batch_size=16 -> 2 trait batches (16 full + 4 partial)
+        # 100 genotypes / page_cap=66 -> 2 genotype pages (66 full + 34 partial)
+        assert len(figures) == 4
+
+        for fig in figures:
+            plt.close(fig)

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -4617,8 +4617,8 @@ class TestBoxplotGenotypePagination:
         """Pagination sorts safely when genotype values have mixed types.
 
         `sorted()` on a raw mixed str/int/float sequence raises TypeError in
-        Python; pagination sorts by `str(value)` internally to avoid this
-        while leaving the underlying genotype values unchanged.
+        Python; pagination falls back to sorting by `str(value)` only in
+        that case, leaving the underlying genotype values unchanged.
         """
         n_genotypes = 90
         df = self._make_df(n_genotypes)
@@ -4632,6 +4632,35 @@ class TestBoxplotGenotypePagination:
         assert len(figures) >= 1
         for fig in figures:
             plt.close(fig)
+
+    def test_pagination_preserves_natural_order_for_numeric_genotypes(self):
+        """A purely-numeric genotype column keeps numeric order, not lexicographic.
+
+        The mixed-dtype fallback (str-keyed sort) must only engage for a
+        genuinely mixed-dtype column; a homogeneous numeric column should
+        still sort as 1, 2, ..., 12 rather than "1", "10", "11", "12", "2", ...
+        """
+        n_samples_per_geno = 2
+        genotype_ids = list(range(1, 13))  # 12 genotypes: horizontal orientation
+        data = {
+            "trait_0": np.random.randn(len(genotype_ids) * n_samples_per_geno),
+            "geno": [g for g in genotype_ids for _ in range(n_samples_per_geno)],
+        }
+        df = pd.DataFrame(data)
+
+        fig = create_trait_boxplots_by_genotype(df, ["trait_0"], orientation="auto")
+
+        ax = [a for a in fig.get_axes() if a.get_visible()][0]
+        y_labels = [
+            label.get_text() for label in ax.get_yticklabels() if label.get_text()
+        ]
+        expected_order = [str(g) for g in sorted(genotype_ids)]
+        assert y_labels == expected_order, (
+            f"Expected natural numeric order {expected_order}, got {y_labels} "
+            "(lexicographic string order would incorrectly place 10/11/12 "
+            "before 2)"
+        )
+        plt.close(fig)
 
 
 class TestBatchedFigureGenerators:

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -4439,9 +4439,9 @@ class TestBoxplotGenotypePagination:
         figures = create_trait_boxplots_by_genotype_batched(df, trait_cols)
 
         # 1 trait -> 1 trait batch; multiple genotype pages expected
-        assert len(figures) > 1, (
-            f"Expected multiple genotype pages for 480 genotypes, got {len(figures)}"
-        )
+        assert (
+            len(figures) > 1
+        ), f"Expected multiple genotype pages for 480 genotypes, got {len(figures)}"
         for fig in figures:
             plt.close(fig)
 
@@ -4590,10 +4590,9 @@ class TestBoxplotGenotypePagination:
 
 
 class TestBatchedFigureGenerators:
-    """Tests for the private generator functions backing the batched figure
-    creators (Issue #110).
+    """Tests for the private generator functions backing the batched figure creators.
 
-    ExploratoryAnalysisStep and GenerateStaticFiguresStep need to save+close
+    Issue #110: ExploratoryAnalysisStep and GenerateStaticFiguresStep need to save+close
     each batch figure as soon as it's produced, not after the full batch list
     already exists in memory. This requires the batched creators to be
     expressible as generators (yield one figure at a time), with the existing
@@ -4621,9 +4620,7 @@ class TestBatchedFigureGenerators:
         df = self._make_df(10, n_traits=20)
         trait_cols = [f"trait_{i}" for i in range(20)]
 
-        wrapper_figures = create_trait_histograms_batched(
-            df, trait_cols, batch_size=8
-        )
+        wrapper_figures = create_trait_histograms_batched(df, trait_cols, batch_size=8)
         generator_figures = list(
             _generate_trait_histogram_batches(df, trait_cols, batch_size=8)
         )
@@ -4640,8 +4637,10 @@ class TestBatchedFigureGenerators:
             plt.close(fig)
 
     def test_boxplot_generator_matches_list_wrapper_output(self):
-        """list(_generate_trait_boxplot_batches(...)) matches the public wrapper,
-        including paginated output."""
+        """list(_generate_trait_boxplot_batches(...)) matches the public wrapper.
+
+        Including paginated output.
+        """
         from sleap_roots_analyze.visualization import _generate_trait_boxplot_batches
 
         df = self._make_df(480, n_traits=20)
@@ -4677,9 +4676,9 @@ class TestBatchedFigureGenerators:
         gen = _generate_trait_boxplot_batches(df, trait_cols)
 
         # Constructing the generator must not create any figures yet
-        assert set(plt.get_fignums()) == fignums_before, (
-            "Generator construction should not eagerly create figures"
-        )
+        assert (
+            set(plt.get_fignums()) == fignums_before
+        ), "Generator construction should not eagerly create figures"
 
         first_fig = next(gen)
         fignums_after_one = set(plt.get_fignums())

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -4287,3 +4287,120 @@ class TestBoxplotLabelOverlapFixes:
 
         plt.close(fig_vert)
         plt.close(fig_horiz)
+
+
+class TestBoxplotHorizontalHeightCap:
+    """Tests for capping horizontal-orientation boxplot subplot height (Issue #110).
+
+    The vertical branch already caps adaptive subplot width at 20 inches. The
+    horizontal branch had no equivalent cap, so datasets with hundreds of
+    genotypes could produce a figure large enough to fail to allocate. These
+    tests cover both the single-figure function (where the cap must actually
+    take effect) and the batched wrapper.
+    """
+
+    def _make_df(self, n_genotypes, n_traits=1, samples_per_geno=2):
+        """Helper to create a DataFrame with the given number of genotypes."""
+        np.random.seed(42)
+        n_samples = n_genotypes * samples_per_geno
+        data = {f"trait_{i}": np.random.randn(n_samples) for i in range(n_traits)}
+        data["geno"] = [
+            f"Genotype_{i:03d}" for i in range(n_genotypes)
+        ] * samples_per_geno
+        return pd.DataFrame(data)
+
+    def test_direct_call_horizontal_height_capped(self):
+        """480 genotypes via the single-figure function stays at or under the cap.
+
+        This specifically catches the bug where a cap applied only to the
+        batched wrapper's local variable is silently discarded by this inner
+        function's own uncapped recomputation.
+        """
+        df = self._make_df(480)
+        trait_cols = ["trait_0"]
+
+        fig = create_trait_boxplots_by_genotype(df, trait_cols, orientation="auto")
+
+        _, height = fig.get_size_inches()
+        assert height <= 20.0, (
+            f"Horizontal subplot height {height} exceeds the 20.0 inch cap for "
+            "480 genotypes"
+        )
+        plt.close(fig)
+
+    def test_batched_call_horizontal_height_capped(self):
+        """480 genotypes via the batched wrapper stays at or under the cap."""
+        df = self._make_df(480)
+        trait_cols = ["trait_0"]
+
+        figures = create_trait_boxplots_by_genotype_batched(df, trait_cols)
+
+        assert len(figures) >= 1
+        for fig in figures:
+            _, height = fig.get_size_inches()
+            assert height <= 20.0, (
+                f"Batched horizontal subplot height {height} exceeds the 20.0 "
+                "inch cap for 480 genotypes"
+            )
+        for fig in figures:
+            plt.close(fig)
+
+    def test_horizontal_height_cap_boundary(self):
+        """At exactly the cap boundary, height matches the cap (no off-by-one)."""
+        # 60 genotypes * 0.3 in/genotype = 18.0 in, chosen to equal a custom cap
+        df = self._make_df(60)
+        trait_cols = ["trait_0"]
+
+        fig = create_trait_boxplots_by_genotype(
+            df, trait_cols, orientation="auto", max_subplot_height=18.0
+        )
+
+        _, height = fig.get_size_inches()
+        assert height == pytest.approx(18.0, abs=1e-6)
+        plt.close(fig)
+
+    def test_horizontal_height_unchanged_below_cap(self):
+        """Below the cap, height matches the existing uncapped formula exactly."""
+        df = self._make_df(30)  # 30 * 0.3 = 9.0, well under the 20.0 default cap
+        trait_cols = ["trait_0"]
+
+        fig = create_trait_boxplots_by_genotype(df, trait_cols, orientation="auto")
+
+        _, height = fig.get_size_inches()
+        assert height == pytest.approx(max(4.0, 30 * 0.3), abs=1e-6)
+        plt.close(fig)
+
+    def test_custom_max_subplot_height_respected(self):
+        """A non-default max_subplot_height, not the 20.0 default, bounds output."""
+        df = self._make_df(480)
+        trait_cols = ["trait_0"]
+
+        fig = create_trait_boxplots_by_genotype(
+            df, trait_cols, orientation="auto", max_subplot_height=10.0
+        )
+
+        _, height = fig.get_size_inches()
+        assert height == pytest.approx(10.0, abs=1e-6)
+        plt.close(fig)
+
+    def test_horizontal_boxplots_zero_genotypes_and_zero_traits(self):
+        """Empty-input edge cases (0 genotypes, empty trait_cols) do not raise."""
+        df_no_genotype_col = pd.DataFrame({"trait_0": np.random.randn(10)})
+
+        fig = create_trait_boxplots_by_genotype(df_no_genotype_col, ["trait_0"])
+        plt.close(fig)
+
+        figures = create_trait_boxplots_by_genotype_batched(
+            df_no_genotype_col, ["trait_0"]
+        )
+        for f in figures:
+            plt.close(f)
+
+        df_with_genotype = self._make_df(5)
+        fig_empty_traits = create_trait_boxplots_by_genotype(df_with_genotype, [])
+        plt.close(fig_empty_traits)
+
+        figures_empty_traits = create_trait_boxplots_by_genotype_batched(
+            df_with_genotype, []
+        )
+        assert figures_empty_traits == []

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -4588,6 +4588,51 @@ class TestBoxplotGenotypePagination:
         for fig in figures:
             plt.close(fig)
 
+    def test_pagination_exact_boundary_one_page(self):
+        """Genotype count exactly equal to max_genotypes_per_page stays one page."""
+        df = self._make_df(20)
+        trait_cols = ["trait_0"]
+
+        figures = create_trait_boxplots_by_genotype_batched(
+            df, trait_cols, max_genotypes_per_page=20
+        )
+
+        assert len(figures) == 1
+        plt.close(figures[0])
+
+    def test_pagination_one_over_boundary_two_pages(self):
+        """One genotype over max_genotypes_per_page produces a second, 1-genotype page."""
+        df = self._make_df(21)
+        trait_cols = ["trait_0"]
+
+        figures = create_trait_boxplots_by_genotype_batched(
+            df, trait_cols, max_genotypes_per_page=20
+        )
+
+        assert len(figures) == 2
+        for fig in figures:
+            plt.close(fig)
+
+    def test_pagination_with_mixed_dtype_genotype_values(self):
+        """Pagination sorts safely when genotype values have mixed types.
+
+        `sorted()` on a raw mixed str/int/float sequence raises TypeError in
+        Python; pagination sorts by `str(value)` internally to avoid this
+        while leaving the underlying genotype values unchanged.
+        """
+        n_genotypes = 90
+        df = self._make_df(n_genotypes)
+        # Replace a few genotype labels with non-string values, as could occur
+        # with a numeric-looking or partially-unsanitized genotype column.
+        df.loc[df["geno"] == "Genotype_000", "geno"] = 12345
+        df.loc[df["geno"] == "Genotype_001", "geno"] = 67.5
+
+        figures = create_trait_boxplots_by_genotype_batched(df, ["trait_0"])
+
+        assert len(figures) >= 1
+        for fig in figures:
+            plt.close(fig)
+
 
 class TestBatchedFigureGenerators:
     """Tests for the private generator functions backing the batched figure creators.

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -4587,3 +4587,108 @@ class TestBoxplotGenotypePagination:
 
         for fig in figures:
             plt.close(fig)
+
+
+class TestBatchedFigureGenerators:
+    """Tests for the private generator functions backing the batched figure
+    creators (Issue #110).
+
+    ExploratoryAnalysisStep and GenerateStaticFiguresStep need to save+close
+    each batch figure as soon as it's produced, not after the full batch list
+    already exists in memory. This requires the batched creators to be
+    expressible as generators (yield one figure at a time), with the existing
+    public functions becoming thin list(...) wrappers so external callers are
+    unaffected.
+    """
+
+    def _make_df(self, n_genotypes, n_traits=1, samples_per_geno=2):
+        """Helper to create a DataFrame with the given number of genotypes."""
+        np.random.seed(42)
+        n_samples = n_genotypes * samples_per_geno
+        data = {f"trait_{i}": np.random.randn(n_samples) for i in range(n_traits)}
+        data["geno"] = [
+            f"Genotype_{i:03d}" for i in range(n_genotypes)
+        ] * samples_per_geno
+        return pd.DataFrame(data)
+
+    def test_histogram_generator_matches_list_wrapper_output(self):
+        """list(_generate_trait_histogram_batches(...)) matches the public wrapper."""
+        from sleap_roots_analyze.visualization import (
+            _generate_trait_histogram_batches,
+            create_trait_histograms_batched,
+        )
+
+        df = self._make_df(10, n_traits=20)
+        trait_cols = [f"trait_{i}" for i in range(20)]
+
+        wrapper_figures = create_trait_histograms_batched(
+            df, trait_cols, batch_size=8
+        )
+        generator_figures = list(
+            _generate_trait_histogram_batches(df, trait_cols, batch_size=8)
+        )
+
+        assert len(generator_figures) == len(wrapper_figures)
+        for gen_fig, wrap_fig in zip(generator_figures, wrapper_figures):
+            assert gen_fig.get_size_inches() == pytest.approx(
+                wrap_fig.get_size_inches()
+            )
+
+        for fig in wrapper_figures:
+            plt.close(fig)
+        for fig in generator_figures:
+            plt.close(fig)
+
+    def test_boxplot_generator_matches_list_wrapper_output(self):
+        """list(_generate_trait_boxplot_batches(...)) matches the public wrapper,
+        including paginated output."""
+        from sleap_roots_analyze.visualization import _generate_trait_boxplot_batches
+
+        df = self._make_df(480, n_traits=20)
+        trait_cols = [f"trait_{i}" for i in range(20)]
+
+        wrapper_figures = create_trait_boxplots_by_genotype_batched(
+            df, trait_cols, batch_size=8
+        )
+        generator_figures = list(
+            _generate_trait_boxplot_batches(df, trait_cols, batch_size=8)
+        )
+
+        assert len(generator_figures) == len(wrapper_figures)
+        assert len(generator_figures) > 1  # sanity: pagination should have engaged
+        for gen_fig, wrap_fig in zip(generator_figures, wrapper_figures):
+            assert gen_fig.get_size_inches() == pytest.approx(
+                wrap_fig.get_size_inches()
+            )
+
+        for fig in wrapper_figures:
+            plt.close(fig)
+        for fig in generator_figures:
+            plt.close(fig)
+
+    def test_boxplot_generator_yields_lazily(self):
+        """A figure is not created until the generator is actually advanced."""
+        from sleap_roots_analyze.visualization import _generate_trait_boxplot_batches
+
+        df = self._make_df(480, n_traits=1)
+        trait_cols = ["trait_0"]
+
+        fignums_before = set(plt.get_fignums())
+        gen = _generate_trait_boxplot_batches(df, trait_cols)
+
+        # Constructing the generator must not create any figures yet
+        assert set(plt.get_fignums()) == fignums_before, (
+            "Generator construction should not eagerly create figures"
+        )
+
+        first_fig = next(gen)
+        fignums_after_one = set(plt.get_fignums())
+        assert len(fignums_after_one - fignums_before) == 1, (
+            "Advancing the generator once should create exactly one new figure, "
+            "not the entire batch"
+        )
+        plt.close(first_fig)
+
+        remaining = list(gen)
+        for fig in remaining:
+            plt.close(fig)


### PR DESCRIPTION
## Summary

Fixes #110: `ExploratoryAnalysisStep.execute()` and `GenerateStaticFiguresStep` accumulated every
step-4/static figure in memory before saving/closing any of them, so peak memory scaled with the
total number of figures generated rather than the size of the single largest one. On large
experiments (many genotypes + traits) this caused an OOM (`bad allocation`) — confirmed against a
real production run (MO Soybean 2021 Diversity Screen, 2,675 samples × ~1,061 columns × 489
genotypes), a strictly harder case than the issue's own 94-genotype repro.

- **Incremental save+close** (the P0 root cause): both pipeline steps now save and close each
  figure immediately after it's produced, via new private generator functions
  (`_generate_trait_histogram_batches`, `_generate_trait_boxplot_batches`) that the existing public
  `create_trait_histograms_batched()`/`create_trait_boxplots_by_genotype_batched()` now wrap. Peak
  concurrently-open figures measured on a 480-genotype/300-trait fixture: **45 → 4**
  (`ExploratoryAnalysisStep`) and **40 → ≤5** (`GenerateStaticFiguresStep`).
- **Height cap**: `create_trait_boxplots_by_genotype()`'s horizontal-orientation branch had no cap
  on subplot height, unlike the vertical branch's existing 20" width cap — at 489 genotypes that's
  ~147" per subplot, large enough to fail to allocate on its own. Added a `max_subplot_height=20.0`
  cap at the point where it actually takes effect (a naive version of this fix, caught during
  review, would have been silently discarded by an inner recomputation).
- **Genotype pagination**: the height cap alone is memory-safe but not readable at extreme genotype
  counts (20" ÷ 489 genotypes ≈ 0.04"/genotype). `create_trait_boxplots_by_genotype_batched()` now
  splits genotypes into consecutive, alphabetically-sorted pages (auto-sized from the cap: ~66
  genotypes/page horizontal, ~40 vertical) so every genotype stays at the same readable spacing used
  today below the cap, just spread across more figures. Every genotype still appears — nothing is
  sampled out.

## Process

Followed this repo's OpenSpec + TDD workflow end to end:
`openspec/changes/fix-110-oom-exploratory-analysis/` (proposal → design → tasks → spec delta,
`openspec validate --strict` passing). The proposal went through **two rounds** of 5-subagent
adversarial review before implementation — round 1 caught a critical bug in the initial cap design
(it would have been silently discarded before rendering); round 2, after genotype pagination was
added per explicit direction, caught several concrete edge-case gaps (NaN/missing genotype column
handling, an orientation-consistency gap pagination would have reintroduced, an arithmetic error in
a test's worked example). Every task was implemented test-first (red → green), with one disclosed
exception (Task 4) where implementation preceded its test — verified honestly after the fact via a
`git stash`/`git stash pop` round-trip that confirmed genuine red (peak=40) then green.

A **pre-merge 5-subagent review** (code quality, testing, statistical rigor, performance/memory,
behavioral correctness) found no BLOCKING issues but surfaced real IMPORTANT findings that are
included in this PR:
- Hoisted redundant per-page DataFrame filtering out of the trait-batch loop (~19x recomputation →
  once per page).
- Fixed a real, previously-unguarded `sorted()` TypeError risk on mixed-dtype genotype columns —
  found by a new test written *in response to* this review round, in both the new pagination code
  and one pre-existing call site it routes through.
- Wrapped figure save+close in `try/finally` in both pipeline steps, so a `savefig` failure can't
  leak a figure — directly relevant given this PR's whole purpose.
- Made the peak-concurrent-figures tests baseline-relative instead of an absolute threshold, so an
  unrelated test's leaked figure can't inflate the result.

## Test plan

- [x] `openspec validate fix-110-oom-exploratory-analysis --strict` passes
- [x] Full test suite (`uv run pytest`): 2863 passed, 37 skipped, 0 failed
- [x] `ruff check` / `black --check` clean on all touched files
- [x] `mypy` + `mypy-baseline filter` (CI's exact `type-check` command): 0 new errors
- [x] Visual QA: generated boxplot figures for a genotype count that triggers pagination (120
  genotypes, 2 pages) and visually confirmed labels are readable and the suptitle correctly
  identifies the genotype range on each page
- [x] Pre-merge 5-subagent review: no blocking findings; all IMPORTANT findings fixed and re-verified

## Out of scope (deliberately, not accidentally)

- #202 (`feature_selection_strategy` silently ignored in two visualization functions) — different
  bug, same file, already separately investigated.
- `create_correlation_heatmap`'s existing 60" figsize cap, and #110's own P2 suggestion (300→150
  DPI for step-4-only diagnostic plots) — independent memory reductions, left for a follow-up.
- `create_exploratory_summary_plots()`'s single combined-genotype boxplot — bounded by a separate,
  pre-existing, already-safe `AdaptiveSizingConfig.max_height` (16") code path, not paginated by
  this change.
- A smarter-than-alphabetical genotype pagination strategy (sampling/clustering) — this change does
  the simplest thing that preserves completeness and readability; recommend filing a follow-up
  issue for a high-genotype-count display strategy if basic pagination proves insufficient in
  practice (per #110's own P1 note).

Closes #110.
