### PR TITLE
fix(#202): honor feature_selection in PCA biplot and contribution plot

### DIFF
--- a/.mypy-baseline.txt
+++ b/.mypy-baseline.txt
@@ -265,7 +265,6 @@ src/sleap_roots_analyze/visualization.py:0: error: Argument 1 to "len" has incom
 src/sleap_roots_analyze/visualization.py:0: error: Item "None" of "Any | None" has no attribute "head"  [union-attr]
 src/sleap_roots_analyze/visualization.py:0: error: Argument 1 to "len" has incompatible type "Any | None"; expected "Sized"  [arg-type]
 src/sleap_roots_analyze/visualization.py:0: error: Incompatible types in assignment (expression has type "signedinteger[_32Bit | _64Bit]", variable has type "int | None")  [assignment]
-src/sleap_roots_analyze/visualization.py:0: error: Incompatible types in assignment (expression has type "ndarray[tuple[Any, ...], dtype[signedinteger[_32Bit | _64Bit]]]", variable has type "list[Any]")  [assignment]
 src/sleap_roots_analyze/visualization.py:0: error: Module has no attribute "tab20"  [attr-defined]
 src/sleap_roots_analyze/visualization.py:0: error: Argument 3 to "linspace" has incompatible type "int | None"; expected "SupportsIndex"  [arg-type]
 src/sleap_roots_analyze/visualization.py:0: error: Argument 1 to "range" has incompatible type "int | None"; expected "SupportsIndex"  [arg-type]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -113,6 +113,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (PR #193 review).
 
 ### Fixed
+- `create_pca_biplot` now honors `feature_selection="top_variance"` (#202): the
+  `feature_selection`→`method` mapping had `elif` branches for `extreme`/
+  `top_absolute`/`top_contribution`/`vector_length` but none for `top_variance`,
+  so it silently fell into `else: method = "vector_length"` — a materially
+  different selection criterion (eigenvalue-weighted variance contribution vs.
+  unweighted Euclidean norm in the PC plane). An explicit `top_variance` branch
+  now passes `pc_indices=None` (rather than the biplot's 2 displayed PCs) since
+  `select_top_features_from_pca`'s `top_variance` method ranks across all
+  retained PCs and ignores `pc_indices` entirely. Any other `feature_selection`
+  value now raises `ValueError` instead of silently substituting
+  `vector_length`. `create_feature_contribution_plot` **removes** its
+  `feature_selection` parameter (BREAKING): the parameter was never referenced
+  in the function body — every code path always ranked by total variance
+  contribution regardless of what was passed — and wiring it up would have made
+  the chart's own title (which asserts the displayed traits are the top
+  contributors) misdescribe non-contribution-selected content, so the
+  parameter is removed rather than fixed, matching the parameter-free
+  `create_feature_contribution_heatmap` precedent. Its on-the-fly ranking
+  branch now delegates to `select_top_features_from_pca(method="top_variance")`
+  instead of duplicating the formula inline. No in-repo caller nor the
+  verified downstream `bloom` consumer passed `feature_selection` to this
+  function, so removal is backward-compatible in practice.
 - `ExploratoryAnalysisStep.execute()` and `GenerateStaticFiguresStep` no longer accumulate every
   step-4/static figure in memory before saving any of them — an OOM (`bad allocation`) on large
   experiments with many genotypes and traits (#110). Peak concurrently-open figures dropped from

--- a/openspec/changes/fix-pca-feature-selection-wiring/design.md
+++ b/openspec/changes/fix-pca-feature-selection-wiring/design.md
@@ -1,0 +1,105 @@
+## Context
+
+Issue #202 documents two independent bugs where `feature_selection`
+(sourced from `pca.feature_selection_strategy` in config) fails to actually
+control which features get selected/plotted. Both live in
+`visualization.py` and both were introduced as incomplete follow-through on
+earlier work (`create_pca_biplot`'s mapping block was rewritten in PR #37
+after `top_variance` already existed elsewhere; `create_feature_contribution_plot`'s
+parameter was added in the same commit as an unused
+`select_top_features_from_pca` import, per the issue's git archaeology).
+
+## Gotcha: `select_top_features_from_pca`'s `top_variance` method ignores `pc_indices`
+
+`pca.py:105-113`:
+
+```python
+elif method == "top_variance":
+    # Use total variance contribution across all available PCs
+    n_pcs = min(loadings.shape[1], len(eigenvalues))
+    contributions = np.zeros(n_features)
+
+    for i in range(n_pcs):
+        contributions += eigenvalues[i] * loadings[:n_features, i] ** 2
+
+    return np.argsort(contributions)[::-1][:n_features_to_select].tolist()
+```
+
+This loops over `range(n_pcs)` — every retained PC — regardless of whatever
+`pc_indices` argument was passed. Verified empirically: calling this method
+with `pc_indices=[0, 1]` explicit vs. omitted (defaults to `[0, 1]` inside
+the function) produces identical output either way, because the
+`top_variance` branch never reads `pc_indices` at all. The shared docstring
+for `pc_indices` (`pca.py:36`) doesn't call this out explicitly; only the
+`top_variance` bullet's parenthetical "(all PCs)" hints at it.
+
+`create_umap_colored_by_top_traits` already has a correct workaround for
+this (`visualization.py:2776-2783`):
+
+```python
+top_indices = select_top_features_from_pca(
+    ...
+    method=feature_selection,
+    pc_indices=pc_indices if feature_selection != "top_variance" else None,
+)
+```
+
+**Decision**: `create_pca_biplot`'s fix must apply the same workaround —
+when `method == "top_variance"`, pass `pc_indices=None` rather than
+`[pc_x_idx, pc_y_idx]`. Passing the biplot's 2 displayed PC indices would
+silently no-op (the method ignores them anyway) and produce no visible
+error, but it would misleadingly suggest the biplot's 2-PC scope is
+respected when it isn't. `pc_indices=None` makes the "ranked across all
+retained PCs, not just the 2 shown" behavior explicit at the call site,
+matching what actually happens.
+
+This also means `top_variance` and `top_contribution` are related but
+distinct: `top_variance` is mathematically `top_contribution` summed over
+*all* retained PCs rather than an arbitrary subset — they only coincide
+when a run retains exactly 2 PCs total (verified: with >2 retained PCs they
+select different features). `top_variance` is also not equivalent to
+`vector_length` (eigenvalue-weighted variance contribution vs. unweighted
+Euclidean norm in the PC plane) — confirmed empirically to select different
+feature sets — so the previous silent `vector_length` fallback was a real
+behavior change, not a harmless substitution between equivalent methods.
+
+## Decision: remove, don't wire up, `create_feature_contribution_plot`'s `feature_selection`
+
+Two options were considered for `create_feature_contribution_plot`:
+
+1. **Wire it up**: call `select_top_features_from_pca(method=feature_selection, ...)`
+   to choose `top_traits`, keep displaying true per-PC variance-contribution
+   bars for whichever traits get picked, and make the title dynamic (e.g.
+   `f"Top {n} Features by {feature_selection}: Variance Contribution"`) so
+   it doesn't misdescribe non-contribution-selected content.
+2. **Remove the parameter**: hardcode variance-based selection, delegating
+   to `select_top_features_from_pca(method="top_variance", pc_indices=None, ...)`
+   instead of duplicating the ranking formula inline.
+
+**Chosen: option 2.** The chart's bars always plot true eigenvalue-weighted
+variance contribution regardless of which traits are shown — that's the one
+thing this chart visualizes. Selecting traits by a different criterion
+(e.g. `extreme`, which surfaces traits that dominate a PC's *direction* but
+can contribute little to that PC's *variance* if its eigenvalue is small)
+would make the unconditional title
+(`f"Top {n} Feature Contributions to First {k} PCs"`, asserting displayed
+traits *are* the top contributors) false. There's also direct in-repo
+precedent: `create_feature_contribution_heatmap`
+(`visualization.py:3114-3203`) — same purpose, same era, same author — has
+no `feature_selection` parameter at all; it hardcodes top-by-contribution
+selection. That is this codebase's own prior answer to "should a
+*contribution* chart accept a non-contribution selection criterion?", and
+the answer is no. Option 1 is not ruled out permanently — if a genuine
+cross-check use case appears (e.g. in a notebook or an explicit feature
+request), it can be revisited then — but nothing today asks for it, and
+inventing it now would be scope creep beyond #202.
+
+## Non-goals
+
+- Not touching `create_feature_contribution_heatmap` — it already has the
+  correct, parameter-free behavior this change moves
+  `create_feature_contribution_plot` toward; no fix needed there.
+- Not changing `PCAAnalysisStep`'s hardcoded `pc_indices=[0, 1]` (#203) — a
+  different call site with its own scoping question.
+- Not redesigning `n_top_features` semantics (#206) or fixing the UMAP
+  top-traits PC1-negative-only bug (#207).

--- a/openspec/changes/fix-pca-feature-selection-wiring/proposal.md
+++ b/openspec/changes/fix-pca-feature-selection-wiring/proposal.md
@@ -1,0 +1,129 @@
+## Why
+
+Fixes #202. `pca.feature_selection_strategy` defaults to `"top_variance"` in
+`PCAConfig` (`pipeline/config/components.py:421`) and is the explicit value
+in several active viz configs (e.g.
+`configs/active/viz/mo_soybean_2021_grouped.yaml`, and the
+`configs/examples/viz_*.yaml` templates). It is threaded from
+`generate_static_figures.py` into two visualization functions, and in both
+cases the configured value is silently not what actually selects the
+plotted features:
+
+- `create_pca_biplot` (`visualization.py:2260-2269`) maps `feature_selection`
+  to a `method` variable via `if`/`elif` branches for `extreme`,
+  `top_absolute`, `top_contribution`, and `vector_length` — there is no
+  `top_variance` branch, so `"top_variance"` falls into
+  `else: method = "vector_length"` with no warning. `top_variance` and
+  `vector_length` are empirically different selection criteria
+  (eigenvalue-weighted variance contribution vs. unweighted Euclidean norm),
+  so this silently changes which features are plotted for every config that
+  sets `feature_selection_strategy: "top_variance"`.
+- `create_feature_contribution_plot` (`visualization.py:1967-2013` onward)
+  accepts a `feature_selection` parameter that is never referenced anywhere
+  in the function body — every code path ranks by precomputed/derived
+  variance contribution regardless of what is passed.
+
+See `design.md` for the full investigation, including a verified gotcha in
+`select_top_features_from_pca`'s `"top_variance"` method that the fix for
+`create_pca_biplot` must account for, and the reasoning for removing
+(rather than wiring up) `create_feature_contribution_plot`'s parameter.
+
+## What Changes
+
+- `create_pca_biplot` (`visualization.py`): add an explicit `top_variance`
+  branch to the `feature_selection` → `method` mapping that passes
+  `method="top_variance"` straight through (mirroring
+  `create_umap_colored_by_top_traits`, `visualization.py:2751-2783`), and
+  change the `else` branch to raise `ValueError` for genuinely unrecognized
+  `feature_selection` values instead of silently substituting
+  `vector_length`. When `method == "top_variance"`, do **not** pass
+  `pc_indices=[pc_x_idx, pc_y_idx]` to `select_top_features_from_pca` — pass
+  `pc_indices=None` instead, matching the existing `top_variance` workaround
+  in `create_umap_colored_by_top_traits` (see `design.md` for why). Update
+  the function's docstring to list `top_variance` as valid and document the
+  `ValueError`.
+- **BREAKING**: `create_feature_contribution_plot` (`visualization.py`):
+  **remove** the `feature_selection` parameter entirely (do not wire it
+  up). The chart's
+  own title (`f"Top {n} Feature Contributions to First {k} PCs"`) asserts
+  the displayed traits *are* the top contributors to variance — a
+  non-contribution selection method would make the title misdescribe its
+  own content, and the sibling `create_feature_contribution_heatmap`
+  (`visualization.py:3114-3203`, same purpose, no such parameter) is
+  existing precedent for the same reasoning. The on-the-fly
+  (backward-compatibility) branch, which currently duplicates the
+  `top_variance` ranking formula inline, is refactored to delegate to
+  `select_top_features_from_pca(method="top_variance", pc_indices=None,
+  ...)` instead of reimplementing it. The two pre-calculated-contributions
+  branches are unchanged (they already select by taking the head of a
+  DataFrame the caller pre-sorted by contribution elsewhere; they never
+  referenced `feature_selection` and don't need the delegation).
+- `pipeline/steps/generate_static_figures.py` (~L407-414): remove the
+  `feature_selection=config.pca.feature_selection_strategy` argument from
+  the `create_feature_contribution_plot(...)` call site, since the
+  parameter no longer exists. The `create_pca_biplot` call site
+  (~L342-351) and the `create_umap_colored_by_top_traits` call site
+  (~L534-541) are unchanged — they already pass
+  `feature_selection=config.pca.feature_selection_strategy` and now behave
+  correctly for `"top_variance"` once the `create_pca_biplot` fix lands.
+- Add regression tests: `create_pca_biplot(feature_selection="top_variance")`
+  selects the same feature indices as calling
+  `select_top_features_from_pca(method="top_variance", pc_indices=None,
+  ...)` directly for the displayed PCs, and `create_pca_biplot` raises
+  `ValueError` for an unrecognized `feature_selection` string. Update/add a
+  test confirming `create_feature_contribution_plot`'s signature no longer
+  accepts `feature_selection` and that the `generate_static_figures.py`
+  call site compiles without it.
+- Regenerate/review the golden viz-config runs that set
+  `feature_selection_strategy: "top_variance"`
+  (`configs/active/viz/mo_soybean_2021_grouped.yaml` and the
+  `configs/examples/viz_{comprehensive,minimal,publication,standard}.yaml`
+  templates) since their `pca_biplot` output will change once the fix
+  lands — bars/arrows previously ranked by `vector_length` will be ranked
+  by `top_variance` instead. Explicitly out of scope for regeneration: the
+  flat `configs/active/viz_standard.yaml` /
+  `configs/active/viz_turface_19genotypes.yaml` files and the top-level
+  `configs/viz_*.yaml` duplicates also match `feature_selection_strategy:
+  "top_variance"` by grep, but are pre-reorg orphans superseded by the
+  `configs/active/viz/` subfolder split (confirmed via `git log`: last
+  touched by `cc7ede1`, well before `configs/active/viz/` was introduced,
+  and not referenced by any `configs/active/run_manifest*.yaml`) — not
+  live golden configs, so they are not regenerated or reviewed here.
+
+## Impact
+
+- Affected specs: `visualization-pipeline` — modify the "Pass parameters to
+  PCA biplot" scenario area to cover `feature_selection` correctness, and
+  the "PCA Feature Contribution Bar Chart" requirement to reflect the
+  parameter's removal.
+- Affected code:
+  - `src/sleap_roots_analyze/visualization.py`
+    (`create_pca_biplot`, `create_feature_contribution_plot`)
+  - `src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py`
+    (~L407-414)
+  - `tests/test_visualization.py`
+  - `docs/CHANGELOG.md` `[Unreleased]` — new `### Fixed` entry
+- Breaking change (narrow, intentional): `create_feature_contribution_plot`
+  no longer accepts a `feature_selection` keyword argument. Verified against
+  the real downstream consumer
+  (`Salk-Harnessing-Plants-Initiative/bloom`, `staging` branch, genuine
+  `sleap-roots-analyze>=0.1.0a5` pip dependency): its `pca_analysis` MCP
+  tool calls both `create_pca_biplot` and `create_feature_contribution_plot`
+  but never passes `feature_selection` to either, so both changes are
+  backward-compatible with that consumer.
+- Visual/output change: any pipeline run configured with
+  `pca.feature_selection_strategy: "top_variance"` will now produce a
+  different `pca_biplot.png` (features selected by `top_variance` instead
+  of the previously-silent `vector_length` fallback). No change for
+  `"extreme"`, `"top_absolute"`, or `"top_contribution"` configs — those
+  branches were already handled correctly. `pca_feature_contributions.png`
+  output is unchanged for all configs (it always ranked by variance
+  contribution; only the never-effective parameter is removed).
+- Explicitly out of scope (tracked separately, not touched here):
+  - #203 — `PCAAnalysisStep` hardcodes `pc_indices=[0,1]` in
+    `pipeline/steps/pca_analysis.py`; a different call site needing its own
+    maintainer decision on PC scoping.
+  - #206 — redesigning `n_top_features`'s semantics.
+  - #207 — UMAP top-traits PC1-negative-only bug.
+  - #64 and #68 — already closed as superseded by this issue and #206
+    respectively.

--- a/openspec/changes/fix-pca-feature-selection-wiring/specs/visualization-pipeline/spec.md
+++ b/openspec/changes/fix-pca-feature-selection-wiring/specs/visualization-pipeline/spec.md
@@ -1,0 +1,112 @@
+## MODIFIED Requirements
+
+### Requirement: Pipeline Step Parameter Passing
+The `GenerateStaticFiguresStep` SHALL pass genotype highlighting parameters from configuration to underlying plotting functions.
+
+The `PCAAnalysisStep` SHALL use the post-filtering feature names returned by
+`perform_pca_analysis()` (via `pca_results["feature_names"]`) instead of the original
+`trait_cols` list when constructing the loadings DataFrame index, computing
+`n_features_total` for feature selection, and mapping feature indices to names.
+
+The `PCAAnalysisStep` SHALL log the names and count of any traits excluded due to zero
+variance, and SHALL emit a Python `UserWarning` when more than 50% of input traits are
+excluded.
+
+The `PCAAnalysisStep` SHALL store `excluded_zero_variance_traits` (list of excluded trait
+names) and `n_traits_after_filtering` (int) in its output metadata for downstream
+inspection and reproducibility.
+
+`create_pca_biplot` SHALL honor every `feature_selection` value it documents
+— `"vector_length"`, `"extreme"`, `"top_absolute"`, `"top_contribution"`,
+and `"top_variance"` — by selecting features using the matching method in
+`select_top_features_from_pca()`, and SHALL raise `ValueError` for any other
+value instead of silently substituting `"vector_length"`. When
+`feature_selection == "top_variance"`, `create_pca_biplot` SHALL call
+`select_top_features_from_pca(..., pc_indices=None)` rather than passing the
+biplot's two displayed PC indices, since `select_top_features_from_pca`'s
+`"top_variance"` method ranks across all retained PCs regardless of
+`pc_indices` and passing the 2-index list would misleadingly imply the
+biplot's PC scope is honored.
+
+#### Scenario: Pass parameters to PCA biplot
+- **WHEN** generating PCA biplot via `create_pca_biplot`
+- **THEN** the step SHALL pass `config.static_viz.genotypes_to_color` to the function
+- **AND** the step SHALL pass `config.static_viz.highlight_genotypes` to the function
+
+#### Scenario: Pass parameters to PC boxplots
+- **WHEN** generating PC boxplots via `create_pc_genotype_boxplots`
+- **THEN** the step SHALL pass `config.static_viz.highlight_genotypes` to the function
+- **AND** the highlighted genotypes SHALL appear in gold with bold labels
+
+#### Scenario: PCA step handles zero-variance traits gracefully
+- **WHEN** the input DataFrame contains traits with zero variance (constant values)
+- **THEN** the PCA step SHALL complete successfully using only non-zero-variance traits
+- **AND** the loadings CSV index SHALL match the actual features used in PCA
+- **AND** `excluded_zero_variance_traits` SHALL list the excluded trait names in metadata
+- **AND** `n_traits_after_filtering` SHALL reflect the count of traits actually used
+
+#### Scenario: PCA step warns on high zero-variance fraction
+- **WHEN** more than 50% of input traits have zero variance
+- **THEN** the PCA step SHALL emit a `UserWarning` indicating potential data quality issues
+- **AND** the step SHALL still complete successfully with the remaining traits
+
+#### Scenario: PCA step with no zero-variance traits
+- **WHEN** all input traits have non-zero variance
+- **THEN** the PCA step SHALL behave identically to current behavior
+- **AND** `excluded_zero_variance_traits` SHALL be an empty list
+- **AND** no warning SHALL be emitted
+
+#### Scenario: create_pca_biplot honors top_variance feature selection
+- **WHEN** `create_pca_biplot` is called with `feature_selection="top_variance"`
+- **THEN** the features selected for display SHALL be the same set returned
+  by `select_top_features_from_pca(method="top_variance", pc_indices=None,
+  ...)` called directly with the same loadings, eigenvalues, feature count,
+  and `top_n_features`
+- **AND** the selection SHALL NOT silently fall back to the
+  `"vector_length"` method
+
+#### Scenario: create_pca_biplot rejects an unrecognized feature_selection value
+- **WHEN** `create_pca_biplot` is called with a `feature_selection` value
+  that is not one of `"vector_length"`, `"extreme"`, `"top_absolute"`,
+  `"top_contribution"`, or `"top_variance"`
+- **THEN** the function SHALL raise `ValueError`
+- **AND** it SHALL NOT silently substitute `"vector_length"`
+
+#### Scenario: create_pca_biplot continues to honor pre-existing feature_selection methods
+- **WHEN** `create_pca_biplot` is called with `feature_selection` set to
+  `"vector_length"`, `"extreme"`, `"top_absolute"`, or `"top_contribution"`
+- **THEN** the features selected for display SHALL match a direct
+  `select_top_features_from_pca(method=<same value>, pc_indices=[pc_x_idx,
+  pc_y_idx])` call with the same loadings, eigenvalues, feature count, and
+  `top_n_features`
+
+### Requirement: PCA Feature Contribution Bar Chart
+The visualization pipeline SHALL generate a stacked horizontal bar chart showing per-PC variance contributions for top features, matching notebook output.
+
+`create_feature_contribution_plot` SHALL always select the displayed
+features by total variance contribution (equivalent to
+`select_top_features_from_pca(method="top_variance", pc_indices=None,
+...)`) and SHALL NOT accept a `feature_selection` parameter, since the
+chart's bars always plot true per-PC variance contribution regardless of
+which traits are shown — a non-contribution selection criterion would make
+the chart's title (which asserts the displayed traits are the top
+contributors) misdescribe its own content. `GenerateStaticFiguresStep`
+SHALL NOT pass a `feature_selection` argument to this function.
+
+#### Scenario: Standard PCA analysis complete
+- **WHEN** PCA results are available and `static_viz.create_pca_plots` is enabled
+- **THEN** the pipeline SHALL generate a feature contribution bar chart via `create_feature_contribution_plot()`
+- **AND** the chart SHALL be saved alongside other PCA figures (scree plot, biplot, heatmaps)
+
+#### Scenario: create_feature_contribution_plot has no feature_selection parameter
+- **WHEN** `create_feature_contribution_plot`'s signature is inspected
+- **THEN** it SHALL NOT include a `feature_selection` parameter
+- **AND** calling it with a `feature_selection` keyword argument SHALL raise `TypeError`
+
+#### Scenario: On-the-fly contribution ranking matches select_top_features_from_pca
+- **WHEN** `create_feature_contribution_plot` computes contributions on the
+  fly (no pre-calculated `trait_contrib_df`/`feature_contributions` in
+  `pca_results`)
+- **THEN** the top features selected SHALL be identical, in the same order,
+  to calling `select_top_features_from_pca(method="top_variance",
+  pc_indices=None, ...)` directly with the same loadings and eigenvalues

--- a/openspec/changes/fix-pca-feature-selection-wiring/tasks.md
+++ b/openspec/changes/fix-pca-feature-selection-wiring/tasks.md
@@ -1,0 +1,183 @@
+# Tasks: fix-pca-feature-selection-wiring
+
+**Suggested commit grouping**: Task 1 → one `test(#202):` commit (red).
+Tasks 2 and 3 → **one combined `fix(#202):` commit** (green) — do not split
+across two commits: Task 2 alone (fixing only `create_pca_biplot`) would
+leave Task 1.4/1.6's `create_feature_contribution_plot` assertions still
+red if committed on its own, and Task 3.1 (removing the parameter) must
+land in the exact same commit as Task 3.3 (removing the matching call-site
+kwarg in `generate_static_figures.py`) — splitting those two would leave a
+`TypeError` at runtime on any pipeline invocation between commits, which is
+a broken build, not just a failing test. Task 4 → verification, no code
+change. Task 5 → `docs(#202):` + config regeneration, landed last so
+code-correctness review and image/data-diff review stay separable. Never
+leave a red/broken state as the branch tip while the PR is open for
+review. Single PR for both bugs (same issue, same root cause pattern,
+shared consistency test spanning both functions).
+
+## Task 1: Write failing tests (TDD Red Phase)
+
+- [x] 1.1 In `tests/test_visualization.py`, add
+      `test_create_pca_biplot_top_variance_feature_selection` (near the
+      existing `test_create_pca_biplot`, ~line 2243): call `create_pca_biplot`
+      with `feature_selection="top_variance"` and `top_n_features=5` (pin
+      this value explicitly — matches the existing test's convention) using
+      the existing `pca_viz_results`/`pca_viz_dataframe` fixtures and
+      `trait_names = [f"trait_{i}" for i in range(10)]`. Separately call
+      `select_top_features_from_pca(loadings=pca_viz_results["loadings"],
+      eigenvalues=pca_viz_results["eigenvalues"], n_features_total=10,
+      n_features_to_select=5, method="top_variance", pc_indices=None)`
+      directly, map the returned indices to trait names, and assert that
+      set matches the set of `text.get_text()` values collected from
+      `fig.axes[0].texts` (the per-feature loading labels `create_pca_biplot`
+      draws at `visualization.py:2658-2666`). Note: `adjustText`'s normal
+      label-repositioning path only mutates existing `Text` objects and
+      does not add to `ax.texts`; if this proves flaky in practice (its
+      rare `ax.annotate("", ...)` fallback would add an empty-string entry),
+      filter `texts` to non-empty `get_text()` values before comparing.
+- [x] 1.2 In the same file, add
+      `test_create_pca_biplot_unrecognized_feature_selection_raises`:
+      call `create_pca_biplot(..., feature_selection="not_a_real_method")`
+      and assert it raises `ValueError`.
+- [x] 1.3 Add `test_create_pca_biplot_feature_selection_methods_dispatch_correctly`,
+      parametrized over `["vector_length", "extreme", "top_absolute",
+      "top_contribution"]` (the four pre-existing, currently-untested
+      mapping branches — grepping `test_visualization.py` for
+      `feature_selection` today returns no matches, so none of these
+      branches has direct coverage; Task 2.4's "no regressions" claim is
+      otherwise unverifiable). For each method, assert `create_pca_biplot`'s
+      selected/plotted features (via `fig.axes[0].texts`, same technique as
+      1.1) match a direct `select_top_features_from_pca(method=...,
+      pc_indices=[pc_x_idx, pc_y_idx])` call with the same inputs.
+- [x] 1.4 Update `test_create_feature_contribution_plot_consistency`
+      (~line 2182) — no functional change needed to the test itself since
+      it doesn't pass `feature_selection`, but confirm it still exercises
+      both the pre-calculated and on-the-fly branches after Task 3's
+      refactor (it's the regression guard that the two branches keep
+      agreeing).
+- [x] 1.5 Add `test_create_feature_contribution_plot_no_feature_selection_param`:
+      assert calling `inspect.signature(create_feature_contribution_plot).parameters`
+      no longer contains `"feature_selection"`, and that calling the
+      function with a stray `feature_selection=...` kwarg raises
+      `TypeError`.
+- [x] 1.6 In `tests/test_step_generate_static_figures.py`, find the existing
+      test(s) mocking `create_feature_contribution_plot` (currently a plain
+      `Mock(return_value=Mock())` around line 1544, which silently accepts
+      any stray kwarg and would NOT catch a regression if Task 3.3 were
+      skipped or reverted). Change the mock to `Mock(spec=create_feature_contribution_plot)`
+      (or assert on `mock_contrib.call_args.kwargs` directly) and assert
+      `"feature_selection"` is not among the kwargs passed by
+      `GenerateStaticFiguresStep`.
+- [x] 1.7 Run `uv run pytest tests/test_visualization.py -k "pca_biplot or feature_contribution"`
+      and the `test_step_generate_static_figures.py` test from 1.6, confirm
+      1.1, 1.2, and 1.5 FAIL on current code (1.1 fails because
+      `top_variance` silently maps to `vector_length`'s different feature
+      set; 1.2 fails because the unrecognized string currently falls
+      through to `vector_length` with no error; 1.5 fails because the
+      parameter still exists), 1.3 PASSES (regression guard — the four
+      existing methods already dispatch correctly today), and 1.6 PASSES
+      (regression guard — the current call site already doesn't pass
+      `feature_selection` incorrectly today, this just tightens the
+      assertion so a future regression would be caught).
+
+## Task 2: Fix `create_pca_biplot`
+
+- [x] 2.1 In `visualization.py`, add an explicit `elif feature_selection ==
+      "top_variance": method = "top_variance"` branch to the mapping block
+      (~L2260-2269), and change the trailing `else` to
+      `raise ValueError(f"Unrecognized feature_selection: {feature_selection!r}")`.
+- [x] 2.2 Change the `select_top_features_from_pca(...)` call (~L2272-2279)
+      to pass `pc_indices=[pc_x_idx, pc_y_idx] if method != "top_variance" else None`
+      — see `design.md` for why `top_variance` must not receive the 2-PC
+      scope (the method ignores `pc_indices` entirely, so passing the
+      2-index list would silently no-op rather than error, misleadingly
+      suggesting the biplot's PC scope is respected).
+- [x] 2.3 Update the function's docstring (`feature_selection` Args entry,
+      ~L2203-2207) to list `top_variance` as a valid value and add a
+      `Raises: ValueError` entry for unrecognized values.
+
+## Task 3: Fix `create_feature_contribution_plot` and its call site
+
+- [x] 3.1 In `visualization.py`, remove the `feature_selection` parameter
+      from `create_feature_contribution_plot`'s signature and docstring
+      (~L1967-1993).
+- [x] 3.2 Refactor the on-the-fly (backward-compatibility) branch
+      (~L2085-2122, the `else` branch that currently duplicates the
+      `top_variance` ranking formula) to call
+      `select_top_features_from_pca(loadings=..., eigenvalues=...,
+      n_features_total=len(trait_names), n_features_to_select=top_n,
+      method="top_variance", pc_indices=None)` and use the returned indices
+      to build `top_traits`/`contributions`/`total_contributions`, instead
+      of the manual `np.argsort` duplicate. The two pre-calculated
+      (`trait_contrib_df`-based) branches are unchanged — they never
+      referenced `feature_selection` and already select via
+      `.head()` on data pre-sorted elsewhere.
+- [x] 3.3 In `pipeline/steps/generate_static_figures.py` (~L407-414), remove
+      the `feature_selection=config.pca.feature_selection_strategy,`
+      argument from the `create_feature_contribution_plot(...)` call. This
+      MUST land in the same commit as 3.1 (see commit-grouping note above).
+- [x] 3.4 Grep the repo for any other caller of
+      `create_feature_contribution_plot(...feature_selection=...)` besides
+      the one fixed in 3.3, to confirm no other call site breaks.
+
+## Task 4: Verify no regressions
+
+- [x] 4.1 Run all Task 1 tests, confirm 1.1, 1.2, 1.3, and 1.5 now PASS
+      (green), and 1.6/1.4 continue to PASS.
+- [x] 4.2 Run the full test suite (`uv run pytest --cov --cov-branch`),
+      confirm no regressions beyond the tests intentionally changed in
+      Tasks 1-3.
+- [x] 4.3 Run `uv run ruff check src/sleap_roots_analyze tests` and
+      `uv run black --check src/sleap_roots_analyze tests`; fix any issues.
+- [x] 4.4 Run `uv run mypy src/sleap_roots_analyze | uv run mypy-baseline
+      filter --baseline-path .mypy-baseline.txt`, confirm no new errors
+      against the frozen baseline.
+- [x] 4.5 Run `openspec validate fix-pca-feature-selection-wiring --strict`,
+      resolve any issues.
+
+## Task 5: Docs and golden config review
+
+- [x] 5.1 Add a `### Fixed` entry to `docs/CHANGELOG.md` `[Unreleased]`
+      describing both bugs. The entry MUST explicitly state that
+      `create_feature_contribution_plot` **removes** the `feature_selection`
+      parameter (not just "changes" it), and note that no in-repo caller
+      nor the verified downstream consumer (`bloom`) passed it, so this is
+      backward-compatible in practice despite being a signature change.
+- [x] 5.2 Regenerate (or otherwise review) the static-figure outputs for
+      the golden viz configs that set `feature_selection_strategy:
+      "top_variance"`: `configs/active/viz/mo_soybean_2021_grouped.yaml`
+      and `configs/examples/viz_{comprehensive,minimal,publication,standard}.yaml`.
+      Confirm `pca_biplot.png` now shows `top_variance`-selected features
+      instead of the previously-silent `vector_length` fallback, and that
+      `pca_feature_contributions.png` output is unchanged for these
+      configs. Explicitly out of scope (do not regenerate): the flat
+      `configs/active/viz_standard.yaml` and
+      `configs/active/viz_turface_19genotypes.yaml` files, and the
+      top-level `configs/viz_*.yaml` duplicates — these are pre-reorg
+      orphans superseded by the `configs/active/viz/` subfolder (confirmed
+      via `git log`: last touched by `cc7ede1`, before the `active/viz/`
+      split, and not referenced by any `configs/active/run_manifest*.yaml`),
+      not live golden configs.
+
+      **Actual outcome**: the real target
+      (`configs/active/viz/mo_soybean_2021_grouped.yaml`) points to a genuine
+      dataset on a network share via `run-all`, and the four
+      `configs/examples/viz_*.yaml` templates all have `csv_path: ???`
+      placeholders and cannot be run directly. Given a full local pipeline
+      run's cost/duration, the user opted for a synthetic before/after
+      comparison instead of a real `run-all` invocation: a scratch script
+      loaded the real `tests/data/Turface_all_traits_2024.csv` dataset (real
+      trait names, 187 samples, 38 traits), ran PCA with 5 components, and
+      called `create_pca_biplot(..., feature_selection="vector_length")`
+      (simulating the pre-fix silent fallback) vs.
+      `feature_selection="top_variance"` (post-fix, current code) for the
+      same PC pair (PC1/PC4, chosen because it empirically diverges for this
+      dataset — PC1/PC2 coincidentally produced the same top-8 set both
+      ways). Confirmed the two calls select different, non-overlapping-only
+      feature sets (`Depth.mm`, `Width-to-Depth.Ratio`,
+      `Median.Number.of.Roots`, ... vs. `Surface.Area.mm2`,
+      `Average.Root.Orientation.deg`, `Steep.Angle.Frequency`, ...) and
+      rendered both biplots to confirm the arrows/labels differ visually as
+      expected. This demonstrates the fix's real-world effect without
+      requiring the actual golden-config network-drive run, which remains
+      the user's own follow-up to do post-merge if desired.

--- a/src/sleap_roots_analyze/pca.py
+++ b/src/sleap_roots_analyze/pca.py
@@ -34,6 +34,11 @@ def select_top_features_from_pca(
             - "top_variance": Top N by total variance contribution (all PCs)
             - "vector_length": Top N by Euclidean distance in PC plane (traditional biplot)
         pc_indices: Which PCs to consider (0-based). If None, uses first 2 PCs.
+            Ignored entirely by "top_variance", which always ranks across every
+            retained PC (`range(n_pcs)` below) regardless of what is passed here —
+            callers wanting "top_variance" scoped to specific PCs should pass a
+            pre-sliced `loadings`/`eigenvalues` instead (see `create_pca_biplot`
+            and `create_umap_colored_by_top_traits` for this pattern).
 
     Returns:
         List of selected feature indices (order depends on method)

--- a/src/sleap_roots_analyze/pca.py
+++ b/src/sleap_roots_analyze/pca.py
@@ -10,6 +10,13 @@ from sklearn.decomposition import PCA
 from sklearn.preprocessing import StandardScaler
 from typing import Dict, Optional, Tuple, Union, List
 
+# Single source of truth for select_top_features_from_pca's supported `method`
+# values, so callers that pre-validate `method`/`feature_selection` (e.g.
+# create_pca_biplot) can't drift out of sync with this function's own dispatch.
+VALID_SELECTION_METHODS = frozenset(
+    {"extreme", "top_absolute", "top_contribution", "top_variance", "vector_length"}
+)
+
 
 def select_top_features_from_pca(
     loadings: np.ndarray,
@@ -128,7 +135,10 @@ def select_top_features_from_pca(
         return np.argsort(distances)[::-1][:n_features_to_select].tolist()
 
     else:
-        raise ValueError(f"Unknown selection method: {method}")
+        raise ValueError(
+            f"Unknown selection method: {method!r}. Expected one of "
+            f"{sorted(VALID_SELECTION_METHODS)}."
+        )
 
 
 def select_n_components(

--- a/src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py
+++ b/src/sleap_roots_analyze/pipeline/steps/generate_static_figures.py
@@ -410,7 +410,6 @@ class GenerateStaticFiguresStep(BaseStep):
             n_components=None,  # Use variance threshold instead
             variance_threshold=variance_threshold,
             top_n=config.static_viz.feature_contribution_top_n,
-            feature_selection=config.pca.feature_selection_strategy,
         )
         files.extend(
             self._save_figure(

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -2103,7 +2103,7 @@ def create_feature_contribution_plot(
         for i in range(n_components):
             contributions[:, i] = eigenvalues[i] * loadings[:, i] ** 2
 
-        # Sum across selected PCs (for display of unselected features' totals)
+        # Total contribution per feature (all features, before top-N selection below)
         total_contributions_all = np.sum(contributions, axis=1)
 
         # Select top features by total variance contribution, delegating to the
@@ -2274,7 +2274,11 @@ def create_pca_biplot(
     elif feature_selection == "top_variance":
         method = "top_variance"
     else:
-        raise ValueError(f"Unrecognized feature_selection: {feature_selection!r}")
+        raise ValueError(
+            f"Unrecognized feature_selection: {feature_selection!r}. Expected one "
+            "of 'vector_length', 'extreme', 'top_absolute', 'top_contribution', "
+            "'top_variance'."
+        )
 
     # Select features using modular function. "top_variance" ranks by total
     # variance contribution across all retained PCs (not just pc_x/pc_y), so

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -23,7 +23,10 @@ from datetime import datetime
 import logging
 
 # Import PCA functions
-from sleap_roots_analyze.pca import select_top_features_from_pca
+from sleap_roots_analyze.pca import (
+    select_top_features_from_pca,
+    VALID_SELECTION_METHODS,
+)
 
 try:
     import plotly.graph_objects as go
@@ -2262,23 +2265,15 @@ def create_pca_biplot(
     # Get eigenvalues if available for variance-based selection
     eigenvalues = pca_results.get("eigenvalues", np.ones(loadings.shape[1]))
 
-    # Map feature_selection parameter to method
-    if feature_selection == "extreme":
-        method = "extreme"
-    elif feature_selection == "top_absolute":
-        method = "top_absolute"
-    elif feature_selection == "top_contribution":
-        method = "top_contribution"
-    elif feature_selection == "vector_length":
-        method = "vector_length"
-    elif feature_selection == "top_variance":
-        method = "top_variance"
-    else:
+    # feature_selection maps 1:1 onto select_top_features_from_pca's `method`
+    # values; validate against its own VALID_SELECTION_METHODS so this check
+    # can't drift out of sync with what that function actually supports.
+    if feature_selection not in VALID_SELECTION_METHODS:
         raise ValueError(
-            f"Unrecognized feature_selection: {feature_selection!r}. Expected one "
-            "of 'vector_length', 'extreme', 'top_absolute', 'top_contribution', "
-            "'top_variance'."
+            f"Unrecognized feature_selection: {feature_selection!r}. Expected "
+            f"one of {sorted(VALID_SELECTION_METHODS)}."
         )
+    method = feature_selection
 
     # Select features using modular function. "top_variance" ranks by total
     # variance contribution across all retained PCs (not just pc_x/pc_y), so

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -1970,13 +1970,16 @@ def create_feature_contribution_plot(
     n_components: Optional[int] = None,
     variance_threshold: float = 0.95,
     top_n: int = 20,
-    feature_selection: str = "top_variance",  # New parameter
     figsize: Tuple[float, float] = (12, 8),
 ) -> plt.Figure:
     """Create a plot showing feature contributions across selected PCs.
 
     This function can use pre-calculated contributions from run_pca_and_export_artifacts
     (if available in pca_results["trait_contrib_df"]) or calculate them on the fly.
+    Features are always selected by total variance contribution: the chart's own
+    title asserts the displayed traits are the top contributors, so a different
+    selection criterion would misdescribe the chart's own content (matching
+    create_feature_contribution_heatmap's precedent, which has no such parameter).
 
     Args:
         pca_results: Results from perform_pca_analysis or run_pca_and_export_artifacts.
@@ -1985,11 +1988,6 @@ def create_feature_contribution_plot(
         n_components: Number of PCs to consider. If None, use variance threshold.
         variance_threshold: Cumulative variance threshold for PC selection.
         top_n: Number of top contributing features to show.
-        feature_selection: Method for selecting features:
-            - "top_variance": Top N by total variance contribution (default)
-            - "extreme": Top N most positive and negative for displayed PCs
-            - "top_absolute": Top N by absolute loading magnitude
-            - "top_contribution": Top N by contribution to displayed PCs
         figsize: Figure size.
 
     Returns:
@@ -2105,20 +2103,25 @@ def create_feature_contribution_plot(
         for i in range(n_components):
             contributions[:, i] = eigenvalues[i] * loadings[:, i] ** 2
 
-        # Sum across selected PCs
-        total_contributions = np.sum(contributions, axis=1)
+        # Sum across selected PCs (for display of unselected features' totals)
+        total_contributions_all = np.sum(contributions, axis=1)
 
-        # Sort features by total contribution
-        sorted_indices = np.argsort(total_contributions)[::-1]
-
-        # Limit to available features
+        # Select top features by total variance contribution, delegating to the
+        # shared selection function instead of duplicating its ranking formula.
         actual_top_n = min(top_n, len(trait_names))
-        top_indices = sorted_indices[:actual_top_n]
+        top_indices = select_top_features_from_pca(
+            loadings=loadings,
+            eigenvalues=eigenvalues,
+            n_features_total=len(trait_names),
+            n_features_to_select=actual_top_n,
+            method="top_variance",
+            pc_indices=None,
+        )
 
         # Get top features data
         top_traits = [trait_names[i] for i in top_indices]
         contributions = contributions[top_indices]
-        total_contributions = total_contributions[top_indices]
+        total_contributions = total_contributions_all[top_indices]
         available_pcs = n_components
 
     # Create figure
@@ -2205,6 +2208,8 @@ def create_pca_biplot(
             - "extreme": Top N most positive and negative for each PC
             - "top_absolute": Top N by absolute loading magnitude
             - "top_contribution": Top N by variance contribution to displayed PCs
+            - "top_variance": Top N by total variance contribution (all retained PCs,
+              not just pc_x/pc_y)
         figsize: Figure size.
         alpha: Transparency for scatter points.
         arrow_scale: Scaling factor for feature arrows (auto-calculated if None).
@@ -2220,7 +2225,8 @@ def create_pca_biplot(
         PCA biplot figure.
 
     Raises:
-        ValueError: If the PCA sample count cannot be matched to ``df``.
+        ValueError: If the PCA sample count cannot be matched to ``df``, or if
+            ``feature_selection`` is not one of the documented values.
     """
     fig, ax = plt.subplots(figsize=figsize)
 
@@ -2265,17 +2271,23 @@ def create_pca_biplot(
         method = "top_contribution"
     elif feature_selection == "vector_length":
         method = "vector_length"
+    elif feature_selection == "top_variance":
+        method = "top_variance"
     else:
-        method = "vector_length"  # Default to traditional biplot convention
+        raise ValueError(f"Unrecognized feature_selection: {feature_selection!r}")
 
-    # Select features using modular function
+    # Select features using modular function. "top_variance" ranks by total
+    # variance contribution across all retained PCs (not just pc_x/pc_y), so
+    # pc_indices must be None here — select_top_features_from_pca ignores
+    # pc_indices entirely for this method, and passing [pc_x_idx, pc_y_idx]
+    # would misleadingly suggest the biplot's 2-PC scope is honored.
     top_indices = select_top_features_from_pca(
         loadings=loadings,
         eigenvalues=eigenvalues,
         n_features_total=n_features,
         n_features_to_select=top_n_features,
         method=method,
-        pc_indices=[pc_x_idx, pc_y_idx],
+        pc_indices=None if method == "top_variance" else [pc_x_idx, pc_y_idx],
     )
 
     # Plot samples

--- a/tests/test_step_generate_static_figures.py
+++ b/tests/test_step_generate_static_figures.py
@@ -1645,6 +1645,41 @@ class TestMissingPlotsWiring:
         assert "top_n" in call_kwargs
         assert call_kwargs["top_n"] == 15
 
+    def test_feature_contribution_plot_call_does_not_pass_feature_selection(
+        self,
+        static_viz_config_enabled,
+        sample_trait_data,
+        prev_result_with_pca,
+        tmp_path,
+        monkeypatch,
+    ):
+        """Regression test for #202: step no longer passes feature_selection.
+
+        create_feature_contribution_plot no longer accepts feature_selection,
+        so the step must not pass it.
+        """
+        from unittest.mock import Mock
+        from sleap_roots_analyze.pipeline.steps import generate_static_figures
+
+        mock_contrib = Mock(return_value=Mock())
+        monkeypatch.setattr(
+            generate_static_figures, "create_feature_contribution_plot", mock_contrib
+        )
+
+        setup_matplotlib_backend()
+        step = GenerateStaticFiguresStep()
+
+        step.execute(
+            data=sample_trait_data,
+            config=static_viz_config_enabled,
+            run_dir=tmp_path,
+            prev_result=prev_result_with_pca,
+        )
+
+        assert mock_contrib.called
+        call_kwargs = mock_contrib.call_args.kwargs
+        assert "feature_selection" not in call_kwargs
+
     # --- 6b: PCA PC Boxplots Variance Threshold ---
 
     def test_pc_boxplots_uses_variance_threshold_from_pca_config(

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -2179,6 +2179,57 @@ class TestPCAVisualization:
 
         plt.close("all")
 
+    def test_create_feature_contribution_plot_on_the_fly_matches_direct_call(
+        self, pca_viz_results
+    ):
+        """Regression test for #202: on-the-fly ranking matches select_top_features_from_pca directly.
+
+        The refactored on-the-fly branch delegates to
+        select_top_features_from_pca(method="top_variance", pc_indices=None, ...)
+        instead of duplicating its ranking formula inline; this asserts the two
+        stay identical, in order.
+        """
+        from sleap_roots_analyze.visualization import create_feature_contribution_plot
+        from sleap_roots_analyze.pca import select_top_features_from_pca
+
+        trait_names = pca_viz_results["feature_names"]
+        n_components = 3
+        top_n = 10
+
+        # This fixture includes a pre-calculated "feature_contributions" key by
+        # default, which would route through the pre-calculated branch instead of
+        # the on-the-fly branch under test here — strip it to force the on-the-fly
+        # path this test targets.
+        pca_results_no_precalc = {
+            k: v for k, v in pca_viz_results.items() if k != "feature_contributions"
+        }
+        assert "trait_contrib_df" not in pca_results_no_precalc
+        assert "feature_contributions" not in pca_results_no_precalc
+
+        fig = create_feature_contribution_plot(
+            pca_results_no_precalc,
+            trait_names,
+            n_components=n_components,
+            top_n=top_n,
+        )
+        ax = fig.axes[0]
+        plotted_order = [label.get_text() for label in ax.get_yticklabels()]
+
+        expected_indices = select_top_features_from_pca(
+            loadings=pca_viz_results["loadings"][:, :n_components],
+            eigenvalues=pca_viz_results["eigenvalues"][:n_components],
+            n_features_total=len(trait_names),
+            n_features_to_select=min(top_n, len(trait_names)),
+            method="top_variance",
+            pc_indices=None,
+        )
+        # The plot draws highest-contribution at top, i.e. reversed selection order.
+        expected_order = [trait_names[i] for i in expected_indices][::-1]
+
+        assert plotted_order == expected_order
+
+        plt.close("all")
+
     def test_create_feature_contribution_plot_consistency(self):
         """Test that pre-calculated and on-the-fly calculations give consistent results."""
         from sleap_roots_analyze.visualization import create_feature_contribution_plot

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -2240,6 +2240,20 @@ class TestPCAVisualization:
 
         plt.close("all")
 
+    def test_create_feature_contribution_plot_no_feature_selection_param(self):
+        """Regression test for #202: dead feature_selection param is removed.
+
+        It never affected selection, so it must be removed, not silently ignored.
+        """
+        import inspect
+        from sleap_roots_analyze.visualization import create_feature_contribution_plot
+
+        sig = inspect.signature(create_feature_contribution_plot)
+        assert "feature_selection" not in sig.parameters
+
+        with pytest.raises(TypeError):
+            create_feature_contribution_plot({}, [], feature_selection="top_variance")
+
     def test_create_pca_biplot(self, pca_viz_results, pca_viz_dataframe):
         """Test PCA biplot creation."""
         from sleap_roots_analyze.visualization import create_pca_biplot
@@ -2297,6 +2311,120 @@ class TestPCAVisualization:
         assert isinstance(fig, plt.Figure)
         # Should have a colorbar
         assert len(fig.axes) > 1  # Main ax plus colorbar
+
+        plt.close("all")
+
+    def test_create_pca_biplot_top_variance_feature_selection(
+        self, pca_viz_results, pca_viz_dataframe
+    ):
+        """Regression test for #202: "top_variance" must select via that method.
+
+        It must match select_top_features_from_pca(method="top_variance"), not
+        silently fall back to "vector_length".
+        """
+        from sleap_roots_analyze.visualization import create_pca_biplot
+        from sleap_roots_analyze.pca import select_top_features_from_pca
+
+        trait_names = [f"trait_{i}" for i in range(10)]
+        top_n_features = 5
+        # PC1/PC3 (not PC1/PC2) is deliberate: for this fixture's random loadings,
+        # "vector_length" restricted to PC1/PC2 happens to coincide with
+        # "top_variance" over all PCs, which would make this test pass even on the
+        # buggy fallback. PC1/PC3 empirically diverges, so it actually catches #202.
+        pc_x, pc_y = 1, 3
+
+        fig = create_pca_biplot(
+            pca_viz_results,
+            pca_viz_dataframe,
+            trait_names,
+            pc_x=pc_x,
+            pc_y=pc_y,
+            top_n_features=top_n_features,
+            feature_selection="top_variance",
+        )
+
+        expected_indices = select_top_features_from_pca(
+            loadings=pca_viz_results["loadings"],
+            eigenvalues=pca_viz_results["eigenvalues"],
+            n_features_total=len(trait_names),
+            n_features_to_select=top_n_features,
+            method="top_variance",
+            pc_indices=None,
+        )
+        expected_traits = {trait_names[i] for i in expected_indices}
+
+        ax = fig.axes[0]
+        plotted_traits = {text.get_text() for text in ax.texts if text.get_text()}
+
+        assert plotted_traits == expected_traits
+
+        plt.close("all")
+
+    def test_create_pca_biplot_unrecognized_feature_selection_raises(
+        self, pca_viz_results, pca_viz_dataframe
+    ):
+        """Regression test for #202: an unrecognized feature_selection raises.
+
+        It must raise ValueError instead of silently substituting "vector_length".
+        """
+        from sleap_roots_analyze.visualization import create_pca_biplot
+
+        trait_names = [f"trait_{i}" for i in range(10)]
+
+        with pytest.raises(ValueError):
+            create_pca_biplot(
+                pca_viz_results,
+                pca_viz_dataframe,
+                trait_names,
+                pc_x=1,
+                pc_y=2,
+                top_n_features=5,
+                feature_selection="not_a_real_method",
+            )
+
+    @pytest.mark.parametrize(
+        "feature_selection",
+        ["vector_length", "extreme", "top_absolute", "top_contribution"],
+    )
+    def test_create_pca_biplot_feature_selection_methods_dispatch_correctly(
+        self, pca_viz_results, pca_viz_dataframe, feature_selection
+    ):
+        """Regression guard: pre-existing feature_selection methods still work.
+
+        The four pre-existing methods must keep dispatching to their matching
+        select_top_features_from_pca method.
+        """
+        from sleap_roots_analyze.visualization import create_pca_biplot
+        from sleap_roots_analyze.pca import select_top_features_from_pca
+
+        trait_names = [f"trait_{i}" for i in range(10)]
+        top_n_features = 5
+        pc_x, pc_y = 1, 2
+
+        fig = create_pca_biplot(
+            pca_viz_results,
+            pca_viz_dataframe,
+            trait_names,
+            pc_x=pc_x,
+            pc_y=pc_y,
+            top_n_features=top_n_features,
+            feature_selection=feature_selection,
+        )
+
+        expected_indices = select_top_features_from_pca(
+            loadings=pca_viz_results["loadings"],
+            eigenvalues=pca_viz_results["eigenvalues"],
+            n_features_total=len(trait_names),
+            n_features_to_select=top_n_features,
+            method=feature_selection,
+            pc_indices=[pc_x - 1, pc_y - 1],
+        )
+        expected_traits = {trait_names[i] for i in expected_indices}
+
+        ax = fig.axes[0]
+        plotted_traits = {text.get_text() for text in ax.texts if text.get_text()}
+
+        assert plotted_traits == expected_traits
 
         plt.close("all")
 


### PR DESCRIPTION
## Summary

Fixes #202. `pca.feature_selection_strategy` was silently not controlling feature selection in two visualization functions:

- **`create_pca_biplot`**: had `if`/`elif` branches for `extreme`/`top_absolute`/`top_contribution`/`vector_length` but none for `top_variance`, so it silently fell through to `vector_length` — a materially different, differently-weighted selection criterion. Now has an explicit `top_variance` branch, and raises `ValueError` for genuinely unrecognized values instead of silently substituting `vector_length`. When `feature_selection="top_variance"`, `pc_indices=None` is passed (not the 2 displayed PCs), since `select_top_features_from_pca`'s `top_variance` method ranks across all retained PCs and ignores `pc_indices` entirely — mirrors the existing workaround in `create_umap_colored_by_top_traits`.
- **`create_feature_contribution_plot`**: accepted a `feature_selection` parameter that was never referenced anywhere in the function body — every code path always ranked by total variance contribution regardless of what was passed. **Removes** the parameter (breaking, narrow) rather than wiring it up: the chart's own title asserts the displayed traits are the top contributors, so a non-contribution selection criterion would misdescribe the chart, matching the parameter-free `create_feature_contribution_heatmap` precedent. Its on-the-fly ranking branch now delegates to `select_top_features_from_pca(method="top_variance")` instead of duplicating the formula inline.

Verified backward-compatible with the real downstream consumer (`Salk-Harnessing-Plants-Initiative/bloom`, `sleap-roots-analyze>=0.1.0a5`): its `pca_analysis` MCP tool calls both functions but never passes `feature_selection` to either.

Followed the repo's spec-driven + TDD workflow: OpenSpec proposal (`openspec/changes/fix-pca-feature-selection-wiring/`) → 4-agent proposal review → TDD red/green implementation → 5-agent pre-PR self-review → this PR.

## Test plan

- [x] New regression tests: `top_variance` selects the same features as a direct `select_top_features_from_pca(method="top_variance")` call (for both `create_pca_biplot` and `create_feature_contribution_plot`'s on-the-fly branch)
- [x] `create_pca_biplot` raises `ValueError` for an unrecognized `feature_selection`
- [x] Parametrized regression guard confirms the four pre-existing methods (`vector_length`/`extreme`/`top_absolute`/`top_contribution`) still dispatch correctly (previously untested)
- [x] `create_feature_contribution_plot`'s signature no longer accepts `feature_selection`, and the `GenerateStaticFiguresStep` call site no longer passes it (real step-execution test, not just a signature check)
- [x] Full local test suite: 2875 passed, 0 failed
- [x] `black --check`, `ruff check` (src), `mypy` vs. frozen baseline (0 new errors) all clean
- [x] `openspec validate fix-pca-feature-selection-wiring --strict` passes
- [x] Synthetic before/after visual sanity check on real trait data (`tests/data/Turface_all_traits_2024.csv`) confirmed the fix changes which features are plotted, as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)