### PR TITLE
CI: mypy crash-guard on exit code (#160)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,26 @@ jobs:
         shell: bash
         # pipefail is ON by default in Actions; mypy always exits non-zero while the
         # baseline holds errors, so disable it and let `filter`'s exit code (non-zero only
-        # on NEW errors) decide pass/fail.
+        # on NEW errors) decide pass/fail. That safety only holds while the baseline is
+        # non-empty though: once it's paid down to zero, a mypy crash that emits nothing
+        # looks identical to a clean run. Guard against that (issue #160) by capturing
+        # mypy's own exit code via PIPESTATUS and failing on anything outside {0, 1}
+        # (0=clean, 1=errors reported — mypy's documented convention; anything else is a
+        # fatal/usage/internal error or a signal kill). PIPESTATUS must be copied into a
+        # plain array in the very next statement — reading its elements as two separate
+        # statements loses the second one, since bash resets PIPESTATUS after every
+        # subsequent simple command.
         run: |
           set +o pipefail
           uv run mypy src/sleap_roots_analyze | uv run mypy-baseline filter --baseline-path .mypy-baseline.txt
+          status=("${PIPESTATUS[@]}")
+          mypy_status="${status[0]}"
+          filter_status="${status[1]}"
+          if [[ "$mypy_status" != "0" && "$mypy_status" != "1" ]]; then
+            echo "::error::mypy exited with fatal status $mypy_status (expected 0=clean or 1=errors-found); treating as a crash, not a baseline diff."
+            exit 1
+          fi
+          exit "$filter_status"
 
   reproducibility-gates:
     name: Reproducibility gates (determinism)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -130,6 +130,14 @@ summary glyph can raise `UnicodeEncodeError` locally — prefix the command with
 
 Strictness starts lenient (one knob today) and is tightened over time in small follow-up PRs.
 
+CI also guards against mypy itself crashing (issue #160): a fatal/internal-error exit (anything
+other than mypy's documented `0`=clean or `1`=errors-reported) fails the job immediately, with a
+distinct `mypy exited with fatal status ...` annotation, regardless of what `mypy-baseline filter`
+reports. This matters most once the baseline reaches zero — without it, a silent crash would look
+identical to a clean run. The local commands above intentionally don't carry this guard: a local
+terminal already shows a crash directly (non-zero `$?`, stderr output), so there's nothing to
+disambiguate.
+
 ### 6. Update Documentation
 
 - Add docstrings to all functions

--- a/openspec/changes/add-mypy-crash-guard/design.md
+++ b/openspec/changes/add-mypy-crash-guard/design.md
@@ -28,12 +28,28 @@ nothing is indistinguishable, to `filter`, from a clean run — and once the bas
 
 ## Decisions
 
-- **Decision: read mypy's exit code from bash's `PIPESTATUS` array, not a separate invocation.**
-  The step already runs `shell: bash` and already disables `pipefail`, so `${PIPESTATUS[0]}`
-  (mypy) and `${PIPESTATUS[1]}` (`mypy-baseline filter`) are available immediately after the
-  pipeline runs, with no extra process. Fail with a clear `::error::` log line when
-  `PIPESTATUS[0]` is not `0` or `1`; otherwise propagate `PIPESTATUS[1]` as the step's exit code,
-  preserving today's behavior exactly.
+- **Decision: read mypy's exit code from bash's `PIPESTATUS` array, captured atomically in a
+  single statement, not a separate invocation.**
+  The step already runs `shell: bash` and already disables `pipefail`. `PIPESTATUS` reflects only
+  the *most recently executed* pipeline, so it must be copied into a plain array **in the very
+  next statement** after the pipe — any intervening command (even a bare assignment referencing
+  only one element, or an `if [[ ... ]]` test) silently resets it first. Verified empirically:
+  reading `${PIPESTATUS[0]}` and `${PIPESTATUS[1]}` as two separate assignment lines loses the
+  second value. The safe form:
+  ```bash
+  set +o pipefail
+  uv run mypy src/sleap_roots_analyze | uv run mypy-baseline filter --baseline-path .mypy-baseline.txt
+  status=("${PIPESTATUS[@]}")
+  mypy_status="${status[0]}"
+  filter_status="${status[1]}"
+  if [[ "$mypy_status" != "0" && "$mypy_status" != "1" ]]; then
+    echo "::error::mypy exited with fatal status $mypy_status (expected 0=clean or 1=errors-found); treating as a crash, not a baseline diff."
+    exit 1
+  fi
+  exit "$filter_status"
+  ```
+  The step must end with an explicit `exit "$filter_status"` — a `run:` step's reported exit code
+  is its *last executed command's* status, not automatically tied to array contents.
   - Alternative considered: redirect mypy to a temp file, check `$?`, then `cat` the file into
     `filter`. Equivalent result, but adds a throwaway file and an extra step for no behavioral
     gain over `PIPESTATUS`, which the job's shell already supports.
@@ -42,9 +58,10 @@ nothing is indistinguishable, to `filter`, from a clean run — and once the bas
     single invocation already happening.
 - **Decision: treat exactly `{0, 1}` as "mypy ran"; anything else fails immediately.**
   mypy's documented convention is `0` = no errors, `1` = errors reported, and non-`0`/`1` (in
-  practice `2`) for fatal/usage errors and unexpected crashes. Matching on the two expected codes
-  (rather than denylisting `2` specifically) also catches other unexpected exits (e.g. a signal
-  kill) without needing to enumerate them.
+  practice `2` for fatal/usage errors, or `128+signal` e.g. `137` for a signal kill such as OOM)
+  for crashes. Matching on the two expected codes (rather than denylisting `2` specifically) also
+  catches signal kills and other unexpected exits without needing to enumerate them. Verified:
+  `uv run` itself failing to start `mypy` (e.g. a broken env) also surfaces outside `{0, 1}`.
 
 ## Risks / Trade-offs
 
@@ -53,14 +70,35 @@ nothing is indistinguishable, to `filter`, from a clean run — and once the bas
   allowed set, not a redesign.
 - **`PIPESTATUS` is bash-specific**, not POSIX `sh`. The step already declares `shell: bash`
   explicitly (see the existing step), so this is already assumed, not newly introduced.
+- **GitHub Actions' `shell: bash` runs with `-e` (errexit) on by default, in addition to
+  `pipefail`** (only `pipefail` is disabled here). When the pipeline's reported status (`filter`'s,
+  since `pipefail` is off) is non-zero, `errexit` aborts the script right at the pipe line, before
+  the guard's `status=(...)` capture or its `::error::` diagnostic ever runs. The job still ends
+  up correctly red in that case (errexit propagates the same non-zero exit), so this is not a
+  false-green risk — but it means the guard's distinguishing crash message can silently not
+  appear whenever a crash also happens to make `filter` itself exit non-zero on garbled/partial
+  input (as opposed to cleanly reporting `new: 0` on empty input). Accepted: the pass/fail outcome
+  is still correct; only the diagnostic clarity is reduced in that sub-case.
+- **Local reproduction commands in `docs/CONTRIBUTING.md` intentionally do not carry the guard.**
+  A local terminal already shows a crash directly (stderr, non-zero `$?`), so the guard's value is
+  CI-specific; the doc update should say so explicitly rather than leaving the two commands to
+  silently diverge.
 
 ## Migration Plan
 
-1. Add the `PIPESTATUS` check to the `type-check` job's mypy step.
+1. Add the `PIPESTATUS` check (atomic-capture form above) to the `type-check` job's mypy step.
 2. Confirm the three existing cases (clean tree, baseline-covered errors, new untyped def) still
-   pass/fail exactly as before.
-3. Confirm a simulated fatal exit (e.g. temporarily point mypy at a bogus `--config-file`) fails
-   the job even when piped through a `filter` that would otherwise report `new: 0`.
-4. Document the guard in `docs/CONTRIBUTING.md`.
+   pass/fail exactly as before — run the exact `run:` block locally against the real
+   `.mypy-baseline.txt` for the first two, and against a scratch introduced untyped def for the
+   third.
+3. Confirm a simulated fatal exit fails the job even when piped through a `filter` that would
+   otherwise report `new: 0`: point mypy at a bogus `--config-file` (forces exit `2`) and pipe
+   through `filter` against an **empty scratch baseline file**, not the repo's real (non-empty)
+   `.mypy-baseline.txt` — against the real baseline, `filter` already fails today regardless of
+   this change (pre-existing errors read back as "fixed"), so that case doesn't exercise the
+   false-green path this guard closes.
+4. Document the guard in `docs/CONTRIBUTING.md`, noting local repro intentionally stays unguarded.
+5. After pushing, confirm the real `type-check` job (and the unrelated lint/reproducibility/
+   serialization jobs, which this change doesn't touch) go green via `gh pr checks`.
 
 Rollback: revert the step to the current two-line `set +o pipefail` form.

--- a/openspec/changes/add-mypy-crash-guard/design.md
+++ b/openspec/changes/add-mypy-crash-guard/design.md
@@ -1,0 +1,66 @@
+## Context
+
+`.github/workflows/ci.yml`'s `type-check` job runs:
+
+```bash
+set +o pipefail
+uv run mypy src/sleap_roots_analyze | uv run mypy-baseline filter --baseline-path .mypy-baseline.txt
+```
+
+`pipefail` is disabled so the step's exit code is `filter`'s, not mypy's — mypy always exits
+non-zero while the baseline holds errors, so without this the job would never pass. The trade-off,
+flagged as a tracked-but-unticketed risk in #158's design.md, is that mypy's own exit code is now
+invisible to the job: whatever mypy does, `filter` only ever sees stdout. A crash that prints
+nothing is indistinguishable, to `filter`, from a clean run — and once the baseline is empty
+(`new: 0` either way), the job can't tell them apart.
+
+## Goals / Non-Goals
+
+- Goals
+  - Fail CI on a fatal/internal mypy exit (`2`), independent of the baseline's current size.
+  - Leave every currently-passing/failing case (clean run, baseline-covered errors, new untyped
+    def) exactly as it behaves today.
+  - Keep the fix inside the existing job step; no new dependency, script, or job.
+- Non-Goals
+  - Auditing `mypy-baseline` itself for correctness — it's a maintained third-party tool.
+  - Distinguishing *which* fatal error occurred (config vs. crash vs. OOM) beyond surfacing mypy's
+    raw stderr/exit code in the log.
+
+## Decisions
+
+- **Decision: read mypy's exit code from bash's `PIPESTATUS` array, not a separate invocation.**
+  The step already runs `shell: bash` and already disables `pipefail`, so `${PIPESTATUS[0]}`
+  (mypy) and `${PIPESTATUS[1]}` (`mypy-baseline filter`) are available immediately after the
+  pipeline runs, with no extra process. Fail with a clear `::error::` log line when
+  `PIPESTATUS[0]` is not `0` or `1`; otherwise propagate `PIPESTATUS[1]` as the step's exit code,
+  preserving today's behavior exactly.
+  - Alternative considered: redirect mypy to a temp file, check `$?`, then `cat` the file into
+    `filter`. Equivalent result, but adds a throwaway file and an extra step for no behavioral
+    gain over `PIPESTATUS`, which the job's shell already supports.
+  - Alternative considered: re-run `mypy` a second time without the pipe just to get its exit
+    code. Doubles mypy's runtime for no benefit — `PIPESTATUS` gets the same information from the
+    single invocation already happening.
+- **Decision: treat exactly `{0, 1}` as "mypy ran"; anything else fails immediately.**
+  mypy's documented convention is `0` = no errors, `1` = errors reported, and non-`0`/`1` (in
+  practice `2`) for fatal/usage errors and unexpected crashes. Matching on the two expected codes
+  (rather than denylisting `2` specifically) also catches other unexpected exits (e.g. a signal
+  kill) without needing to enumerate them.
+
+## Risks / Trade-offs
+
+- **A legitimate future mypy exit code outside `{0, 1}` could false-positive.** Unlikely — this is
+  mypy's own documented contract — but if it ever happens, the fix is a one-line change to the
+  allowed set, not a redesign.
+- **`PIPESTATUS` is bash-specific**, not POSIX `sh`. The step already declares `shell: bash`
+  explicitly (see the existing step), so this is already assumed, not newly introduced.
+
+## Migration Plan
+
+1. Add the `PIPESTATUS` check to the `type-check` job's mypy step.
+2. Confirm the three existing cases (clean tree, baseline-covered errors, new untyped def) still
+   pass/fail exactly as before.
+3. Confirm a simulated fatal exit (e.g. temporarily point mypy at a bogus `--config-file`) fails
+   the job even when piped through a `filter` that would otherwise report `new: 0`.
+4. Document the guard in `docs/CONTRIBUTING.md`.
+
+Rollback: revert the step to the current two-line `set +o pipefail` form.

--- a/openspec/changes/add-mypy-crash-guard/proposal.md
+++ b/openspec/changes/add-mypy-crash-guard/proposal.md
@@ -1,0 +1,38 @@
+## Why
+
+The mypy frozen-baseline gate (#158, closes #132) runs `mypy | mypy-baseline filter` with
+`set +o pipefail`, so the job's pass/fail comes entirely from `filter`'s exit code and mypy's own
+exit code is discarded. That's safe today only because the baseline is non-empty: if mypy crashes
+(bad config, a broken import, an internal error — exit 2, little or no stdout), the baselined
+errors vanish from its output, `filter` sees them as "resolved", and CI correctly fails. But once
+the baseline is paid down to zero — the explicit end-goal of the ratchet — a crashed mypy that
+emits nothing also yields zero errors, `filter` sees `new: 0`, and CI passes: a false green with
+type checking silently disabled. This was called out as a known, unticketed hole in #158's
+`design.md` ("Crash-safety becomes a hole at zero debt"); #160 is that follow-up.
+
+## What Changes
+
+- In the `type-check` CI job (`.github/workflows/ci.yml`), capture mypy's own exit code via
+  bash's `PIPESTATUS` (rather than only `mypy-baseline filter`'s exit code) and fail the job
+  immediately — regardless of what `filter` reports — when mypy exits with anything other than
+  `0` (clean) or `1` (errors found, mypy's normal exit when errors exist). Any other code (e.g.
+  `2`, mypy's fatal/usage/internal-error exit) is treated as a crash, logged clearly, and fails
+  CI.
+- No change to behavior while the baseline is non-empty: a normal error-bearing run still exits
+  `0`/`1` from mypy and defers to `filter`'s baseline diff exactly as before.
+- Document the guard in `docs/CONTRIBUTING.md`'s existing mypy-ratchet section so a contributor
+  seeing an unfamiliar CI failure mode ("mypy crash-guard tripped") understands it's distinct
+  from a normal baseline diff failure.
+
+No bespoke exit-code-parsing script beyond the guard itself: this stays a few lines of bash in
+the existing job step, using bash's built-in `PIPESTATUS`, not a new tool or dependency.
+
+## Impact
+
+- Affected specs: `developer-tooling` (MODIFIED: Type-Check Gate)
+- Affected code:
+  - `.github/workflows/ci.yml` — extend the `type-check` job's mypy step with the exit-code guard
+  - `docs/CONTRIBUTING.md` — note the crash-guard behavior in the mypy ratchet section
+- Non-breaking: behavior is unchanged for every case CI exercises today (clean run, baseline-covered
+  errors, new untyped def). The only newly-caught case is a fatal/internal mypy exit, which
+  currently doesn't reliably fail CI once the baseline is empty.

--- a/openspec/changes/add-mypy-crash-guard/specs/developer-tooling/spec.md
+++ b/openspec/changes/add-mypy-crash-guard/specs/developer-tooling/spec.md
@@ -1,0 +1,60 @@
+## MODIFIED Requirements
+
+### Requirement: Type-Check Gate
+
+CI SHALL run `mypy` against `src/sleap_roots_analyze` on every pull request and filter its
+output through a committed baseline file so that pre-existing type errors do not block PRs
+while newly introduced type errors do. The gate SHALL run as a dedicated CI job (modeled on
+the existing reproducibility/serialization gates) so it can serve as a required status check.
+The gate SHALL use the standard `mypy-baseline` tool (no bespoke type-checking scripts). The
+mypy configuration SHALL start lenient — targeting the package only, tolerating untyped
+third-party imports, with `disallow_untyped_defs` as the single initial ratchet knob.
+
+The gate SHALL also inspect mypy's own process exit code (independent of `mypy-baseline
+filter`'s exit code) and fail CI immediately when mypy exits with any code other than `0`
+(clean) or `1` (errors reported, its normal exit whenever type errors exist) — for example a
+fatal/usage/internal-error exit (`2`). This guard SHALL apply regardless of what
+`mypy-baseline filter` reports, so that a crashed mypy invocation cannot produce a false-green
+result once the baseline reaches zero recorded errors.
+
+#### Scenario: Pre-existing type debt does not block a PR
+
+- **GIVEN** the committed `.mypy-baseline.txt` records the current set of mypy errors
+- **WHEN** a PR is opened that does not introduce new type errors
+- **THEN** the `type-check` CI job runs `mypy src/sleap_roots_analyze` piped through
+  `mypy-baseline filter`
+- **AND** the job passes because every reported error matches the baseline
+
+#### Scenario: A new untyped def fails the gate
+
+- **GIVEN** a PR adds a function (public or private) without type annotations in `src/sleap_roots_analyze`
+- **WHEN** the `type-check` CI job runs
+- **THEN** mypy reports a `disallow_untyped_defs` error that is absent from the baseline
+- **AND** `mypy-baseline filter` exits non-zero, failing CI
+- **AND** adding the missing annotations makes the job pass without editing the baseline
+
+#### Scenario: Baseline regenerates when existing debt is paid down
+
+- **GIVEN** a contributor fixes a pre-existing type error that is recorded in the baseline
+- **WHEN** they run `mypy src/sleap_roots_analyze | mypy-baseline sync` and commit the updated
+  `.mypy-baseline.txt`
+- **THEN** the baseline shrinks to reflect the resolved error
+- **AND** the gate continues to pass, having ratcheted tighter
+
+#### Scenario: A fatal mypy exit fails CI even when the baseline is empty
+
+- **GIVEN** `.mypy-baseline.txt` currently records zero errors (the ratchet's end state)
+- **WHEN** mypy itself crashes or exits fatally (exit code other than `0` or `1`) and emits no
+  parseable error output
+- **THEN** the `type-check` CI job fails on mypy's own exit code
+- **AND** it does so even though `mypy-baseline filter` would otherwise report `new: 0` on the
+  empty output and exit `0`
+
+#### Scenario: Normal error-bearing runs are unaffected by the guard
+
+- **GIVEN** mypy exits `0` (no errors) or `1` (errors reported, matching mypy's documented
+  convention)
+- **WHEN** the `type-check` CI job runs
+- **THEN** the guard takes no action beyond confirming the exit code is expected
+- **AND** the job's pass/fail outcome is determined by `mypy-baseline filter`'s exit code exactly
+  as before this change

--- a/openspec/changes/add-mypy-crash-guard/tasks.md
+++ b/openspec/changes/add-mypy-crash-guard/tasks.md
@@ -34,9 +34,10 @@
       simulated fatal mypy exit is piped through `filter` against the **real, non-empty**
       baseline — i.e. the new guard doesn't interfere with or mask the already-correct behavior
       in this case. Verified locally: `mypy_status=2 filter_status=100 step_exit=1`.
-- [ ] 2.6 After pushing, confirm via `gh pr checks` that the real `type-check` job goes green (or
+- [x] 2.6 After pushing, confirm via `gh pr checks` that the real `type-check` job goes green (or
       red, matching the local result) and that the unrelated lint/reproducibility/
-      numerical-stability/serialization jobs are unaffected.
+      numerical-stability/serialization jobs are unaffected. Confirmed on PR #218: all 10 checks
+      pass, including `Type check (mypy baseline)` (19s).
 
 ## 3. Documentation
 

--- a/openspec/changes/add-mypy-crash-guard/tasks.md
+++ b/openspec/changes/add-mypy-crash-guard/tasks.md
@@ -1,29 +1,55 @@
 ## 1. CI guard
 
-- [ ] 1.1 In `.github/workflows/ci.yml`'s `type-check` job, capture `${PIPESTATUS[0]}` (mypy) and
-      `${PIPESTATUS[1]}` (`mypy-baseline filter`) after the existing piped `run` command.
-- [ ] 1.2 Fail the step immediately (with a clear `::error::` log message) when mypy's exit code
-      is not `0` or `1`; otherwise exit with `filter`'s status, unchanged from today.
+- [x] 1.1 In `.github/workflows/ci.yml`'s `type-check` job, capture the whole `PIPESTATUS` array
+      in **one atomic statement** (`status=("${PIPESTATUS[@]}")`) immediately after the existing
+      piped `run` command, then read `mypy_status="${status[0]}"` and
+      `filter_status="${status[1]}"` from that copy — reading `PIPESTATUS[0]`/`[1]` as two
+      separate statements loses the second value (bash resets `PIPESTATUS` on every subsequent
+      simple command, including a bare assignment). See `design.md`'s Decisions section for the
+      verified-safe snippet.
+- [x] 1.2 Fail the step immediately (with a clear `::error::` log message) when `mypy_status` is
+      not `0` or `1`; otherwise end the step with an explicit `exit "$filter_status"` — a `run:`
+      step's reported exit is its last executed command's status, not automatically tied to
+      array contents.
 
-## 2. Verification
+## 2. Verification (run locally, before opening the PR, against the exact `run:` block)
 
-- [ ] 2.1 Confirm the job still passes on a clean tree (mypy exit `0`).
-- [ ] 2.2 Confirm the job still passes when all reported errors match the baseline (mypy exit `1`,
-      `filter` exit `0`).
-- [ ] 2.3 Confirm the job still fails when a new untyped def is introduced (mypy exit `1`,
-      `filter` exit non-zero).
-- [ ] 2.4 Confirm the job fails on a simulated fatal mypy exit (e.g. an invalid `--config-file` or
-      similar forced exit-`2` case) even when piped through a `filter` invocation that would
-      report `new: 0` on empty input.
+- [x] 2.1 Confirm the job still passes on a clean tree (mypy exit `0`, `filter` exit `0`).
+      Verified locally against a trivial fully-typed scratch module + empty baseline:
+      `mypy_status=0 filter_status=0 step_exit=0`.
+- [x] 2.2 Confirm the job still passes when all reported errors match the real
+      `.mypy-baseline.txt` (mypy exit `1`, `filter` exit `0`). Verified locally against the real
+      tree: `mypy_status=1 filter_status=0 step_exit=0`.
+- [x] 2.3 Confirm the job still fails when a new untyped def is introduced (mypy exit `1`,
+      `filter` exit non-zero). Verified locally with a scratch untyped def added and removed:
+      `mypy_status=1 filter_status=1 step_exit=1`.
+- [x] 2.4 Confirm the job fails on a simulated fatal mypy exit (e.g. `--config-file` pointed at a
+      nonexistent path, forcing exit `2`) piped through `filter` against an **empty scratch
+      baseline file** (not the repo's real, non-empty `.mypy-baseline.txt` — against the real
+      baseline, `filter` already fails today regardless of this change, so it wouldn't exercise
+      the false-green path being closed). Verified locally: `mypy_status=2 filter_status=0
+      step_exit=1` (crash-guard tripped) — confirms the false-green case is now closed, since
+      `filter_status=0` alone would have passed before this change.
+- [x] 2.5 Confirm the job still fails (for the pre-existing reason, not a new one) when a
+      simulated fatal mypy exit is piped through `filter` against the **real, non-empty**
+      baseline — i.e. the new guard doesn't interfere with or mask the already-correct behavior
+      in this case. Verified locally: `mypy_status=2 filter_status=100 step_exit=1`.
+- [ ] 2.6 After pushing, confirm via `gh pr checks` that the real `type-check` job goes green (or
+      red, matching the local result) and that the unrelated lint/reproducibility/
+      numerical-stability/serialization jobs are unaffected.
 
 ## 3. Documentation
 
-- [ ] 3.1 Add a short note to the "Type Checking (mypy ratchet)" section of
+- [x] 3.1 Add a short note to the "Type Checking (mypy ratchet)" section of
       `docs/CONTRIBUTING.md` explaining the crash-guard: a fatal mypy exit fails CI immediately,
-      distinct from a normal baseline-diff failure.
+      distinct from a normal baseline-diff failure. Clarify that the section's local-repro
+      commands intentionally do NOT carry the guard (a local terminal already shows a crash
+      directly), so they stay simpler than the CI step on purpose.
 
 ## 4. Validation
 
-- [ ] 4.1 Run `openspec validate add-mypy-crash-guard --strict` — must pass.
-- [ ] 4.2 Run `uv run black --check` and `uv run ruff check src/sleap_roots_analyze` — no
+- [x] 4.1 Run `openspec validate add-mypy-crash-guard --strict` — must pass. Passes.
+- [x] 4.2 Run `uv run black --check` and `uv run ruff check src/sleap_roots_analyze` — no
       regressions (this change only touches YAML/Markdown, but confirm nothing else drifted).
+      Both pass (198 files unchanged, all checks passed) — expected, since no Python source
+      changed.

--- a/openspec/changes/add-mypy-crash-guard/tasks.md
+++ b/openspec/changes/add-mypy-crash-guard/tasks.md
@@ -1,0 +1,29 @@
+## 1. CI guard
+
+- [ ] 1.1 In `.github/workflows/ci.yml`'s `type-check` job, capture `${PIPESTATUS[0]}` (mypy) and
+      `${PIPESTATUS[1]}` (`mypy-baseline filter`) after the existing piped `run` command.
+- [ ] 1.2 Fail the step immediately (with a clear `::error::` log message) when mypy's exit code
+      is not `0` or `1`; otherwise exit with `filter`'s status, unchanged from today.
+
+## 2. Verification
+
+- [ ] 2.1 Confirm the job still passes on a clean tree (mypy exit `0`).
+- [ ] 2.2 Confirm the job still passes when all reported errors match the baseline (mypy exit `1`,
+      `filter` exit `0`).
+- [ ] 2.3 Confirm the job still fails when a new untyped def is introduced (mypy exit `1`,
+      `filter` exit non-zero).
+- [ ] 2.4 Confirm the job fails on a simulated fatal mypy exit (e.g. an invalid `--config-file` or
+      similar forced exit-`2` case) even when piped through a `filter` invocation that would
+      report `new: 0` on empty input.
+
+## 3. Documentation
+
+- [ ] 3.1 Add a short note to the "Type Checking (mypy ratchet)" section of
+      `docs/CONTRIBUTING.md` explaining the crash-guard: a fatal mypy exit fails CI immediately,
+      distinct from a normal baseline-diff failure.
+
+## 4. Validation
+
+- [ ] 4.1 Run `openspec validate add-mypy-crash-guard --strict` — must pass.
+- [ ] 4.2 Run `uv run black --check` and `uv run ruff check src/sleap_roots_analyze` — no
+      regressions (this change only touches YAML/Markdown, but confirm nothing else drifted).


### PR DESCRIPTION
## Summary

- Adds a crash-guard to the `type-check` CI job's mypy step: captures mypy's own exit code via bash `PIPESTATUS` and fails CI immediately on anything outside `{0, 1}` (mypy's documented clean/errors-found convention), regardless of what `mypy-baseline filter` reports.
- Closes a known, unticketed hole flagged in #158's `design.md` ("Crash-safety becomes a hole at zero debt"): today the safety net only holds because `.mypy-baseline.txt` is non-empty (298 errors); once it's paid down to zero, a silent mypy crash (bad config, broken import, internal error) would look identical to a clean run and CI would false-green.
- Documents the guard in `docs/CONTRIBUTING.md`'s existing mypy-ratchet section.

Closes #160.

## OpenSpec

- Proposal: `openspec/changes/add-mypy-crash-guard/` (MODIFIED `Type-Check Gate` requirement in `developer-tooling` spec).
- Went through this repo's 5-agent OpenSpec review before implementation. The review caught a real, hands-on-verified BLOCKING bug in the original design: reading `PIPESTATUS[0]`/`PIPESTATUS[1]` as two separate statements loses the second value (bash resets `PIPESTATUS` after any intervening command, even a bare assignment) — the naive literal implementation would have broken CI on every currently-passing PR. Fixed by capturing the whole array atomically in one statement (`status=("${PIPESTATUS[@]}")`) before reading either element.
- `openspec validate add-mypy-crash-guard --strict` passes.

## Test plan

Verified locally against the exact `run:` block (not just reasoned about), covering every case in `tasks.md` §2:
- [x] Clean tree (mypy exit `0`) → job passes (`step_exit=0`)
- [x] Real baseline, real tree (mypy exit `1`, all errors covered) → job passes (`step_exit=0`), unchanged from today
- [x] New untyped def introduced (mypy exit `1`, new error) → job fails (`step_exit=1`), unchanged from today
- [x] Simulated fatal mypy exit (bad `--config-file`, exit `2`) against an **empty** scratch baseline → job fails via the new crash-guard (`step_exit=1`); confirmed this is exactly the false-green case that would have passed (`filter` alone reports `new: 0`) without this change
- [x] Simulated fatal mypy exit against the **real**, non-empty baseline → job still fails (guard fires; would also have failed via `filter`'s own logic)
- [ ] Confirm the real `type-check` job on this PR reflects the same result, and other jobs (lint, reproducibility, numerical-stability, serialization) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
