### PR TITLE
fix(#207): scope pc_indices and round-robin extreme selection in top-traits UMAP

### DIFF
--- a/configs/active/viz/alfalfa_gwas_wave1_canola_models.yaml
+++ b/configs/active/viz/alfalfa_gwas_wave1_canola_models.yaml
@@ -55,9 +55,13 @@ pca:
   # "top_variance" = select traits with highest total variance contribution
   feature_selection_strategy: "extreme"
 
-  # Number of traits to select using the strategy above (for UMAP coloring and metadata)
-  # For "extreme" strategy: 5 means 5 per direction per PC (can select many traits)
-  # These are the traits that will be used to color UMAP plots
+  # Number of traits to select using the strategy above, for PCAAnalysisStep's
+  # metadata/top_features output only. For "extreme" strategy: 5 means 5 per
+  # direction per PC (can select many traits).
+  # NOTE: this does NOT control the "UMAP colored by top traits" plot — that
+  # plot always shows 6 traits (n_traits is hardcoded in
+  # GenerateStaticFiguresStep), round-robin distributed across all retained
+  # PCs and both loading directions.
   n_top_features: 5
 
 umap:

--- a/configs/active/viz/viz_alfalfa_gwas_wave_1_grouped.yaml
+++ b/configs/active/viz/viz_alfalfa_gwas_wave_1_grouped.yaml
@@ -28,13 +28,16 @@ statistics:
 # PCA configuration
 # feature_selection_strategy "extreme" selects the traits with the most extreme
 # positive and negative loadings per PC. n_top_features controls how many are
-# selected for UMAP coloring and metadata storage (one per extreme direction per PC).
+# selected per extreme direction per PC for PCAAnalysisStep's metadata/top_features
+# output only — it does NOT control the "UMAP colored by top traits" plot, which
+# always shows 6 traits (n_traits is hardcoded in GenerateStaticFiguresStep),
+# round-robin distributed across all retained PCs and both loading directions.
 # pca_biplot_top_features (in static_viz) independently controls biplot arrow count.
 pca:
   n_components: 0.95
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5            # 5 extreme traits for UMAP coloring
+  n_top_features: 5            # 5 extreme traits per direction per PC (PCA metadata)
 
 umap:
   enabled: true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -127,6 +127,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clustering-path tests to make the contract verifiable by `pytest` alone.
   First concrete step of #161's mypy-baseline paydown; a matching gap in
   `generate_static_figures.py` is left for a separate follow-up.
+- `create_umap_colored_by_top_traits` no longer collapses `feature_selection="extreme"`
+  to "PC1's most-negative-loading traits only" (#207): `pc_indices` was hardcoded to
+  `[0, 1]` for every method except `"top_variance"`, and for `"extreme"` specifically,
+  `select_top_features_from_pca`'s block-ordered return
+  (`[PC1_neg × n, PC1_pos × n, PC2_neg × n, ...]`) was truncated to `top_indices[:n_traits]`
+  — since `n_traits` was passed as both the per-direction-per-PC count *and* the final
+  slice length, the first block (PC1's `n_traits` most-negative-loading traits) already
+  filled the entire slice. `pc_indices` now scopes to all retained PCs for every method,
+  and `"extreme"` selection is now built via a direction-major/PC-minor round-robin
+  directly in `create_umap_colored_by_top_traits` (every retained PC's most-negative
+  trait, then every PC's most-positive trait, then every PC's 2nd-most-negative, ...),
+  so small `n_traits` relative to PC count can't starve later PCs the way a PC-major
+  ordering would. Per-subplot subtitles now report the trait's actual source PC and
+  direction instead of always re-deriving it from PC1's loading.
+  `select_top_features_from_pca` itself (`pca.py`) is unchanged — `PCAAnalysisStep`
+  still relies on its existing block-ordered, per-direction-per-PC semantics.
 - `create_pca_biplot` now honors `feature_selection="top_variance"` (#202): the
   `feature_selection`→`method` mapping had `elif` branches for `extreme`/
   `top_absolute`/`top_contribution`/`vector_length` but none for `top_variance`,

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -140,9 +140,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trait, then every PC's most-positive trait, then every PC's 2nd-most-negative, ...),
   so small `n_traits` relative to PC count can't starve later PCs the way a PC-major
   ordering would. Per-subplot subtitles now report the trait's actual source PC and
-  direction instead of always re-deriving it from PC1's loading.
+  direction instead of always re-deriving it from PC1's loading — though a trait extreme
+  on more than one PC is still attributed to whichever PC's round-robin turn claims it
+  first, not necessarily its strongest association, and direction balance (both + and -)
+  is only guaranteed once `n_traits >= 2 * n_retained_pcs`.
   `select_top_features_from_pca` itself (`pca.py`) is unchanged — `PCAAnalysisStep`
-  still relies on its existing block-ordered, per-direction-per-PC semantics.
+  still relies on its existing block-ordered, per-direction-per-PC semantics. Every
+  active config with `feature_selection_strategy: "extreme"` (the majority of
+  `configs/active/viz/*.yaml`) will now plot a different trait set for
+  `umap_top_traits.png` than previously generated output — regenerate that figure on
+  next run if a prior copy is being compared against.
 - `create_pca_biplot` now honors `feature_selection="top_variance"` (#202): the
   `feature_selection`→`method` mapping had `elif` branches for `extreme`/
   `top_absolute`/`top_contribution`/`vector_length` but none for `top_variance`,

--- a/openspec/changes/fix-umap-top-traits-extreme-pc-scoping/proposal.md
+++ b/openspec/changes/fix-umap-top-traits-extreme-pc-scoping/proposal.md
@@ -1,0 +1,108 @@
+## Why
+
+`create_umap_colored_by_top_traits()` (`src/sleap_roots_analyze/visualization.py`) is called from
+`GenerateStaticFiguresStep` (`pipeline/steps/generate_static_figures.py:531-541`) for every
+viz-pipeline run, with `n_traits=6` hardcoded. Two compounding hardcodes make its output silently
+wrong for the `"extreme"` feature-selection strategy — the strategy used by the majority of active
+viz configs (`configs/active/viz/*.yaml`):
+
+1. `pc_indices` is scoped to all retained PCs only when `feature_selection == "top_variance"`;
+   every other method (`"extreme"`, `"top_absolute"`, `"top_contribution"`) falls into
+   `pc_indices = [0, 1]`, capping PC scope at 2 regardless of `n_components`. Same root-cause
+   pattern as the still-open #203 (a different call site, `pipeline/steps/pca_analysis.py`) and the
+   one already fixed for `create_pca_biplot` (#202/#214).
+2. For `method="extreme"`, `select_top_features_from_pca()` (`pca.py`) returns a block-ordered
+   list (`[PC1-neg × n, PC1-pos × n, PC2-neg × n, PC2-pos × n, ...]`), and the caller slices
+   `top_indices[:n_traits]`. Because `n_traits` is passed as both the per-direction-per-PC count
+   *and* the final slice length, the first block (PC1's `n_traits` most-negative-loading traits)
+   already fills the entire slice — PC1's positive extremes and every PC2+ trait are never shown,
+   for any `n_components`. Verified empirically against synthetic loadings (see #207).
+
+The net effect: for every active config with `feature_selection_strategy: "extreme"`, the "UMAP
+colored by top traits" plot shows only PC1's most-negative-loading traits, never PC1's positive
+extremes or any other PC — contradicting the config comments that describe this plot as showing
+"the most extreme positive and negative loadings per PC" (plural, both directions).
+
+`top_absolute`/`top_contribution` inherit hardcode 1 only (their `select_top_features_from_pca`
+branches already return an exactly-length-`n` ranked list, so `[:n_traits]` is a no-op); neither
+appears in any active config today, so this proposal fixes their `pc_indices` scoping as a side
+effect of the shared code path without adding dedicated new logic for them.
+
+## What Changes
+
+- In `create_umap_colored_by_top_traits`, compute `pc_indices` from the retained-PC count
+  (`n_components_selected` / `cumulative_variance_ratio` / `variance_threshold`, the same logic
+  already used for `"top_variance"`) for **every** `feature_selection` method, replacing the
+  `else: pc_indices = [0, 1]` branch.
+- For `method="extreme"` specifically, replace the single `select_top_features_from_pca(...,
+  n_features_to_select=n_traits)` call + `top_indices[:n_traits]` truncation with a round-robin
+  construction built directly in `create_umap_colored_by_top_traits`: one sorted-loading iterator
+  per (PC, direction) pair across all retained `pc_indices`, each iterator advancing its own
+  position monotonically across passes and checked against one **global** `seen` set at pop time
+  (so a trait claimed by one pair is skipped, not re-selected, by every other pair). Passes are
+  ordered **direction-major, PC-minor** — pass 1 takes each retained PC's single most-negative
+  unseen trait (PC1, PC2, PC3, ...), pass 2 takes each PC's single most-positive unseen trait, pass
+  3 takes each PC's second-most-negative unseen trait, and so on — continuing until `n_traits`
+  traits are collected or every pair is exhausted. This ordering is required (not the naive
+  PC-major "PC1-, PC1+, PC2-, PC2+, ..." grouping) specifically so that when `n_traits` is smaller
+  than `2 * len(pc_indices)`, every retained PC still gets at least one representative before any
+  PC gets a second — otherwise the same class of bug resurfaces one level up (PC1..PC3 crowd out
+  PC4+ whenever traits-per-PC-pair exceeds the budget). `select_top_features_from_pca()`'s own
+  block-ordered `"extreme"` behavior in `pca.py` is **not** modified — `pipeline/steps/pca_analysis.py`
+  depends on that function's existing per-direction-per-PC count semantics (it consumes every
+  returned index, unsliced), so changing the shared function would be an unscoped side effect on a
+  different call site.
+- Track which (PC, direction) pair each selected trait actually came from (first-come-first-claimed
+  in the round-robin order above, so deterministic when a trait is extreme on more than one PC),
+  and use that to fix the per-subplot subtitle label (currently always reports "PC1+/PC1-" by
+  re-reading `loadings[trait_idx, 0]`, which only looked correct because every trait previously
+  came from PC1) so it names the real source PC and direction.
+- Update the `feature_selection` Args docstring line for `"extreme"` in
+  `create_umap_colored_by_top_traits` (currently "Top N most positive and negative for first 2
+  PCs"), which becomes inaccurate once PC scope is no longer capped at 2.
+- Correct the two config comments that describe this plot's intended-but-currently-broken
+  behavior to match the now-true behavior — including their independently-inaccurate claim that
+  `pca.n_top_features` controls "UMAP coloring" (it does not: the UMAP call site hardcodes
+  `n_traits=6` regardless of `n_top_features`, which only feeds `PCAAnalysisStep`'s separate
+  selection; this claim is wrong today and would stay wrong if only the PC/direction description
+  were corrected):
+  `configs/active/viz/viz_alfalfa_gwas_wave_1_grouped.yaml:29-31` and
+  `configs/active/viz/alfalfa_gwas_wave1_canola_models.yaml:58-61`.
+- Add a `docs/CHANGELOG.md` `### Fixed` entry under `[Unreleased]`, matching the established
+  pattern for this bug class (e.g. the #202 `create_pca_biplot` fix, the #210 OOM fix).
+
+## Out of Scope
+
+- #206's full redesign (1-most-positive + 1-most-negative per retained PC, no `n_traits`
+  truncation at all, panel grid sized to the actual pair count). That is a separate, larger design
+  change. This proposal keeps `n_traits` as-is and only fixes how the existing count is
+  distributed across PCs/directions. Leave a cross-reference to #206 in the PR description rather
+  than closing it.
+- `pipeline/steps/pca_analysis.py`'s independent `pc_indices` hardcode (#203) — different call
+  site, still open, not touched here.
+- `bloommcp` (`Salk-Harnessing-Plants-Initiative/bloom`, `staging`) calls
+  `create_umap_colored_by_top_traits` without ever passing `feature_selection`, so it always uses
+  `"top_variance"` — unaffected by this change (already verified against that repo; see #207
+  comment thread).
+
+## Impact
+
+- Affected specs: `visualization-pipeline` (one requirement modified).
+- Affected code:
+  - `src/sleap_roots_analyze/visualization.py` — `create_umap_colored_by_top_traits`: PC-index
+    scoping, `"extreme"` round-robin selection, subtitle source tracking, docstring correction.
+  - `tests/test_visualization.py` — regression tests: (1) plotted trait set for
+    `feature_selection="extreme"` is not a subset of PC1's single-direction extremes and spans
+    every retained PC even when `n_traits < 2 * len(pc_indices)`; (2) corrected subtitle labeling;
+    (3) `pc_indices` scoping for `top_absolute`/`top_contribution`; (4) `top_variance` output is
+    byte-for-byte unchanged (backward compatibility); (5) exhaustion when distinct extreme traits
+    are fewer than `n_traits`; (6) a dedup case where one trait is extreme on more than one PC.
+  - `tests/test_pca.py` (or equivalent) — direct unit test confirming
+    `select_top_features_from_pca(method="extreme", ...)` is unchanged (still block-ordered,
+    still per-direction-per-PC `n_features_to_select` count), decoupled from the UMAP plotting
+    change.
+  - `configs/active/viz/viz_alfalfa_gwas_wave_1_grouped.yaml`,
+    `configs/active/viz/alfalfa_gwas_wave1_canola_models.yaml` — comment corrections only, no
+    behavioral config changes.
+  - `docs/CHANGELOG.md` — `[Unreleased]` → `### Fixed` entry.
+- No `pyproject.toml` version bump in this PR (per repo convention, cut separately).

--- a/openspec/changes/fix-umap-top-traits-extreme-pc-scoping/specs/visualization-pipeline/spec.md
+++ b/openspec/changes/fix-umap-top-traits-extreme-pc-scoping/specs/visualization-pipeline/spec.md
@@ -1,0 +1,199 @@
+## MODIFIED Requirements
+
+### Requirement: Pipeline Step Parameter Passing
+
+The `GenerateStaticFiguresStep` SHALL pass genotype highlighting parameters from configuration to underlying plotting functions.
+
+The `PCAAnalysisStep` SHALL use the post-filtering feature names returned by
+`perform_pca_analysis()` (via `pca_results["feature_names"]`) instead of the original
+`trait_cols` list when constructing the loadings DataFrame index, computing
+`n_features_total` for feature selection, and mapping feature indices to names.
+
+The `PCAAnalysisStep` SHALL log the names and count of any traits excluded due to zero
+variance, and SHALL emit a Python `UserWarning` when more than 50% of input traits are
+excluded.
+
+The `PCAAnalysisStep` SHALL store `excluded_zero_variance_traits` (list of excluded trait
+names) and `n_traits_after_filtering` (int) in its output metadata for downstream
+inspection and reproducibility.
+
+`create_pca_biplot` SHALL honor every `feature_selection` value it documents
+— `"vector_length"`, `"extreme"`, `"top_absolute"`, `"top_contribution"`,
+and `"top_variance"` — by selecting features using the matching method in
+`select_top_features_from_pca()`, and SHALL raise `ValueError` for any other
+value instead of silently substituting `"vector_length"`. When
+`feature_selection == "top_variance"`, `create_pca_biplot` SHALL call
+`select_top_features_from_pca(..., pc_indices=None)` rather than passing the
+biplot's two displayed PC indices, since `select_top_features_from_pca`'s
+`"top_variance"` method ranks across all retained PCs regardless of
+`pc_indices` and passing the 2-index list would misleadingly imply the
+biplot's PC scope is honored.
+
+`create_umap_colored_by_top_traits` SHALL scope `pc_indices` to all retained PCs (derived
+from `pca_results["n_components_selected"]`, `variance_threshold`, or the 95% cumulative
+variance default, in that priority order) for **every** `feature_selection` method, not
+only `"top_variance"`.
+
+For `feature_selection == "extreme"`, `create_umap_colored_by_top_traits` SHALL build the
+plotted trait set by round-robin selection across (PC, direction) pairs spanning all
+scoped `pc_indices`, instead of taking a single block-ordered `select_top_features_from_pca(...,
+n_features_to_select=n_traits)` call and truncating it to `top_indices[:n_traits]`. The
+round-robin SHALL:
+- maintain one sorted-loading iterator per (PC, direction) pair, each advancing its own
+  position monotonically across passes (never re-scanning from the start);
+- check candidates against a single **global** `seen` set at the moment a trait is popped,
+  so a trait already claimed by one pair is skipped (not re-selected) by every other pair;
+- order passes **direction-major, PC-minor**: pass 1 takes each retained PC's single
+  most-negative unseen trait (PC1, PC2, PC3, ... in order), pass 2 takes each PC's single
+  most-positive unseen trait, pass 3 takes each PC's second-most-negative unseen trait, and
+  so on, continuing until `n_traits` traits are collected or every pair is exhausted;
+- record the (PC, direction) pair that actually claimed each selected trait, on a
+  first-come-first-claimed basis per the pass order above, so the source is deterministic
+  even when a trait is extreme on more than one PC.
+
+The direction-major/PC-minor pass order is required specifically so that when `n_traits`
+is smaller than `2 * len(pc_indices)`, every retained PC still receives at least one
+representative before any PC receives a second — a PC-major pass order (all of PC1's
+extremes before moving to PC2) would reproduce the same class of bug one level up,
+crowding out later PCs whenever per-PC-pair supply exceeds the `n_traits` budget.
+
+This round-robin construction lives in `create_umap_colored_by_top_traits` only;
+`select_top_features_from_pca`'s own `"extreme"` method in `pca.py` (and its
+per-direction-per-PC `n_features_to_select` count semantics, relied on unsliced by
+`PCAAnalysisStep`) SHALL remain unchanged.
+
+For `feature_selection == "extreme"`, each subplot's subtitle SHALL report the actual (PC,
+direction) pair that selected that trait, rather than always re-deriving direction from
+`loadings[trait_idx, 0]` (PC1's loading).
+
+#### Scenario: Pass parameters to PCA biplot
+- **WHEN** generating PCA biplot via `create_pca_biplot`
+- **THEN** the step SHALL pass `config.static_viz.genotypes_to_color` to the function
+- **AND** the step SHALL pass `config.static_viz.highlight_genotypes` to the function
+
+#### Scenario: Pass parameters to PC boxplots
+- **WHEN** generating PC boxplots via `create_pc_genotype_boxplots`
+- **THEN** the step SHALL pass `config.static_viz.highlight_genotypes` to the function
+- **AND** the highlighted genotypes SHALL appear in gold with bold labels
+
+#### Scenario: PCA step handles zero-variance traits gracefully
+- **WHEN** the input DataFrame contains traits with zero variance (constant values)
+- **THEN** the PCA step SHALL complete successfully using only non-zero-variance traits
+- **AND** the loadings CSV index SHALL match the actual features used in PCA
+- **AND** `excluded_zero_variance_traits` SHALL list the excluded trait names in metadata
+- **AND** `n_traits_after_filtering` SHALL reflect the count of traits actually used
+
+#### Scenario: PCA step warns on high zero-variance fraction
+- **WHEN** more than 50% of input traits have zero variance
+- **THEN** the PCA step SHALL emit a `UserWarning` indicating potential data quality issues
+- **AND** the step SHALL still complete successfully with the remaining traits
+
+#### Scenario: PCA step with no zero-variance traits
+- **WHEN** all input traits have non-zero variance
+- **THEN** the PCA step SHALL behave identically to current behavior
+- **AND** `excluded_zero_variance_traits` SHALL be an empty list
+- **AND** no warning SHALL be emitted
+
+#### Scenario: create_pca_biplot honors top_variance feature selection
+- **WHEN** `create_pca_biplot` is called with `feature_selection="top_variance"`
+- **THEN** the features selected for display SHALL be the same set returned
+  by `select_top_features_from_pca(method="top_variance", pc_indices=None,
+  ...)` called directly with the same loadings, eigenvalues, feature count,
+  and `top_n_features`
+- **AND** the selection SHALL NOT silently fall back to the
+  `"vector_length"` method
+
+#### Scenario: create_pca_biplot rejects an unrecognized feature_selection value
+- **WHEN** `create_pca_biplot` is called with a `feature_selection` value
+  that is not one of `"vector_length"`, `"extreme"`, `"top_absolute"`,
+  `"top_contribution"`, or `"top_variance"`
+- **THEN** the function SHALL raise `ValueError`
+- **AND** it SHALL NOT silently substitute `"vector_length"`
+
+#### Scenario: create_pca_biplot continues to honor pre-existing feature_selection methods
+- **WHEN** `create_pca_biplot` is called with `feature_selection` set to
+  `"vector_length"`, `"extreme"`, `"top_absolute"`, or `"top_contribution"`
+- **THEN** the features selected for display SHALL match a direct
+  `select_top_features_from_pca(method=<same value>, pc_indices=[pc_x_idx,
+  pc_y_idx])` call with the same loadings, eigenvalues, feature count, and
+  `top_n_features`
+
+#### Scenario: create_umap_colored_by_top_traits scopes pc_indices beyond PC1/PC2 for non-top_variance methods
+- **GIVEN** `pca_results` resolves to 3 or more retained PCs (via
+  `n_components_selected` or the cumulative variance threshold)
+- **WHEN** `create_umap_colored_by_top_traits` is called with
+  `feature_selection` set to `"extreme"`, `"top_absolute"`, or
+  `"top_contribution"`
+- **THEN** the PC indices considered for feature selection SHALL include every
+  retained PC, not just PC1 and PC2
+
+#### Scenario: create_umap_colored_by_top_traits shows traits from multiple PCs and both directions for extreme selection
+- **GIVEN** `pca_results` resolves to 3 or more retained PCs
+- **WHEN** `create_umap_colored_by_top_traits` is called with
+  `feature_selection="extreme"` and `n_traits` large enough to span more than
+  one (PC, direction) pair
+- **THEN** the plotted trait set SHALL NOT be a subset of PC1's `n_traits`
+  most-negative-loading indices
+- **AND** the plotted trait set SHALL include at least one trait whose
+  extreme loading comes from a PC other than PC1
+- **AND** the plotted trait set SHALL include at least one trait selected for
+  its positive loading
+
+#### Scenario: create_umap_colored_by_top_traits extreme selection round-robins fairly across PCs
+- **WHEN** `create_umap_colored_by_top_traits` is called with
+  `feature_selection="extreme"`, `n_traits=6`, and 3 retained PCs each with
+  distinct most-extreme traits in both directions
+- **THEN** the round-robin construction SHALL select traits from PC1, PC2,
+  and PC3 before exhausting `n_traits`, rather than filling the entire
+  `n_traits` budget from PC1 alone
+
+#### Scenario: create_umap_colored_by_top_traits gives every retained PC at least one representative before any PC gets a second
+- **GIVEN** `pca_results` resolves to 5 retained PCs, each with distinct
+  most-extreme traits in both directions
+- **WHEN** `create_umap_colored_by_top_traits` is called with
+  `feature_selection="extreme"` and `n_traits=6` (fewer than `2 * 5` PC×direction
+  pairs)
+- **THEN** the plotted trait set SHALL include at least one trait from each of
+  the 5 retained PCs
+- **AND** no PC SHALL contribute a second trait until every retained PC has
+  contributed at least one
+
+#### Scenario: create_umap_colored_by_top_traits extreme selection handles fewer distinct extreme traits than n_traits
+- **GIVEN** the total number of distinct traits reachable across all (PC,
+  direction) pairs (after deduplication) is less than `n_traits`
+- **WHEN** `create_umap_colored_by_top_traits` is called with
+  `feature_selection="extreme"`
+- **THEN** the function SHALL return a plotted trait set shorter than
+  `n_traits` without raising an exception
+- **AND** the figure's unused subplot axes SHALL be removed as they are today
+
+#### Scenario: create_umap_colored_by_top_traits deduplicates a trait that is extreme on more than one PC
+- **GIVEN** a single trait is the most-extreme (same or opposite direction)
+  loading on two different retained PCs
+- **WHEN** `create_umap_colored_by_top_traits` is called with
+  `feature_selection="extreme"`
+- **THEN** that trait SHALL appear exactly once in the plotted trait set
+- **AND** the (PC, direction) pair whose round-robin turn claims it first
+  (per pass order) SHALL be recorded as its source for subtitle purposes
+- **AND** the freed round-robin slot for the other PC SHALL be filled by that
+  PC's next-ranked unseen candidate rather than left empty
+
+#### Scenario: create_umap_colored_by_top_traits subtitle reports the true source PC and direction for extreme selection
+- **WHEN** `create_umap_colored_by_top_traits` is called with
+  `feature_selection="extreme"` and a plotted trait was selected for its
+  extreme loading on PC2 (not PC1)
+- **THEN** that trait's subplot subtitle SHALL reference PC2 (e.g. `"PC2+"` or
+  `"PC2-"`), not PC1
+
+#### Scenario: create_umap_colored_by_top_traits leaves select_top_features_from_pca's extreme method unchanged
+- **WHEN** `select_top_features_from_pca(method="extreme", ...)` is called
+  directly (e.g. from `PCAAnalysisStep`)
+- **THEN** it SHALL continue to return the block-ordered list
+  (`PC1_neg, PC1_pos, PC2_neg, PC2_pos, ...`) with `n_features_to_select`
+  traits per direction per PC, unchanged from current behavior
+
+#### Scenario: create_umap_colored_by_top_traits top_variance behavior is unchanged
+- **WHEN** `create_umap_colored_by_top_traits` is called with
+  `feature_selection="top_variance"`
+- **THEN** the selected traits and PC scoping SHALL be identical to current
+  behavior (unaffected by this change)

--- a/openspec/changes/fix-umap-top-traits-extreme-pc-scoping/tasks.md
+++ b/openspec/changes/fix-umap-top-traits-extreme-pc-scoping/tasks.md
@@ -79,10 +79,13 @@
 
 ## 4. Verification and wrap-up
 
-- [ ] 4.1 Run `openspec validate fix-umap-top-traits-extreme-pc-scoping --strict`.
-- [ ] 4.2 Run `/pre-merge-check` (black, ruff, full pytest, coverage, self-review, OpenSpec
-      validation, Copilot triage).
-- [ ] 4.3 Update PR description to note this supersedes itself if/when #206's redesign lands
+- [x] 4.1 Run `openspec validate fix-umap-top-traits-extreme-pc-scoping --strict`.
+- [x] 4.2 Run `/pre-merge-check` (black, ruff, full pytest, coverage, self-review, OpenSpec
+      validation, Copilot triage). Pre-PR 5-agent self-review found no BLOCKING issues;
+      addressed the IMPORTANT findings (redundant `argsort` call, unused test variable,
+      documented the first-claimed-PC-attribution/direction-imbalance caveats, added a
+      CHANGELOG note on cached-figure regeneration). CI green on all 3 platforms — PR #216.
+- [x] 4.3 Update PR description to note this supersedes itself if/when #206's redesign lands
       (cross-reference, don't close #206 or #209).
 
 ## Suggested commit plan (matches this repo's squash-merge-on-main convention)

--- a/openspec/changes/fix-umap-top-traits-extreme-pc-scoping/tasks.md
+++ b/openspec/changes/fix-umap-top-traits-extreme-pc-scoping/tasks.md
@@ -1,0 +1,93 @@
+## 1. PC-index scoping
+
+- [x] 1.1 Write failing tests in `tests/test_visualization.py` asserting that for
+      `feature_selection` in `{"extreme", "top_absolute", "top_contribution"}`, with
+      `pca_results` resolving to 3+ retained PCs, a trait whose extreme/top loading exists only on
+      PC3 (not PC1/PC2) is reachable in the plotted output — i.e. `pc_indices` is not capped at
+      `[0, 1]`. Use hand-built loadings (not QR-random fixtures) so the expected source PC is known
+      in advance, not re-derived via the same `np.argsort` logic under test.
+- [x] 1.2 In `create_umap_colored_by_top_traits` (`src/sleap_roots_analyze/visualization.py`),
+      remove the `if feature_selection == "top_variance": ... else: pc_indices = [0, 1]` branch;
+      compute `pc_indices` from the retained-PC count (`n_components_selected` /
+      `variance_threshold` / 95% default) unconditionally, for every `feature_selection` value.
+      Confirm the tests from 1.1 pass.
+
+## 2. Extreme-method round-robin selection
+
+- [x] 2.1 Write failing regression tests using a hand-built loadings array (9 features x 3+ PCs,
+      each PC given unambiguous, non-overlapping most-negative/most-positive traits — see
+      `test_visualization.py`'s existing `test_create_umap_colored_by_top_traits` for fixture
+      style) asserting, for `feature_selection="extreme"`:
+      - the plotted trait set is NOT a subset of PC1's `n_traits` most-negative-loading indices;
+      - the plotted trait set includes a trait from a non-PC1 source and a positively-loaded trait;
+      - with 5 retained PCs and `n_traits=6` (fewer than `2 * 5` PC×direction pairs), the plotted
+        set includes at least one trait from each of the 5 PCs, and no PC contributes a second
+        trait until every PC has contributed one (this is the case that would fail under a naive
+        PC-major round-robin ordering — it must drive the pass ordering below, not just PC-major
+        grouping).
+- [x] 2.2 In `create_umap_colored_by_top_traits`, replace the `select_top_features_from_pca(...,
+      method="extreme")` call + `top_indices[:n_traits]` truncation with a round-robin
+      construction: one sorted-loading iterator per (PC, direction) pair over the scoped
+      `pc_indices`, each advancing monotonically across passes and checked against one global
+      `seen` set at pop time. Order passes **direction-major, PC-minor**: pass 1 = each PC's single
+      most-negative unseen trait (PC1, PC2, PC3, ... in order), pass 2 = each PC's single
+      most-positive unseen trait, pass 3 = each PC's second-most-negative unseen trait, etc.,
+      continuing until `n_traits` collected or all pairs exhausted. Do not modify
+      `select_top_features_from_pca` in `pca.py`. Confirm the tests from 2.1 pass.
+- [x] 2.3 Write a failing test asserting that when the total number of distinct traits reachable
+      across all (PC, direction) pairs (after dedup) is less than `n_traits`, the function returns
+      a shorter plotted set without raising, and unused subplot axes are still removed correctly.
+      Confirm it passes against 2.2's implementation (should already hold; add the test to lock it
+      in).
+- [x] 2.4 Write a failing test asserting dedup behavior: construct loadings where one trait is the
+      most-extreme loading on two different PCs; assert it appears exactly once in the plotted set,
+      is attributed (for subtitle purposes) to whichever (PC, direction) pair's turn claims it first
+      in pass order, and that the freed round-robin slot for the other PC is backfilled by that
+      PC's next-ranked unseen candidate. Implement the tracking dict `{trait_idx: (pc_idx,
+      direction)}` alongside 2.2 if not already present; confirm this test passes.
+- [x] 2.5 Write a failing test asserting a plotted trait selected from PC2 gets a `"PC2+"`/`"PC2-"`
+      subtitle (not `"PC1±"`). Update the subtitle-generation code to use the tracked (PC,
+      direction) source instead of re-deriving direction from `loadings[trait_idx, 0]`. Confirm the
+      test passes.
+- [x] 2.6 Update the `feature_selection` Args docstring line for `"extreme"` in
+      `create_umap_colored_by_top_traits` (currently "Top N most positive and negative for first 2
+      PCs") to describe the corrected all-retained-PC, round-robin behavior.
+- [x] 2.7 Write a test directly against `select_top_features_from_pca(method="extreme",
+      pc_indices=[0, 1, 2], ...)` (decoupled from `create_umap_colored_by_top_traits`) asserting it
+      still returns the block-ordered list (`PC1_neg, PC1_pos, PC2_neg, PC2_pos, PC3_neg,
+      PC3_pos`) with `n_features_to_select` traits per direction per PC — confirming `pca.py` is
+      genuinely untouched by this change.
+- [x] 2.8 Write a backward-compatibility test capturing `create_umap_colored_by_top_traits`'s
+      plotted trait set for `feature_selection="top_variance"` (using the existing
+      `pca_viz_results`/`pca_viz_dataframe`/`umap_viz_results` fixtures) and asserting it is
+      unchanged by this PR (this path was already correctly all-PC-scoped and untouched).
+- [x] 2.9 Run the full `tests/test_visualization.py` suite to confirm no regressions.
+
+## 3. Config comment and CHANGELOG corrections
+
+- [x] 3.1 Update `configs/active/viz/viz_alfalfa_gwas_wave_1_grouped.yaml:29-31,37` to describe the
+      now-true behavior (traits drawn from all retained PCs, both directions, round-robin
+      distributed) and drop/correct the independently-inaccurate claim that `n_top_features`
+      controls "UMAP coloring" (it does not — the UMAP call site hardcodes `n_traits=6`
+      regardless of `config.pca.n_top_features`, which only feeds `PCAAnalysisStep`).
+- [x] 3.2 Update `configs/active/viz/alfalfa_gwas_wave1_canola_models.yaml:58-61` likewise.
+- [x] 3.3 Run `/validate-config` (or `validate_viz_config()`) against both configs to confirm the
+      comment-only edits didn't break config validation.
+- [x] 3.4 Add a `docs/CHANGELOG.md` `### Fixed` entry under `[Unreleased]`, matching the
+      established pattern for this bug class (e.g. the #202 `create_pca_biplot` fix, the #210 OOM
+      fix).
+
+## 4. Verification and wrap-up
+
+- [ ] 4.1 Run `openspec validate fix-umap-top-traits-extreme-pc-scoping --strict`.
+- [ ] 4.2 Run `/pre-merge-check` (black, ruff, full pytest, coverage, self-review, OpenSpec
+      validation, Copilot triage).
+- [ ] 4.3 Update PR description to note this supersedes itself if/when #206's redesign lands
+      (cross-reference, don't close #206 or #209).
+
+## Suggested commit plan (matches this repo's squash-merge-on-main convention)
+
+1. `fix(#207): scope pc_indices to all retained PCs in top-traits UMAP` — tasks 1.1-1.2.
+2. `fix(#207): round-robin extreme-method trait selection and fix PC subtitle source` — tasks
+   2.1-2.9.
+3. `fix(#207): correct top-traits config comments and changelog` — tasks 3.1-3.4.

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -2916,7 +2916,7 @@ def create_umap_colored_by_top_traits(
         "top_variance": "Contributing",
         "extreme": "Extreme Loading",
         "top_absolute": "Highest Absolute Loading",
-        "top_contribution": "Contributing to PC1-PC2",
+        "top_contribution": "Contributing to Retained PCs",
     }
     title = f"UMAP Colored by Top {n_traits} {method_desc.get(feature_selection, 'Contributing')} Traits"
     fig.suptitle(title, fontsize=14)

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -2803,16 +2803,22 @@ def create_umap_colored_by_top_traits(
         # next sweep (second-most-negative, second-most-positive, ...). This
         # guarantees every retained PC contributes once before any PC
         # contributes twice, which a PC-major ordering (all of PC1 before
-        # moving to PC2) would not.
+        # moving to PC2) would not. It does NOT guarantee a balanced mix of
+        # directions: when n_traits < 2 * len(pc_indices), the negative pass
+        # completes before any positive trait is reached, so the plotted set
+        # can skew toward one direction — PC sign is an arbitrary convention
+        # with no biological meaning, so this is a display artifact, not a
+        # scientific one. A trait that is extreme on more than one PC is
+        # attributed (for its subtitle) to whichever pair's turn claims it
+        # first in this pass order, not necessarily its strongest association.
+        ascending_by_pc = {
+            pc_idx: np.argsort(loadings[:n_features, pc_idx]) for pc_idx in pc_indices
+        }
         direction_iters = [
-            (pc_idx, "-", iter(np.argsort(loadings[:n_features, pc_idx]).tolist()))
+            (pc_idx, "-", iter(ascending_by_pc[pc_idx].tolist()))
             for pc_idx in pc_indices
         ] + [
-            (
-                pc_idx,
-                "+",
-                iter(np.argsort(loadings[:n_features, pc_idx])[::-1].tolist()),
-            )
+            (pc_idx, "+", iter(ascending_by_pc[pc_idx][::-1].tolist()))
             for pc_idx in pc_indices
         ]
 

--- a/src/sleap_roots_analyze/visualization.py
+++ b/src/sleap_roots_analyze/visualization.py
@@ -2738,9 +2738,13 @@ def create_umap_colored_by_top_traits(
         n_traits: Number of top traits to plot.
         feature_selection: Method for selecting features:
             - "top_variance": Top N by total variance contribution (default)
-            - "extreme": Top N most positive and negative for first 2 PCs
-            - "top_absolute": Top N by absolute loading magnitude
-            - "top_contribution": Top N by contribution to first 2 PCs
+            - "extreme": Most positive/negative loading traits, round-robin
+              distributed across all retained PCs (direction-major, PC-minor)
+              up to n_traits total
+            - "top_absolute": Top N by absolute loading magnitude across all
+              retained PCs
+            - "top_contribution": Top N by contribution across all retained
+              PCs
         variance_threshold: Cumulative variance threshold for PC selection.
             If None, use the same threshold as perform_pca_analysis.
         figsize: Figure size.
@@ -2758,40 +2762,88 @@ def create_umap_colored_by_top_traits(
     loadings = pca_results["loadings"]
     eigenvalues = pca_results["eigenvalues"]
 
-    # Determine which PCs to use for variance calculation
-    if feature_selection == "top_variance":
-        # Use the same PCA threshold/components as perform_pca_analysis by default
-        cumulative_var = pca_results["cumulative_variance_ratio"]
+    # Determine which PCs to use for variance calculation. Scope to all
+    # retained PCs for every method (not just "top_variance") — see #207.
+    cumulative_var = pca_results["cumulative_variance_ratio"]
 
-        # Check if pca_results has the selected components info
-        if "n_components_selected" in pca_results:
-            n_pcs = pca_results["n_components_selected"]
-        elif variance_threshold is not None:
-            # Use provided threshold
-            n_pcs = np.argmax(cumulative_var >= variance_threshold) + 1
-        else:
-            # Default to 95% variance if not specified
-            n_pcs = np.argmax(cumulative_var >= 0.95) + 1
-
-        # Clamp n_pcs to available data
-        n_pcs = min(n_pcs, loadings.shape[1], len(eigenvalues))
-        pc_indices = list(range(n_pcs))
+    # Check if pca_results has the selected components info
+    if "n_components_selected" in pca_results:
+        n_pcs = pca_results["n_components_selected"]
+    elif variance_threshold is not None:
+        # Use provided threshold
+        n_pcs = np.argmax(cumulative_var >= variance_threshold) + 1
     else:
-        # For other methods, use first 2 PCs by default
-        pc_indices = [0, 1]
+        # Default to 95% variance if not specified
+        n_pcs = np.argmax(cumulative_var >= 0.95) + 1
+
+    # Clamp n_pcs to available data
+    n_pcs = min(n_pcs, loadings.shape[1], len(eigenvalues))
+    pc_indices = list(range(n_pcs))
 
     # Ensure we handle the correct number of features
     n_features = min(len(trait_columns), loadings.shape[0])
 
-    # Select top features using modular function
-    top_indices = select_top_features_from_pca(
-        loadings=loadings,
-        eigenvalues=eigenvalues,
-        n_features_total=n_features,
-        n_features_to_select=n_traits,
-        method=feature_selection,
-        pc_indices=pc_indices if feature_selection != "top_variance" else None,
-    )
+    # Maps a selected trait index to the (pc_idx, direction) pair that chose
+    # it, for "extreme" subtitle labeling below. Empty for other methods.
+    trait_extreme_source: Dict[int, Tuple[int, str]] = {}
+
+    if feature_selection == "extreme":
+        # Round-robin across (PC, direction) pairs so every retained PC gets
+        # fair representation, instead of taking select_top_features_from_pca's
+        # block-ordered list (all of PC1's negatives, then PC1's positives,
+        # then PC2's negatives, ...) and truncating it to n_traits — which
+        # front-loads PC1 and can starve every other PC entirely (#207).
+        # select_top_features_from_pca's own "extreme" method is left
+        # unchanged (pipeline/steps/pca_analysis.py relies on its existing
+        # per-direction-per-PC block-ordered semantics, unsliced).
+        #
+        # Passes are direction-major, PC-minor: each sweep below first visits
+        # every retained PC's next-most-negative unseen trait, then every
+        # retained PC's next-most-positive unseen trait, before starting the
+        # next sweep (second-most-negative, second-most-positive, ...). This
+        # guarantees every retained PC contributes once before any PC
+        # contributes twice, which a PC-major ordering (all of PC1 before
+        # moving to PC2) would not.
+        direction_iters = [
+            (pc_idx, "-", iter(np.argsort(loadings[:n_features, pc_idx]).tolist()))
+            for pc_idx in pc_indices
+        ] + [
+            (
+                pc_idx,
+                "+",
+                iter(np.argsort(loadings[:n_features, pc_idx])[::-1].tolist()),
+            )
+            for pc_idx in pc_indices
+        ]
+
+        top_indices: List[int] = []
+        seen = set()
+        exhausted = [False] * len(direction_iters)
+        while len(top_indices) < n_traits and not all(exhausted):
+            for i, (pc_idx, direction, it) in enumerate(direction_iters):
+                if len(top_indices) >= n_traits:
+                    break
+                if exhausted[i]:
+                    continue
+                for idx in it:
+                    if idx not in seen:
+                        idx = int(idx)
+                        seen.add(idx)
+                        top_indices.append(idx)
+                        trait_extreme_source[idx] = (pc_idx, direction)
+                        break
+                else:
+                    exhausted[i] = True
+    else:
+        # Select top features using modular function
+        top_indices = select_top_features_from_pca(
+            loadings=loadings,
+            eigenvalues=eigenvalues,
+            n_features_total=n_features,
+            n_features_to_select=n_traits,
+            method=feature_selection,
+            pc_indices=pc_indices if feature_selection != "top_variance" else None,
+        )
 
     # Calculate contributions for display (always use variance contribution for labels)
     contributions = np.zeros(n_features)
@@ -2836,10 +2888,12 @@ def create_umap_colored_by_top_traits(
         # Add selection method to subtitle if not default
         subtitle = f"(Contribution: {contributions[trait_idx]:.3f})"
         if feature_selection == "extreme":
-            # Check if this was positive or negative loading
-            pc1_loading = loadings[trait_idx, 0] if loadings.shape[1] > 0 else 0
-            direction = "+" if pc1_loading > 0 else "-"
-            subtitle = f"(PC1{direction}, Contrib: {contributions[trait_idx]:.3f})"
+            # Report the actual (PC, direction) pair that selected this trait
+            # in the round-robin above, rather than re-deriving it from PC1's
+            # loading (which was only ever correct when every trait happened
+            # to come from PC1 — see #207).
+            source_pc, direction = trait_extreme_source[trait_idx]
+            subtitle = f"(PC{source_pc + 1}{direction}, Contrib: {contributions[trait_idx]:.3f})"
 
         ax.set_title(
             f"{trait_name}\n{subtitle}",

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -2528,3 +2528,33 @@ class TestFeatureSelection:
         # Feature 2: 2.0 * 0.5^2 + 1.0 * 0.5^2 = 0.50 + 0.25 = 0.75
         # Feature 0 has highest contribution
         assert selected[0] == 0
+
+    def test_extreme_selection_remains_block_ordered_across_three_pcs(self):
+        """Extreme method stays block-ordered per-PC, unchanged by the #207 fix."""
+        n_features = 12
+        loadings = np.random.RandomState(2).uniform(-0.05, 0.05, size=(n_features, 3))
+        loadings[0, 0] = -0.9  # PC1 most negative
+        loadings[1, 0] = -0.8  # PC1 2nd most negative
+        loadings[2, 0] = 0.9  # PC1 most positive
+        loadings[3, 0] = 0.8  # PC1 2nd most positive
+        loadings[4, 1] = -0.9  # PC2 most negative
+        loadings[5, 1] = -0.8  # PC2 2nd most negative
+        loadings[6, 1] = 0.9  # PC2 most positive
+        loadings[7, 1] = 0.8  # PC2 2nd most positive
+        loadings[8, 2] = -0.9  # PC3 most negative
+        loadings[9, 2] = -0.8  # PC3 2nd most negative
+        loadings[10, 2] = 0.9  # PC3 most positive
+        loadings[11, 2] = 0.8  # PC3 2nd most positive
+
+        eigenvalues = np.array([3.0, 2.0, 1.0])
+
+        selected = select_top_features_from_pca(
+            loadings=loadings,
+            eigenvalues=eigenvalues,
+            n_features_total=n_features,
+            n_features_to_select=2,
+            method="extreme",
+            pc_indices=[0, 1, 2],
+        )
+
+        assert selected == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -1987,6 +1987,64 @@ class TestCreateHeritabilityThresholdPlot:
         plt.close("all")
 
 
+def _multi_pc_extreme_pca_results(n_pcs=5):
+    """Build hand-constructed PCA results with unambiguous per-PC extremes.
+
+    Feature ``2 * pc`` is PC ``pc``'s most-negative loading and feature
+    ``2 * pc + 1`` is PC ``pc``'s most-positive loading, for every PC in
+    ``range(n_pcs)``. All other loadings are small noise (well below the
+    intentional +/-0.7..0.9 magnitudes), so expected selections are known in
+    advance rather than re-derived via ``np.argsort`` inside a test.
+
+    Returns:
+        Tuple of (pca_results dict, {feature_idx: (pc_idx, direction)} map
+        for the intentional extremes, total feature count).
+    """
+    n_features = 2 * n_pcs + 2  # plus 2 filler features never selected
+    rng = np.random.RandomState(0)
+    loadings = rng.uniform(-0.05, 0.05, size=(n_features, n_pcs))
+    extremes = {}
+    for pc in range(n_pcs):
+        neg_magnitude = 0.9 - 0.05 * pc
+        pos_magnitude = 0.85 - 0.05 * pc
+        loadings[2 * pc, pc] = -neg_magnitude
+        loadings[2 * pc + 1, pc] = pos_magnitude
+        extremes[2 * pc] = (pc, "-")
+        extremes[2 * pc + 1] = (pc, "+")
+
+    eigenvalues = np.linspace(n_pcs, 1.0, n_pcs)
+    pca_results = {
+        "loadings": loadings,
+        "eigenvalues": eigenvalues,
+        "cumulative_variance_ratio": np.cumsum(eigenvalues / eigenvalues.sum()),
+        "n_components_selected": n_pcs,
+    }
+    return pca_results, extremes, n_features
+
+
+def _plotted_trait_indices(fig, n_features):
+    """Parse plotted trait indices (as ints) from a figure's subplot titles."""
+    indices = []
+    for ax in fig.axes:
+        title = ax.get_title()
+        if not title:
+            continue
+        trait_name = title.split("\n")[0]
+        idx = int(trait_name.removeprefix("trait_"))
+        assert 0 <= idx < n_features
+        indices.append(idx)
+    return indices
+
+
+def _plotted_subtitle(fig, trait_idx):
+    """Return the subtitle (second title line) for a specific plotted trait."""
+    for ax in fig.axes:
+        title = ax.get_title()
+        if title.startswith(f"trait_{trait_idx}\n"):
+            return title.split("\n", 1)[1]
+    raise AssertionError(f"trait_{trait_idx} was not plotted")
+
+
 class TestPCAVisualization:
     """Tests for PCA visualization functions."""
 
@@ -2853,6 +2911,308 @@ class TestPCAVisualization:
         # Count actual plot axes (excluding colorbars)
         plot_axes = [ax for ax in axes if not hasattr(ax, "colorbar")]
         assert len(plot_axes) >= 6 or len(plot_axes) == len(trait_columns[:6])
+
+        plt.close("all")
+
+    def test_create_umap_colored_by_top_traits_scopes_pc_indices_beyond_two(self):
+        """pc_indices SHALL span all retained PCs for non-top_variance methods (#207).
+
+        Uses "top_absolute" (not "extreme") because its selection is a single
+        already-ranked, already-length-n list with no block-truncation
+        interaction — isolating the pc_indices-scoping fix from the separate
+        "extreme" round-robin fix.
+        """
+        from sleap_roots_analyze.visualization import create_umap_colored_by_top_traits
+
+        n_features = 6
+        n_pcs = 4
+        loadings = np.full((n_features, n_pcs), 0.05)
+        # Feature 0: moderately strong on PC1 and PC2 only (sum abs = 1.15),
+        # nothing on PC3/PC4. Under the old hardcoded pc_indices=[0, 1] scope
+        # this feature has the highest (and only nonzero) abs-loading sum.
+        loadings[0] = [0.6, 0.55, 0.0, 0.0]
+        # Feature 2: zero on PC1/PC2 (invisible under the old [0, 1] scope) but
+        # overwhelmingly strong on PC4 (index 3) — a PC the old hardcoded scope
+        # can never see. Its total abs-loading sum (1.3) exceeds feature 0's
+        # (1.15) only once pc_indices spans all 4 retained PCs.
+        loadings[2] = [0.0, 0.0, 0.0, 1.3]
+
+        eigenvalues = np.array([5.0, 4.0, 3.0, 2.0])
+        pca_results = {
+            "loadings": loadings,
+            "eigenvalues": eigenvalues,
+            "cumulative_variance_ratio": np.cumsum(eigenvalues / eigenvalues.sum()),
+            "n_components_selected": n_pcs,
+        }
+
+        trait_columns = [f"trait_{i}" for i in range(n_features)]
+        rng = np.random.RandomState(0)
+        df = pd.DataFrame({col: rng.randn(20) for col in trait_columns})
+        umap_results = {"embedding": rng.randn(20, 2)}
+
+        fig = create_umap_colored_by_top_traits(
+            umap_results,
+            df,
+            trait_columns,
+            trait_columns,
+            pca_results,
+            n_traits=1,
+            feature_selection="top_absolute",
+        )
+
+        plotted = {ax.get_title().split("\n")[0] for ax in fig.axes if ax.get_title()}
+        assert plotted == {"trait_2"}, (
+            "Expected the PC4-dominant trait to be selected once pc_indices "
+            f"spans all retained PCs; got {plotted}"
+        )
+
+        plt.close("all")
+
+    def test_create_umap_colored_by_top_traits_extreme_spans_multiple_pcs_and_directions(
+        self,
+    ):
+        """Regression test for #207: extreme selection must span multiple PCs."""
+        from sleap_roots_analyze.visualization import create_umap_colored_by_top_traits
+        from sleap_roots_analyze.pca import select_top_features_from_pca
+
+        n_pcs = 5
+        n_traits = 6
+        pca_results, extremes, n_features = _multi_pc_extreme_pca_results(n_pcs)
+        trait_columns = [f"trait_{i}" for i in range(n_features)]
+        rng = np.random.RandomState(0)
+        df = pd.DataFrame({col: rng.randn(20) for col in trait_columns})
+        umap_results = {"embedding": rng.randn(20, 2)}
+
+        fig = create_umap_colored_by_top_traits(
+            umap_results,
+            df,
+            trait_columns,
+            trait_columns,
+            pca_results,
+            n_traits=n_traits,
+            feature_selection="extreme",
+        )
+
+        plotted = set(_plotted_trait_indices(fig, n_features))
+
+        # The pre-fix bug: plotted set == PC1's n_traits most-negative-loading
+        # indices exactly (via select_top_features_from_pca with pc_indices
+        # hardcoded to [0, 1] and a single truncating slice).
+        pc1_most_negative = select_top_features_from_pca(
+            loadings=pca_results["loadings"],
+            eigenvalues=pca_results["eigenvalues"],
+            n_features_total=n_features,
+            n_features_to_select=n_traits,
+            method="extreme",
+            pc_indices=[0, 1],
+        )[:n_traits]
+        assert not plotted.issubset(set(pc1_most_negative)), (
+            f"Plotted set {plotted} is a subset of PC1's most-negative "
+            f"extremes {pc1_most_negative} — the #207 bug has resurfaced"
+        )
+
+        pc1_neg_idx, pc1_pos_idx = 0, 1
+        assert any(
+            extremes.get(idx, (None, None))[0] not in (None, 0) for idx in plotted
+        ), f"Expected a trait from a PC other than PC1 in {plotted}"
+        assert any(
+            extremes.get(idx, (None, None))[1] == "+" for idx in plotted
+        ), f"Expected at least one positively-loaded trait in {plotted}"
+
+        plt.close("all")
+
+    def test_create_umap_colored_by_top_traits_extreme_gives_every_pc_a_representative_first(
+        self,
+    ):
+        """Every retained PC gets one trait before any PC gets a second."""
+        from sleap_roots_analyze.visualization import create_umap_colored_by_top_traits
+
+        n_pcs = 5
+        n_traits = 6  # fewer than 2 * 5 = 10 PC x direction pairs
+        pca_results, extremes, n_features = _multi_pc_extreme_pca_results(n_pcs)
+        trait_columns = [f"trait_{i}" for i in range(n_features)]
+        rng = np.random.RandomState(0)
+        df = pd.DataFrame({col: rng.randn(20) for col in trait_columns})
+        umap_results = {"embedding": rng.randn(20, 2)}
+
+        fig = create_umap_colored_by_top_traits(
+            umap_results,
+            df,
+            trait_columns,
+            trait_columns,
+            pca_results,
+            n_traits=n_traits,
+            feature_selection="extreme",
+        )
+
+        plotted = _plotted_trait_indices(fig, n_features)
+        pcs_seen_in_order = [extremes[idx][0] for idx in plotted if idx in extremes]
+
+        assert set(pcs_seen_in_order) == set(range(n_pcs)), (
+            f"Expected all {n_pcs} retained PCs represented; got PCs "
+            f"{sorted(set(pcs_seen_in_order))} from plotted traits {plotted}"
+        )
+        # No PC should repeat before every PC has appeared once.
+        first_repeat_pos = next(
+            (
+                i
+                for i, pc in enumerate(pcs_seen_in_order)
+                if pc in pcs_seen_in_order[:i]
+            ),
+            len(pcs_seen_in_order),
+        )
+        assert first_repeat_pos >= n_pcs, (
+            "A PC repeated before every retained PC contributed at least "
+            f"once: PC order was {pcs_seen_in_order}"
+        )
+
+        plt.close("all")
+
+    def test_create_umap_colored_by_top_traits_extreme_handles_fewer_distinct_traits_than_n_traits(
+        self,
+    ):
+        """Exhaustion: fewer distinct reachable traits than n_traits SHALL NOT raise."""
+        from sleap_roots_analyze.visualization import create_umap_colored_by_top_traits
+
+        pca_results, _extremes, n_features = _multi_pc_extreme_pca_results(n_pcs=1)
+        assert n_features == 4  # only 4 distinct traits ever reachable
+        trait_columns = [f"trait_{i}" for i in range(n_features)]
+        rng = np.random.RandomState(0)
+        df = pd.DataFrame({col: rng.randn(20) for col in trait_columns})
+        umap_results = {"embedding": rng.randn(20, 2)}
+
+        fig = create_umap_colored_by_top_traits(
+            umap_results,
+            df,
+            trait_columns,
+            trait_columns,
+            pca_results,
+            n_traits=10,  # more than the 4 distinct traits available
+            feature_selection="extreme",
+        )
+
+        plotted = _plotted_trait_indices(fig, n_features)
+        assert len(plotted) == n_features == len(set(plotted))
+
+        plt.close("all")
+
+    def test_create_umap_colored_by_top_traits_extreme_deduplicates_multi_pc_extreme_trait(
+        self,
+    ):
+        """A trait extreme on two PCs is plotted once; the freed slot backfills."""
+        from sleap_roots_analyze.visualization import create_umap_colored_by_top_traits
+
+        n_features = 6
+        n_pcs = 2
+        loadings = np.random.RandomState(1).uniform(
+            -0.05, 0.05, size=(n_features, n_pcs)
+        )
+        # Feature 0 is the most-negative loading on BOTH PC1 and PC2.
+        loadings[0, 0] = -0.9
+        loadings[0, 1] = -0.9
+        # Distinct second-most-negative traits per PC, so the freed slot has
+        # somewhere to go once feature 0 is claimed by the first PC in order.
+        loadings[1, 0] = -0.6
+        loadings[2, 1] = -0.6
+        loadings[3, 0] = 0.9  # PC1 most positive
+        loadings[4, 1] = 0.9  # PC2 most positive
+
+        eigenvalues = np.array([2.0, 1.0])
+        pca_results = {
+            "loadings": loadings,
+            "eigenvalues": eigenvalues,
+            "cumulative_variance_ratio": np.cumsum(eigenvalues / eigenvalues.sum()),
+            "n_components_selected": n_pcs,
+        }
+        trait_columns = [f"trait_{i}" for i in range(n_features)]
+        rng = np.random.RandomState(0)
+        df = pd.DataFrame({col: rng.randn(20) for col in trait_columns})
+        umap_results = {"embedding": rng.randn(20, 2)}
+
+        fig = create_umap_colored_by_top_traits(
+            umap_results,
+            df,
+            trait_columns,
+            trait_columns,
+            pca_results,
+            n_traits=4,
+            feature_selection="extreme",
+        )
+
+        plotted = _plotted_trait_indices(fig, n_features)
+        assert plotted.count(0) == 1, f"trait_0 plotted more than once: {plotted}"
+        # PC1 claims feature 0 first (pass order visits pc_indices in order),
+        # so PC2's negative slot is backfilled by feature 2 (its own
+        # second-most-negative), not left empty.
+        assert 2 in plotted, f"Expected PC2's backfilled negative trait in {plotted}"
+
+        plt.close("all")
+
+    def test_create_umap_colored_by_top_traits_extreme_subtitle_reports_true_source_pc(
+        self,
+    ):
+        """A trait extreme on PC2 SHALL get a "PC2+/-" subtitle, not "PC1+/-"."""
+        from sleap_roots_analyze.visualization import create_umap_colored_by_top_traits
+
+        n_pcs = 3
+        pca_results, extremes, n_features = _multi_pc_extreme_pca_results(n_pcs)
+        trait_columns = [f"trait_{i}" for i in range(n_features)]
+        rng = np.random.RandomState(0)
+        df = pd.DataFrame({col: rng.randn(20) for col in trait_columns})
+        umap_results = {"embedding": rng.randn(20, 2)}
+
+        fig = create_umap_colored_by_top_traits(
+            umap_results,
+            df,
+            trait_columns,
+            trait_columns,
+            pca_results,
+            n_traits=6,  # exactly enough for one trait per (PC, direction) pair
+            feature_selection="extreme",
+        )
+
+        # trait_2 is PC2 (0-indexed pc=1)'s most-negative loading.
+        pc_idx, direction = extremes[2]
+        assert (pc_idx, direction) == (1, "-")
+        subtitle = _plotted_subtitle(fig, 2)
+        assert subtitle.startswith(
+            "(PC2-"
+        ), f"Expected trait_2's subtitle to report PC2-, got: {subtitle!r}"
+
+        plt.close("all")
+
+    def test_create_umap_colored_by_top_traits_top_variance_matches_direct_selection(
+        self, umap_viz_results, pca_viz_dataframe, pca_viz_results
+    ):
+        """top_variance selection/PC-scoping SHALL be unaffected by the #207 fix."""
+        from sleap_roots_analyze.visualization import create_umap_colored_by_top_traits
+        from sleap_roots_analyze.pca import select_top_features_from_pca
+
+        trait_columns = [f"trait_{i}" for i in range(10)]
+        n_traits = 6
+
+        fig = create_umap_colored_by_top_traits(
+            umap_viz_results,
+            pca_viz_dataframe,
+            trait_columns,
+            trait_columns,
+            pca_viz_results,
+            n_traits=n_traits,
+            feature_selection="top_variance",
+        )
+
+        n_features = min(len(trait_columns), pca_viz_results["loadings"].shape[0])
+        expected_indices = select_top_features_from_pca(
+            loadings=pca_viz_results["loadings"],
+            eigenvalues=pca_viz_results["eigenvalues"],
+            n_features_total=n_features,
+            n_features_to_select=n_traits,
+            method="top_variance",
+            pc_indices=None,
+        )
+
+        plotted = _plotted_trait_indices(fig, n_features)
+        assert plotted == expected_indices[: len(plotted)]
 
         plt.close("all")
 

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -3011,7 +3011,6 @@ class TestPCAVisualization:
             f"extremes {pc1_most_negative} — the #207 bug has resurfaced"
         )
 
-        pc1_neg_idx, pc1_pos_idx = 0, 1
         assert any(
             extremes.get(idx, (None, None))[0] not in (None, 0) for idx in plotted
         ), f"Expected a trait from a PC other than PC1 in {plotted}"

--- a/tests/test_visualization.py
+++ b/tests/test_visualization.py
@@ -2968,6 +2968,62 @@ class TestPCAVisualization:
 
         plt.close("all")
 
+    def test_create_umap_colored_by_top_traits_top_contribution_scopes_pc_indices(
+        self,
+    ):
+        """pc_indices scoping also applies to "top_contribution" (#207).
+
+        Mirrors the "top_absolute" scoping test above, but for
+        "top_contribution", whose ranking is eigenvalue-weighted
+        (contribution = eigenvalue * loading**2) rather than a plain
+        abs-loading sum.
+        """
+        from sleap_roots_analyze.visualization import create_umap_colored_by_top_traits
+
+        n_features = 6
+        n_pcs = 4
+        loadings = np.zeros((n_features, n_pcs))
+        # Feature 0: loads only on PC1 (eigenvalue 5.0).
+        # Contribution = 5.0 * 0.6**2 = 1.8, visible under the old hardcoded
+        # pc_indices=[0, 1] scope.
+        loadings[0, 0] = 0.6
+        # Feature 2: loads only on PC4 (eigenvalue 2.0, index 3) — invisible
+        # under the old [0, 1] scope (contribution there = 0).
+        # Contribution = 2.0 * 1.0**2 = 2.0, exceeding feature 0's 1.8 only
+        # once pc_indices spans all 4 retained PCs.
+        loadings[2, 3] = 1.0
+
+        eigenvalues = np.array([5.0, 4.0, 3.0, 2.0])
+        pca_results = {
+            "loadings": loadings,
+            "eigenvalues": eigenvalues,
+            "cumulative_variance_ratio": np.cumsum(eigenvalues / eigenvalues.sum()),
+            "n_components_selected": n_pcs,
+        }
+
+        trait_columns = [f"trait_{i}" for i in range(n_features)]
+        rng = np.random.RandomState(0)
+        df = pd.DataFrame({col: rng.randn(20) for col in trait_columns})
+        umap_results = {"embedding": rng.randn(20, 2)}
+
+        fig = create_umap_colored_by_top_traits(
+            umap_results,
+            df,
+            trait_columns,
+            trait_columns,
+            pca_results,
+            n_traits=1,
+            feature_selection="top_contribution",
+        )
+
+        plotted = {ax.get_title().split("\n")[0] for ax in fig.axes if ax.get_title()}
+        assert plotted == {"trait_2"}, (
+            "Expected the PC4-dominant trait to be selected once pc_indices "
+            f"spans all retained PCs; got {plotted}"
+        )
+
+        plt.close("all")
+
     def test_create_umap_colored_by_top_traits_extreme_spans_multiple_pcs_and_directions(
         self,
     ):


### PR DESCRIPTION
## Summary

Fixes #207. `create_umap_colored_by_top_traits()` had two compounding hardcodes that made the
"UMAP colored by top traits" plot show only PC1's most-negative-loading traits for
`feature_selection_strategy: "extreme"` — the strategy used by most active viz configs —
regardless of `n_components`.

- `pc_indices` was hardcoded to `[0, 1]` for every method except `"top_variance"`, capping PC
  scope at 2. Same root-cause pattern as the still-open #203 (a different call site). Now
  scoped to all retained PCs for every method.
- For `"extreme"` specifically, `select_top_features_from_pca`'s block-ordered return
  (`[PC1_neg × n, PC1_pos × n, PC2_neg × n, ...]`) was truncated via `top_indices[:n_traits]`.
  Since `n_traits` was passed as both the per-direction-per-PC count *and* the final slice
  length, PC1's `n_traits` most-negative-loading traits alone filled the entire slice — PC1's
  positive extremes and every other PC were never shown. `"extreme"` selection is now built
  via a direction-major/PC-minor round-robin directly in `create_umap_colored_by_top_traits`
  (every retained PC's most-negative trait, then every PC's most-positive trait, then every
  PC's 2nd-most-negative, ...) so a small `n_traits` relative to PC count can't starve later
  PCs the way a PC-major ordering would.
  `select_top_features_from_pca` itself (`pca.py`) is **unchanged** —
  `pipeline/steps/pca_analysis.py` still relies on its existing block-ordered,
  per-direction-per-PC semantics, consumed unsliced.

Per-subplot subtitles now report the trait's true source PC/direction instead of always
re-deriving it from PC1's loading (only ever correct by coincidence when every trait happened
to come from PC1).

**Known limitation, called out in code comments + CHANGELOG:** a trait extreme on more than one
PC is attributed to whichever PC's round-robin turn claims it first, not necessarily its
strongest association; direction balance (both + and −) is only guaranteed once
`n_traits >= 2 * n_retained_pcs`. PC sign has no biological meaning on its own, so this is a
display-ordering artifact, not a scientific one.

**Supersession note:** #206 proposes a larger redesign (1 most-positive + 1 most-negative per
retained PC, no `n_traits` truncation at all, panel grid sized to the actual pair count). This PR
is the narrower, pragmatic fix — it does not implement that redesign. If/when #206 lands, it
subsumes this fix. Not closing #206 or #209.

## Changes

- `src/sleap_roots_analyze/visualization.py`: `create_umap_colored_by_top_traits` — PC-index
  scoping for all methods, `"extreme"` round-robin selection, subtitle source tracking,
  docstring correction.
- `tests/test_visualization.py`: 7 new tests — PC-scoping regression (via `top_absolute`),
  extreme selection spans multiple PCs/directions, fair PC representation before any PC repeats,
  exhaustion handling, cross-PC dedup + backfill, correct subtitle source, and a `top_variance`
  backward-compatibility check against a direct `select_top_features_from_pca` call.
- `tests/test_pca.py`: 1 new test confirming `select_top_features_from_pca`'s `"extreme"` method
  is unchanged (still block-ordered, still per-direction-per-PC count).
- `configs/active/viz/viz_alfalfa_gwas_wave_1_grouped.yaml`,
  `configs/active/viz/alfalfa_gwas_wave1_canola_models.yaml`: corrected comments that previously
  described the intended-but-broken behavior, and dropped an independently-inaccurate claim that
  `n_top_features` controls this plot (it doesn't — the call site hardcodes `n_traits=6`).
- `docs/CHANGELOG.md`: `[Unreleased]` → `### Fixed` entry.
- `openspec/changes/fix-umap-top-traits-extreme-pc-scoping/`: proposal, delta spec, tasks —
  reviewed by a 5-agent adversarial pass before implementation (caught and fixed a real design
  bug in the original round-robin ordering: PC-major grouping would have starved later PCs
  whenever `n_traits < 2 * n_pcs`, just at a different threshold than the original bug).

## Test plan

- [x] `uv run pytest tests/test_visualization.py tests/test_pca.py` — all pass, including new
      regression tests confirmed to fail against the pre-fix code (verified via temporary
      `git stash` of the implementation commit).
- [x] `uv run pytest tests/` (full suite) — no regressions.
- [x] `uv run black --check` / `uv run ruff check` — clean.
- [x] `openspec validate fix-umap-top-traits-extreme-pc-scoping --strict` — valid.
- [x] Both edited configs still load via `load_viz_config()` (comment-only changes verified
      non-breaking).
- [x] Pre-PR self-review (5 subagents: code quality, testing/TDD, statistical rigor,
      performance/cross-platform, behavioral correctness) — no BLOCKING findings; addressed the
      IMPORTANT ones (redundant `argsort` call, unused test variable, documented the
      first-claimed-PC-attribution and direction-imbalance caveats, added a CHANGELOG note that
      active `"extreme"`-strategy configs' `umap_top_traits.png` output will regenerate
      differently).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
