### PR TITLE
Fix #206: variance-driven PCA top-feature selection (+ #203 pc_indices scoping)

### DIFF
--- a/.mypy-baseline.txt
+++ b/.mypy-baseline.txt
@@ -4,7 +4,6 @@ src/sleap_roots_analyze/pipeline_runner.py:0: error: Incompatible types in assig
 src/sleap_roots_analyze/pipeline_runner.py:0: error: Argument 1 to "append" of "list" has incompatible type "tuple[Any, None]"; expected "tuple[Any, float]"  [arg-type]
 src/sleap_roots_analyze/pipeline_runner.py:0: error: Argument 1 to "_format_removed_traits_section" of "PipelineRunner" has incompatible type "list[tuple[str, list[tuple[Any, float]]]]"; expected "list[tuple[str, list[tuple[str, float | None]]]]"  [arg-type]
 src/sleap_roots_analyze/pipeline_runner.py:0: error: Need type annotation for "lines" (hint: "lines: list[<type>] = ...")  [var-annotated]
-src/sleap_roots_analyze/pca.py:0: error: Incompatible types in assignment (expression has type "signedinteger[_32Bit | _64Bit]", variable has type "int | None")  [assignment]
 src/sleap_roots_analyze/data_utils.py:0: error: Function is missing a type annotation  [no-untyped-def]
 src/sleap_roots_analyze/data_utils.py:0: error: Function is missing a type annotation  [no-untyped-def]
 src/sleap_roots_analyze/data_utils.py:0: error: Function is missing a type annotation  [no-untyped-def]

--- a/configs/active/viz/alfalfa_gwas_groups_1_to_6_combined.yaml
+++ b/configs/active/viz/alfalfa_gwas_groups_1_to_6_combined.yaml
@@ -28,7 +28,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/alfalfa_gwas_groups_1_to_6_combined_no_root_widths.yaml
+++ b/configs/active/viz/alfalfa_gwas_groups_1_to_6_combined_no_root_widths.yaml
@@ -22,7 +22,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: extreme
-  n_top_features: 5
 umap:
   enabled: true
   n_neighbors: 15

--- a/configs/active/viz/alfalfa_gwas_w1w2_combined.yaml
+++ b/configs/active/viz/alfalfa_gwas_w1w2_combined.yaml
@@ -20,7 +20,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/alfalfa_gwas_wave1.yaml
+++ b/configs/active/viz/alfalfa_gwas_wave1.yaml
@@ -28,7 +28,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/alfalfa_gwas_wave1_canola.yaml
+++ b/configs/active/viz/alfalfa_gwas_wave1_canola.yaml
@@ -28,7 +28,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/alfalfa_gwas_wave1_canola_models.yaml
+++ b/configs/active/viz/alfalfa_gwas_wave1_canola_models.yaml
@@ -55,14 +55,14 @@ pca:
   # "top_variance" = select traits with highest total variance contribution
   feature_selection_strategy: "extreme"
 
-  # Number of traits to select using the strategy above, for PCAAnalysisStep's
-  # metadata/top_features output only. For "extreme" strategy: 5 means 5 per
-  # direction per PC (can select many traits).
-  # NOTE: this does NOT control the "UMAP colored by top traits" plot — that
+  # NOTE: "extreme" always selects exactly 1 most-positive and 1
+  # most-negative loading trait per retained PC for PCAAnalysisStep's
+  # metadata/top_features output — n_top_features is not read for this
+  # strategy (see PCAConfig.n_top_features docstring).
+  # This also does NOT control the "UMAP colored by top traits" plot — that
   # plot always shows 6 traits (n_traits is hardcoded in
   # GenerateStaticFiguresStep), round-robin distributed across all retained
   # PCs and both loading directions.
-  n_top_features: 5
 
 umap:
   # Enable UMAP dimensionality reduction (recommended for n ≥ 15)

--- a/configs/active/viz/amaranth_tis108_exp1.yaml
+++ b/configs/active/viz/amaranth_tis108_exp1.yaml
@@ -30,7 +30,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/canola_diversity_screen_qc.yaml
+++ b/configs/active/viz/canola_diversity_screen_qc.yaml
@@ -27,7 +27,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: extreme
-  n_top_features: 5
 umap:
   enabled: true
   n_neighbors: 15

--- a/configs/active/viz/emily_shane_pennycress_2026_02_09.yaml
+++ b/configs/active/viz/emily_shane_pennycress_2026_02_09.yaml
@@ -28,7 +28,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/emily_shane_soybean_2026_01_15.yaml
+++ b/configs/active/viz/emily_shane_soybean_2026_01_15.yaml
@@ -28,7 +28,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/emily_shane_soybean_2026_03_03.yaml
+++ b/configs/active/viz/emily_shane_soybean_2026_03_03.yaml
@@ -26,7 +26,6 @@ pca:
   n_components: 0.95
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/emily_shane_soybean_2026_03_03_grouped.yaml
+++ b/configs/active/viz/emily_shane_soybean_2026_03_03_grouped.yaml
@@ -26,7 +26,6 @@ pca:
   n_components: 0.95
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/giftol_pennycress_s32_2026_05_11.yaml
+++ b/configs/active/viz/giftol_pennycress_s32_2026_05_11.yaml
@@ -28,7 +28,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/javier_ttc_salk_soybean.yaml
+++ b/configs/active/viz/javier_ttc_salk_soybean.yaml
@@ -28,7 +28,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/javier_ttc_salk_soybean_brightness.yaml
+++ b/configs/active/viz/javier_ttc_salk_soybean_brightness.yaml
@@ -29,7 +29,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/javier_ttc_salk_soybean_full_experiment_9wave.yaml
+++ b/configs/active/viz/javier_ttc_salk_soybean_full_experiment_9wave.yaml
@@ -30,7 +30,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/javier_ttc_salk_soybean_full_experiment_9wave_per_wave.yaml
+++ b/configs/active/viz/javier_ttc_salk_soybean_full_experiment_9wave_per_wave.yaml
@@ -32,7 +32,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/shree_weep_soybean.yaml
+++ b/configs/active/viz/shree_weep_soybean.yaml
@@ -28,7 +28,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/suyash_arabidopsis_pgm1_pac_2026_05_22.yaml
+++ b/configs/active/viz/suyash_arabidopsis_pgm1_pac_2026_05_22.yaml
@@ -35,7 +35,6 @@ pca:
 
   feature_selection_strategy: "extreme"
 
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/suyash_arabidopsis_pgm1_pac_2026_05_22.yaml
+++ b/configs/active/viz/suyash_arabidopsis_pgm1_pac_2026_05_22.yaml
@@ -35,7 +35,6 @@ pca:
 
   feature_selection_strategy: "extreme"
 
-
 umap:
   enabled: true
 

--- a/configs/active/viz/turface_alfalfa_gwas.yaml
+++ b/configs/active/viz/turface_alfalfa_gwas.yaml
@@ -20,7 +20,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz/viz_alfalfa_gwas_wave_1_grouped.yaml
+++ b/configs/active/viz/viz_alfalfa_gwas_wave_1_grouped.yaml
@@ -26,18 +26,18 @@ statistics:
   alpha: 0.05
 
 # PCA configuration
-# feature_selection_strategy "extreme" selects the traits with the most extreme
-# positive and negative loadings per PC. n_top_features controls how many are
-# selected per extreme direction per PC for PCAAnalysisStep's metadata/top_features
-# output only — it does NOT control the "UMAP colored by top traits" plot, which
-# always shows 6 traits (n_traits is hardcoded in GenerateStaticFiguresStep),
-# round-robin distributed across all retained PCs and both loading directions.
+# feature_selection_strategy "extreme" always selects exactly 1 most-positive
+# and 1 most-negative loading trait per retained PC for PCAAnalysisStep's
+# metadata/top_features output — n_top_features is not read for this strategy
+# (see PCAConfig.n_top_features docstring). It does NOT control the "UMAP
+# colored by top traits" plot, which always shows 6 traits (n_traits is
+# hardcoded in GenerateStaticFiguresStep), round-robin distributed across all
+# retained PCs and both loading directions.
 # pca_biplot_top_features (in static_viz) independently controls biplot arrow count.
 pca:
   n_components: 0.95
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5            # 5 extreme traits per direction per PC (PCA metadata)
 
 umap:
   enabled: true

--- a/configs/active/viz/viz_cylinder_edpie.yaml
+++ b/configs/active/viz/viz_cylinder_edpie.yaml
@@ -58,14 +58,13 @@ statistics:
   alpha: 0.05
 
 # PCA configuration (matches notebook: trait_viz_cylinder_20251105.ipynb, Cell 6)
-# Note: n_top_features controls how many features are selected during PCA analysis.
-# For "extreme" strategy, this is the count per extreme (top + bottom).
+# Note: "extreme" always selects exactly 1 most-positive and 1 most-negative
+# loading trait per retained PC — n_top_features is not read for this strategy.
 # See static_viz.pca_biplot_top_features for display settings.
 pca:
   n_components: 0.75             # Keep components explaining 75% variance (PCA_EXPLAINED_VARIANCE_THRESHOLD)
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 1              # 1 feature per extreme = 2 features per PC
 
 # UMAP configuration (disabled by default)
 umap:
@@ -127,7 +126,8 @@ static_viz:
   create_heritability_plots: true
   create_genotype_comparisons: true
 
-  # PCA biplot feature control - matches pca.n_top_features for extreme strategy
+  # PCA biplot feature control - independent of pca.n_top_features, which is
+  # not read for "extreme" (see the pca: block comment above)
   pca_biplot_top_features: 1
 
   # Genotype highlighting (from notebook: trait_viz_cylinder_20251105.ipynb, Cell 7)

--- a/configs/active/viz/viz_field_2024_clean.yaml
+++ b/configs/active/viz/viz_field_2024_clean.yaml
@@ -50,8 +50,7 @@ statistics:
 pca:
   n_components: 0.75             # Keep components explaining 75% variance
   standardize: true
-  feature_selection_strategy: "extreme"  # Show extreme loadings
-  n_top_features: 1              # Top features for biplot
+  feature_selection_strategy: "extreme"  # 1 most-positive + 1 most-negative trait per retained PC (n_top_features not read)
 
 # UMAP configuration (disabled by default)
 umap:

--- a/configs/active/viz/viz_root_coring.yaml
+++ b/configs/active/viz/viz_root_coring.yaml
@@ -50,8 +50,7 @@ statistics:
 pca:
   n_components: 0.75             # Keep components explaining 75% variance (matches notebook)
   standardize: true
-  feature_selection_strategy: "extreme"  # Matches notebook
-  n_top_features: 1              # Matches N_TOP_FEATURES_BIPLOT
+  feature_selection_strategy: "extreme"  # 1 most-positive + 1 most-negative trait per retained PC (n_top_features not read)
 
 # UMAP configuration (disabled by default, matching notebook parameters)
 umap:

--- a/configs/active/viz/viz_turface_150genotypes.yaml
+++ b/configs/active/viz/viz_turface_150genotypes.yaml
@@ -46,7 +46,6 @@ pca:
   n_components: 0.80             # Keep components explaining 80% variance (matches notebook)
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 1
 
 # UMAP configuration (matching notebook parameters)
 umap:

--- a/configs/active/viz/viz_turface_19genotypes.yaml
+++ b/configs/active/viz/viz_turface_19genotypes.yaml
@@ -38,14 +38,13 @@ statistics:
   alpha: 0.05
 
 # PCA configuration
-# Note: n_top_features controls how many features are selected during PCA analysis.
-# For "extreme" strategy, this is the count per extreme (top + bottom), so 1 means
-# 2 features total per PC. See static_viz.pca_biplot_top_features for display settings.
+# Note: "extreme" always selects exactly 1 most-positive and 1 most-negative
+# loading trait per retained PC — n_top_features is not read for this
+# strategy. See static_viz.pca_biplot_top_features for display settings.
 pca:
   n_components: 0.95             # Keep components explaining 95% variance
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 1              # 1 feature per extreme = 2 features per PC
 
 # UMAP configuration
 umap:
@@ -91,9 +90,9 @@ adaptive_sizing:
   max_height: 16.0
 
 # Static visualization settings
-# Note: pca_biplot_top_features controls how many feature arrows are shown on the
-# PCA biplot. This is separate from pca.n_top_features (analysis). Set to match
-# the intended display (e.g., 1 for extreme strategy shows 1 arrow per extreme).
+# Note: pca_biplot_top_features controls how many feature arrows are shown on
+# the PCA biplot. This is independent of pca.n_top_features, which is not
+# read for "extreme" (see the pca: block comment above).
 static_viz:
   enabled: true
   formats:
@@ -107,7 +106,7 @@ static_viz:
   create_trait_correlations: true
   create_heritability_plots: true
   create_genotype_comparisons: true
-  pca_biplot_top_features: 1     # Match pca.n_top_features for extreme strategy
+  pca_biplot_top_features: 1
 
   # Genotype image grid configuration (RhizoVision flatbed scanner images)
   # RhizoVision outputs: "features.png" (default), "seg.png" (segmentation)

--- a/configs/active/viz/weep_maurizio_wave1.yaml
+++ b/configs/active/viz/weep_maurizio_wave1.yaml
@@ -28,7 +28,6 @@ pca:
   n_components: 0.75
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/active/viz_turface_150genotypes.yaml
+++ b/configs/active/viz_turface_150genotypes.yaml
@@ -46,7 +46,6 @@ pca:
   n_components: 0.80             # Keep components explaining 80% variance (matches notebook)
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 1
 
 # UMAP configuration (disabled by default, matching notebook parameters)
 umap:

--- a/configs/examples/viz_comprehensive.yaml
+++ b/configs/examples/viz_comprehensive.yaml
@@ -36,14 +36,18 @@ statistics:
   alpha: 0.05
 
 # PCA configuration
-# Note: pca.n_top_features controls how many features are selected for ANALYSIS purposes
-# (e.g., identifying interesting genotypes). This is separate from visualization settings.
+# Note: n_top_features's meaning depends on feature_selection_strategy: ignored
+# entirely for "extreme" (always 1 most-positive + 1 most-negative trait per
+# retained PC); for "top_variance" (used below), a value < 1 is a cumulative
+# variance-fraction threshold and >= 1 is a fixed count, as set below; for
+# "top_absolute"/"top_contribution", a fixed count only. Affects
+# PCAAnalysisStep's metadata/top_features.csv output, not any plot directly.
 # See static_viz.pca_biplot_top_features for controlling biplot arrow count.
 pca:
   n_components: 0.95
   standardize: true
   feature_selection_strategy: "top_variance"
-  n_top_features: 15  # Features used for analysis (e.g., interesting genotype identification)
+  n_top_features: 15  # Fixed count (>= 1) of top features by variance contribution
 
 # UMAP configuration (ENABLED)
 umap:
@@ -98,9 +102,8 @@ adaptive_sizing:
 
 # Static visualization settings (ALL ENABLED)
 # Note: pca_biplot_top_features controls how many feature arrows appear on the PCA biplot.
-# This is separate from pca.n_top_features (analysis). For "extreme" selection strategies,
-# set this to match the desired per-extreme count (e.g., 1 shows the most extreme feature
-# in each direction per PC, giving up to 4 total arrows for 2 PCs).
+# This is independent of pca.n_top_features (analysis), which is not read at
+# all when pca.feature_selection_strategy is "extreme".
 static_viz:
   enabled: true
   formats:

--- a/configs/examples/viz_minimal.yaml
+++ b/configs/examples/viz_minimal.yaml
@@ -33,13 +33,15 @@ statistics:
   alpha: 0.05
 
 # PCA configuration
-# Note: pca.n_top_features controls analysis features, separate from biplot display.
+# Note: n_top_features's meaning depends on feature_selection_strategy —
+# ignored entirely for "extreme"; for "top_variance" (used below), a value
+# < 1 is a cumulative variance-fraction threshold and >= 1 is a fixed count.
 # See static_viz.pca_biplot_top_features for controlling biplot arrow count.
 pca:
   n_components: 0.95
   standardize: true
   feature_selection_strategy: "top_variance"
-  n_top_features: 5  # Fewer features for speed (analysis only)
+  n_top_features: 5  # Fewer features for speed (fixed count)
 
 # UMAP configuration (DISABLED)
 umap:

--- a/configs/examples/viz_publication.yaml
+++ b/configs/examples/viz_publication.yaml
@@ -34,14 +34,18 @@ statistics:
   alpha: 0.05
 
 # PCA configuration
-# Note: pca.n_top_features controls how many features are selected for ANALYSIS purposes
-# (e.g., identifying interesting genotypes). This is separate from visualization settings.
+# Note: n_top_features's meaning depends on feature_selection_strategy: ignored
+# entirely for "extreme" (always 1 most-positive + 1 most-negative trait per
+# retained PC); for "top_variance" (used below), a value < 1 is a cumulative
+# variance-fraction threshold and >= 1 is a fixed count, as set below; for
+# "top_absolute"/"top_contribution", a fixed count only. Affects
+# PCAAnalysisStep's metadata/top_features.csv output, not any plot directly.
 # See static_viz.pca_biplot_top_features for controlling biplot arrow count.
 pca:
   n_components: 0.95
   standardize: true
   feature_selection_strategy: "top_variance"
-  n_top_features: 10  # Features used for analysis (e.g., interesting genotype identification)
+  n_top_features: 10  # Fixed count (>= 1) of top features by variance contribution
 
 # UMAP configuration (optional for publications)
 umap:
@@ -83,9 +87,8 @@ adaptive_sizing:
 
 # Static visualization settings (HIGH QUALITY)
 # Note: pca_biplot_top_features controls how many feature arrows appear on the PCA biplot.
-# This is separate from pca.n_top_features (analysis). For "extreme" selection strategies,
-# set this to match the desired per-extreme count (e.g., 1 shows the most extreme feature
-# in each direction per PC, giving up to 4 total arrows for 2 PCs).
+# This is independent of pca.n_top_features (analysis), which is not read at
+# all when pca.feature_selection_strategy is "extreme".
 static_viz:
   enabled: true
   formats:

--- a/configs/examples/viz_standard.yaml
+++ b/configs/examples/viz_standard.yaml
@@ -34,14 +34,18 @@ statistics:
   alpha: 0.05
 
 # PCA configuration
-# Note: pca.n_top_features controls how many features are selected for ANALYSIS purposes
-# (e.g., identifying interesting genotypes). This is separate from visualization settings.
+# Note: n_top_features's meaning depends on feature_selection_strategy: ignored
+# entirely for "extreme" (always 1 most-positive + 1 most-negative trait per
+# retained PC); for "top_variance" (used below), a value < 1 is a cumulative
+# variance-fraction threshold and >= 1 is a fixed count, as set below; for
+# "top_absolute"/"top_contribution", a fixed count only. Affects
+# PCAAnalysisStep's metadata/top_features.csv output, not any plot directly.
 # See static_viz.pca_biplot_top_features for controlling biplot arrow count.
 pca:
   n_components: 0.95  # Keep components explaining 95% variance
   standardize: true
   feature_selection_strategy: "top_variance"
-  n_top_features: 10  # Features used for analysis (e.g., interesting genotype identification)
+  n_top_features: 10  # Fixed count (>= 1) of top features by variance contribution
 
 # UMAP configuration (disabled by default)
 umap:
@@ -88,9 +92,8 @@ adaptive_sizing:
 
 # Static visualization settings
 # Note: pca_biplot_top_features controls how many feature arrows appear on the PCA biplot.
-# This is separate from pca.n_top_features (analysis). For "extreme" selection strategies,
-# set this to match the desired per-extreme count (e.g., 1 shows the most extreme feature
-# in each direction per PC, giving up to 4 total arrows for 2 PCs).
+# This is independent of pca.n_top_features (analysis), which is not read at
+# all when pca.feature_selection_strategy is "extreme".
 static_viz:
   enabled: true
   formats:

--- a/configs/templates/viz_template_no_images.yaml
+++ b/configs/templates/viz_template_no_images.yaml
@@ -8,9 +8,12 @@
 #   - pipeline_name
 #
 # OPTIONAL CUSTOMIZATIONS:
-#   - pca.n_top_features (default: 5 traits for UMAP coloring)
 #   - static_viz.pca_biplot_top_features (default: 1 = 2 arrows/PC for "extreme" strategy)
 #   - umap.n_neighbors (recommended: min(15, n_samples // 4))
+#
+# Note: pca.n_top_features is not read when pca.feature_selection_strategy is
+# "extreme" (used below) — that strategy always selects exactly 1
+# most-positive and 1 most-negative loading trait per retained PC.
 #
 # This template includes ALL required schema fields. Do not remove sections.
 
@@ -47,7 +50,6 @@ pca:
   n_components: 0.95
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 5
 
 umap:
   enabled: true

--- a/configs/templates/viz_template_with_images.yaml
+++ b/configs/templates/viz_template_with_images.yaml
@@ -9,9 +9,12 @@
 #   - pipeline_name
 #
 # OPTIONAL CUSTOMIZATIONS:
-#   - pca.n_top_features (default: 5 traits for UMAP coloring)
 #   - static_viz.pca_biplot_top_features (default: 1 = 2 arrows/PC for "extreme" strategy)
 #   - umap.n_neighbors (recommended: min(15, n_samples // 4))
+#
+# Note: pca.n_top_features is not read when pca.feature_selection_strategy is
+# "extreme" (used below) — that strategy always selects exactly 1
+# most-positive and 1 most-negative loading trait per retained PC.
 #
 # This template includes ALL required schema fields. Do not remove sections.
 
@@ -60,14 +63,12 @@ pca:
   standardize: true
 
   # Feature selection strategy: "extreme" or "top_variance"
-  # "extreme" = select traits with most extreme positive AND negative PC loadings
-  # "top_variance" = select traits with highest total variance contribution
+  # "extreme" = always selects 1 most-positive + 1 most-negative loading trait
+  #   per retained PC; n_top_features is not read for this strategy
+  # "top_variance" = select traits with highest total variance contribution;
+  #   n_top_features < 1 is a cumulative-variance-fraction threshold, >= 1 is
+  #   a fixed count
   feature_selection_strategy: "extreme"
-
-  # Number of traits to select using the strategy above (for UMAP coloring and metadata)
-  # For "extreme" strategy: 5 means 5 per direction per PC (can select many traits)
-  # These are the traits that will be used to color UMAP plots
-  n_top_features: 5
 
 umap:
   # Enable UMAP dimensionality reduction (recommended for n ≥ 15)

--- a/configs/viz_field_2024_clean.yaml
+++ b/configs/viz_field_2024_clean.yaml
@@ -50,8 +50,7 @@ statistics:
 pca:
   n_components: 0.75             # Keep components explaining 75% variance
   standardize: true
-  feature_selection_strategy: "extreme"  # Show extreme loadings
-  n_top_features: 1              # Top features for biplot
+  feature_selection_strategy: "extreme"  # 1 most-positive + 1 most-negative trait per retained PC (n_top_features not read)
 
 # UMAP configuration (disabled by default)
 umap:

--- a/configs/viz_root_coring.yaml
+++ b/configs/viz_root_coring.yaml
@@ -50,8 +50,7 @@ statistics:
 pca:
   n_components: 0.75             # Keep components explaining 75% variance (matches notebook)
   standardize: true
-  feature_selection_strategy: "extreme"  # Matches notebook
-  n_top_features: 1              # Matches N_TOP_FEATURES_BIPLOT
+  feature_selection_strategy: "extreme"  # 1 most-positive + 1 most-negative trait per retained PC (n_top_features not read)
 
 # UMAP configuration (disabled by default, matching notebook parameters)
 umap:

--- a/configs/viz_turface_150genotypes.yaml
+++ b/configs/viz_turface_150genotypes.yaml
@@ -46,7 +46,6 @@ pca:
   n_components: 0.80             # Keep components explaining 80% variance (matches notebook)
   standardize: true
   feature_selection_strategy: "extreme"
-  n_top_features: 1
 
 # UMAP configuration (disabled by default, matching notebook parameters)
 umap:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -239,9 +239,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `validate_qc_config()`/`validate_viz_config()` now reject a
   `n_top_features < 1` for `"top_absolute"`/`"top_contribution"` (which
   still require a plain count) and reject a non-whole-number
-  `n_top_features >= 1` for every strategy except `"extreme"`. The ~28
-  active configs pairing `feature_selection_strategy: "extreme"` with an
-  explicit `n_top_features` have that now-meaningless line removed.
+  `n_top_features >= 1` for every strategy except `"extreme"`. **Every**
+  active config using `feature_selection_strategy: "extreme"` (49 files,
+  not just the ones that set `n_top_features` explicitly) produces
+  different `top_features.csv` output on its next run — both because the
+  count is no longer configurable and because feature selection is now
+  correctly scoped to every retained PC instead of only PC1/PC2 (#203). The
+  28 configs that had an explicit, now-meaningless `n_top_features` line
+  under `"extreme"` have that line removed.
 - `calculate_heritability_estimates` additively returns `blup` (`dict[str, float]`) and
   `intercept` (`float`) keys per trait when its mixed model succeeds (#109) — both
   existing return shapes (plain dict, or the `remove_low_h2=True` 4-tuple) are

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -113,6 +113,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (PR #193 review).
 
 ### Fixed
+- `PCAAnalysisStep` now always passes `pc_indices=list(range(n_components))`
+  explicitly to `select_top_features_from_pca()` (#203), instead of relying
+  on that function's `[0, 1]` default. Runs configured with `pca.n_components`
+  selecting 3 or more PCs (e.g. a variance threshold like `0.75`) now scope
+  `feature_selection_strategy="extreme"`/`"top_absolute"`/`"top_contribution"`
+  selection to every retained PC for `top_features.csv` and the
+  `top_features` metadata list, instead of silently only ever considering
+  PC1/PC2 regardless of how many components were actually retained.
 - `ReduceTraitRedundancyStep`'s `files_generated` type annotations now match its
   runtime `Path` values (#161): `execute()`'s and `_cluster_experiment()`'s
   `files_generated` locals are annotated `List[Path]`, and
@@ -212,6 +220,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `remove_low_h2=False` (PR #193 review).
 
 ### Changed
+- **BREAKING**: `pca.n_top_features` no longer controls a plain,
+  hand-picked count for `feature_selection_strategy="extreme"` (#206).
+  `PCAAnalysisStep` now always selects exactly 1 most-positive-loading and 1
+  most-negative-loading trait per retained PC for this strategy — the
+  field is not read at all, and a `logger.info()` notice fires when it is
+  set alongside `"extreme"`. `n_top_features` also changes type from `int`
+  to `float`: for `feature_selection_strategy="top_variance"`, a value
+  `< 1` is now a cumulative-variance-fraction threshold (mirroring
+  `pca.n_components`'s existing `< 1` = ratio / `>= 1` = count convention),
+  resolved via the new `select_n_features_by_variance()` helper
+  (`pca.py`); a value `>= 1` preserves the existing fixed-count behavior.
+  `validate_qc_config()`/`validate_viz_config()` now reject a
+  `n_top_features < 1` for `"top_absolute"`/`"top_contribution"` (which
+  still require a plain count) and reject a non-whole-number
+  `n_top_features >= 1` for every strategy except `"extreme"`. The ~28
+  active configs pairing `feature_selection_strategy: "extreme"` with an
+  explicit `n_top_features` have that now-meaningless line removed.
 - `calculate_heritability_estimates` additively returns `blup` (`dict[str, float]`) and
   `intercept` (`float`) keys per trait when its mixed model succeeds (#109) — both
   existing return shapes (plain dict, or the `remove_low_h2=True` 4-tuple) are

--- a/openspec/changes/fix-pca-top-feature-selection/design.md
+++ b/openspec/changes/fix-pca-top-feature-selection/design.md
@@ -1,0 +1,363 @@
+## Context
+
+`pca.n_top_features` is read in exactly one place,
+`PCAAnalysisStep.execute()` (`pca_analysis.py:109-115`):
+
+```python
+top_feature_indices = select_top_features_from_pca(
+    loadings=pca_results["loadings"],
+    eigenvalues=pca_results["eigenvalues"],
+    n_features_total=len(feature_names),
+    n_features_to_select=config.pca.n_top_features,
+    method=config.pca.feature_selection_strategy,
+)
+```
+
+No `pc_indices` is passed, so `select_top_features_from_pca()` defaults to
+`[0, 1]` (#203). `n_top_features` itself is a hand-picked integer with no
+principled basis — every active config that uses
+`feature_selection_strategy: "extreme"` sets a different value (`1` or `5`),
+and #206 asks: is there a non-arbitrary alternative?
+
+For `"extreme"`, yes: "1 most-positive-loading trait + 1 most-negative-
+loading trait per retained PC" requires no count at all — it falls out of
+calling `select_top_features_from_pca(n_features_to_select=1,
+pc_indices=list(range(n_components)))`. For `"top_variance"`, the codebase
+already has a precedent for count vs. threshold: `PCAConfig.n_components`
+(`< 1` = variance-ratio threshold, `>= 1` = fixed count).
+
+## Goals / Non-Goals
+
+- Goals:
+  - Resolve #203: `pca_analysis.py` passes `pc_indices` explicitly, scoped
+    to all retained PCs.
+  - Resolve #206 Part 1: `"extreme"` selection has no arbitrary count.
+  - Resolve #206 Part 2: `"top_variance"` supports a variance-fraction
+    threshold, mirroring `n_components`'s convention.
+  - Leave `select_top_features_from_pca()`'s public signature unchanged
+    (bloommcp calls it/its siblings directly with plain-int counts for
+    unrelated purposes — `top_n_features` on `create_pca_biplot`,
+    `n_traits` on `create_umap_colored_by_top_traits`).
+- Non-Goals:
+  - Threshold support for `"top_absolute"` / `"top_contribution"` — no
+    active config uses them; deferred, and explicitly guarded against being
+    invoked with a `< 1` value so the gap is loud, not silent.
+  - Widening `pca.feature_selection_strategy`'s validation enum to accept
+    `"vector_length"` — see Decision 3.
+  - Changing `create_pca_biplot`'s `top_n_features` or
+    `static_viz.pca_biplot_top_features` — a separate, unrelated config
+    field.
+  - A step-level `PCAAnalysisStep` defense-in-depth guard mirroring
+    `FilterHeritabilityStep`'s — see Decision 3.
+
+## Decisions
+
+### Decision 1: What happens to `n_top_features` under `"extreme"`?
+
+**Chosen: document it as ignored (issue's option "b"), not a validation
+error (option "a").**
+
+Rationale:
+
+1. **Direct precedent in the same function.** `select_top_features_from_pca()`'s
+   own docstring already documents that `pc_indices` is "ignored entirely by
+   `top_variance`, which always ranks across every retained PC ... regardless
+   of what is passed here" (`pca.py:44-48`) — no runtime warning, just an
+   explicit doc contract. `n_top_features` under `"extreme"` is the same
+   shape of problem (a parameter some methods don't use) and should follow
+   the same, already-established resolution for consistency within one
+   file.
+2. **"Explicitly set" is not cleanly detectable.** Option (a) requires
+   distinguishing "the user wrote `n_top_features: 10`" from "the user
+   didn't set it and got the default of `10`" — both parse to the identical
+   dataclass value once OmegaConf resolves the config. Doing this properly
+   would mean adding raw-YAML-presence tracking (the "explicit config
+   validation" tier project.md describes for a few load-bearing fields like
+   `cleanup.max_nan_fraction`) purely to gate a warning on an otherwise
+   harmless, ignored field — disproportionate machinery for this problem.
+   A simpler value-based check (`n_top_features != default`) is worse: it
+   would misfire on every config that happens to type the same number as
+   the default.
+3. **It isn't a footgun.** Unlike the `feature_selection_strategy` enum
+   check (an invalid string breaks execution) or the new `< 1` validation
+   added in Decision 3 below (a fractional value breaks count-based
+   methods), a stale `n_top_features` value under `"extreme"` doesn't
+   produce a wrong or crashing result — it produces *no* result, cleanly,
+   because it's never read. The "no silent no-ops" precedent from #204 was
+   about a field masquerading as load-bearing while doing nothing with zero
+   documentation trail; here the ignoring is documented at the point of
+   definition.
+
+**Cheap additional safeguard, adopted after adversarial review**: although
+no validation error fires, `PCAAnalysisStep.execute()` SHALL emit a single
+`logger.info()` whenever `feature_selection_strategy == "extreme"`, stating
+plainly that `n_top_features` is not read for this method. This costs
+nothing (no explicit-vs-default detection needed — the statement is true
+unconditionally whenever `"extreme"` is selected, default or not, so there
+is no "misfire" concept to guard against) and closes the gap an adversarial
+review pass correctly identified: a config from before this change (in
+this repo, a fork, or a collaborator's local copy) that still carries a
+stale `n_top_features: 5` next to `"extreme"` will otherwise get a silently
+different `top_features.csv` with zero runtime signal, only a docstring
+nobody reads mid-run. `logger.info` (not `warnings.warn`) is chosen
+specifically so it cannot be mistaken for an error and cannot break any
+existing test that asserts on `warnings.catch_warnings()` emitting nothing
+for the zero-variance-handling paths already covered by this step.
+
+Consequence: the 28 active configs pairing `feature_selection_strategy:
+"extreme"` with an explicit `n_top_features` (27 under
+`configs/active/viz/`, plus the flat pre-reorg duplicate
+`configs/active/viz_turface_150genotypes.yaml`; verified via
+`grep -rln "n_top_features" configs/active/` intersected with
+`grep -rln 'feature_selection_strategy:.*extreme' configs/active/` — zero
+matches under `configs/active/qc/`) get that line **removed** (not merely
+left alone) as part of this change, so no config file implies a count that
+no longer exists for this method.
+
+### Decision 2: `select_n_features_by_variance()` as a new, separate helper
+
+`select_top_features_from_pca()` is a shared function — `create_pca_biplot`
+and `create_umap_colored_by_top_traits` also call it, with plain-int counts
+(`top_n_features`, `n_traits`) that are unrelated to this redesign and out
+of scope for #206. Changing `select_top_features_from_pca()`'s own
+`n_features_to_select` parameter to accept `< 1` thresholds would force
+every caller to reason about the overload, including two functions this
+issue explicitly does not touch.
+
+Instead, `select_n_features_by_variance(feature_contributions_df,
+threshold) -> int` is a new, small function that only `PCAAnalysisStep`
+calls, structurally mirroring `select_n_components()`
+(`pca.py:144-192`):
+
+```python
+def select_n_features_by_variance(feature_contributions_df, threshold):
+    if len(feature_contributions_df) == 0:
+        raise ValueError("feature_contributions_df must have at least one row")
+    cumulative = feature_contributions_df["fractional_contribution"].cumsum()
+    if threshold <= 0:
+        n = 1
+    elif cumulative.iloc[-1] >= threshold:
+        n = int(np.argmax(cumulative.to_numpy() >= threshold)) + 1
+    else:
+        n = len(feature_contributions_df)
+    return max(1, min(n, len(feature_contributions_df)))
+```
+
+(`threshold <= 0` is handled explicitly rather than left to fall out of
+`np.argmax(cumulative >= 0)`, which is technically also `0` → `n=1` for any
+non-empty, non-negative-contribution input — the explicit branch documents
+the intent rather than relying on that coincidence.)
+
+It consumes `perform_pca_analysis()`'s existing `feature_contributions`
+DataFrame (`pca.py:899-904`, already sorted descending by
+`total_contribution`, with a `fractional_contribution` column summing to 1)
+— no new computation, just a cumulative-sum stopping rule. `PCAAnalysisStep`
+calls it only when `feature_selection_strategy == "top_variance"` and
+`n_top_features < 1`, to resolve a concrete int, then calls
+`select_top_features_from_pca()` exactly as it does today with that int.
+
+**Considered and deliberately not done**: extracting a shared
+`_first_index_crossing_threshold(cumulative, threshold, total) -> int`
+helper used by both `select_n_features_by_variance()` and
+`select_n_components()` (which independently implements the same
+`np.argmax(cumulative >= threshold) + 1` crossing rule over
+`explained_variance_ratio_`'s cumulative sum, `pca.py:181-192`). The two
+are structurally similar but not identical — `select_n_components()`
+additionally clamps against `n_samples - 1`/`max_components`, concerns
+that don't apply to a feature-contributions DataFrame — and
+`select_n_components()` is an existing, tested function used by
+`perform_pca_analysis()` and `run_pca_and_export_artifacts()`, both outside
+this proposal's scope. Refactoring it for a marginal DRY win when only two
+call sites exist is disproportionate to the benefit (per this project's
+"Simplicity First: avoid frameworks without clear justification... only
+add complexity with... multiple proven use cases requiring abstraction,"
+`openspec/AGENTS.md`). Revisit if a third "cumulative-threshold-crossing"
+use case appears.
+
+**Known, accepted footgun**: `n_top_features == 1.0` takes the `>= 1`
+count branch (selects exactly 1 feature), not "100% of variance." This
+diverges from the more intuitive reading a user might bring from
+`n_components: 1.0`-style thinning, where `1.0` is a boundary threshold
+value, not a count. This is an intentional consequence of reusing the
+existing `< 1` / `>= 1` convention exactly as `n_components` already
+defines it (mirroring, not reinterpreting, that convention per the Goals
+above) — documented in the `PCAConfig.n_top_features` docstring and in the
+spec's scenario for the `1.0`/boundary case (see the `visualization-pipeline`
+delta), not silently left to surprise a user.
+
+### Decision 3: Reject invalid `n_top_features` values for methods that don't support a threshold, at config-validation time — and explicitly not with a step-level guard
+
+`"top_absolute"` and `"top_contribution"` still read `n_top_features` as a
+plain count inside `select_top_features_from_pca()` (e.g.
+`np.argsort(...)[::-1][:n_features_to_select]`). Two distinct footguns need
+rejecting:
+
+1. A `< 1` float passed through unchanged would silently truncate —
+   `int(0.5)` is `0`, so `[:0]` selects nothing, with no error.
+2. A non-integer `>= 1` float (e.g. `5.7`) would also silently truncate —
+   `int(5.7)` is `5` — with no indication the fractional part was dropped.
+   This applies to `"top_variance"`'s own `>= 1` count branch too, not just
+   `"top_absolute"`/`"top_contribution"`: nothing about the count branch is
+   `"top_variance"`-specific once `n_top_features >= 1`.
+
+Both `validate_qc_config()` and `validate_viz_config()`
+(`pipeline/config/utils.py`) already have a PCA-config validation block
+(`n_components <= 0` → error, `feature_selection_strategy` enum check) —
+this adds two sibling checks in the same block:
+
+```python
+strategy = config.pca.feature_selection_strategy
+n_top = config.pca.n_top_features
+
+if n_top < 1 and strategy not in ("extreme", "top_variance"):
+    raise ValueError(
+        "pca.n_top_features < 1 (variance-fraction threshold) is only "
+        "supported for feature_selection_strategy='top_variance'; got "
+        f"'{strategy}' with n_top_features={n_top}. Use an integer "
+        ">= 1 for this strategy."
+    )
+if n_top >= 1 and strategy != "extreme" and abs(n_top - round(n_top)) > 1e-9:
+    raise ValueError(
+        f"pca.n_top_features must be a whole number when >= 1 (got "
+        f"{n_top} for feature_selection_strategy='{strategy}'); the "
+        "fractional part would be silently truncated."
+    )
+```
+
+(A tolerance-based comparison, not exact `!=`, per adversarial review — free
+hardening against a future config-generation path that computes
+`n_top_features` rather than hand-typing it as a literal. As of this
+proposal, every `n_top_features` value in this codebase's configs and
+tests is a hand-typed literal — grepped and confirmed — so this is
+defensive, not fixing a live bug.)
+
+`"extreme"` is excluded from **both** checks because the value is ignored
+entirely for that method (Decision 1) — any value is harmless there and
+shouldn't be flagged as an error.
+
+**`"vector_length"` is deliberately not named in either check.**
+`pca.feature_selection_strategy`'s pre-existing validation enum in the same
+two functions (`valid_pca_strategies = ["extreme", "top_absolute",
+"top_contribution", "top_variance"]`) has never included `"vector_length"`
+as a valid value for *this* field — that string is a valid value only for
+the separate `create_pca_biplot(feature_selection=...)` parameter, a
+different config surface entirely. Grepping `configs/` confirms no config
+anywhere sets `pca.feature_selection_strategy: "vector_length"` (it would
+already fail today's enum check if it did). Naming it in the two checks
+above would describe an unreachable branch and make the new validation
+untestable for that case; widening the enum to make it reachable would be
+an unrelated scope expansion. Both are avoided — the checks above name only
+`"top_absolute"` and `"top_contribution"` as the count-only strategies.
+
+**No step-level (`PCAAnalysisStep`) defense-in-depth guard is added**,
+unlike `FilterHeritabilityStep`'s guard for its own cross-field validation
+(`config-management` spec, "FilterHeritabilityStep Defense-in-Depth Guard").
+That guard exists for a specific historical reason: `heritability_results`
+being empty is a runtime *data* condition (upstream step didn't compute
+heritability) that config validation alone cannot see coming, so a
+runtime guard is the only place it can be caught. The new
+`n_top_features`/`feature_selection_strategy` checks here are pure
+*config* conditions, fully knowable at validation time with no dependency
+on runtime data — every config-driven pipeline entry point
+(`configure-run-all`, the CLI, `run_pipeline`) already calls
+`validate_qc_config()`/`validate_viz_config()` before execution per this
+project's "Validation at pipeline start" convention (`project.md`,
+Configuration Philosophy). A step-level guard would duplicate that same
+check for the sole benefit of programmatically-constructed `PCAConfig`
+objects that skip validation on purpose — a narrower, lower-value case than
+`FilterHeritabilityStep`'s, and not required by #206/#203. Left as an
+explicit non-goal (see `proposal.md`'s Impact section) rather than silently
+omitted.
+
+### Decision 4: New `ADDED` requirement, not a `MODIFIED` rewrite of "Pipeline Step Parameter Passing"
+
+The existing `visualization-pipeline` requirement "Pipeline Step Parameter
+Passing" (`openspec/specs/visualization-pipeline/spec.md:65-262`) is already
+large — it covers `GenerateStaticFiguresStep`'s genotype-highlighting
+passthrough, `PCAAnalysisStep`'s zero-variance handling, `create_pca_biplot`'s
+`feature_selection` dispatch, and `create_umap_colored_by_top_traits`'s
+round-robin extreme-selection construction (~20 scenarios, four distinct
+functions). None of that existing text needs to change for this proposal —
+the new normative behavior (pc_indices scoping, extreme/top_variance/
+count-strategy resolution) is purely additive, not a modification of any
+existing sentence. Folding it into that requirement via a `MODIFIED` delta
+would have meant pasting all ~200 lines of unrelated pre-existing content
+just to append a few new paragraphs, and would have grown an
+already-overloaded requirement to a fifth concern.
+
+Instead, this proposal adds a new, standalone requirement — "PCA Analysis
+Step Feature Selection Resolution" — scoped specifically to
+`PCAAnalysisStep`'s `pc_indices`/`n_top_features` resolution logic, under
+`## ADDED Requirements` in the `visualization-pipeline` delta. This keeps
+the delta small, testable independently, and doesn't touch the existing
+requirement's text at all.
+
+## Risks / Trade-offs
+
+- **Output change for every `"extreme"` config.** `top_features.csv`
+  content changes for all 28 active configs using `"extreme"` paired with
+  an explicit `n_top_features` (scoped to all retained PCs instead of
+  PC1/PC2, and exactly 1-per-direction regardless of the old count) —
+  and, more broadly, for every active config using `"extreme"` at all
+  (49 files total, verified via `grep -rl 'feature_selection_strategy:.*extreme'
+  configs/active/`), since the `pc_indices` scoping fix (#203) applies
+  regardless of whether `n_top_features` was explicitly set. This is the
+  intended fix for #203/#206, not a regression — but it's a real output
+  diff, not just a doc/config change. Mitigation: regression tests assert
+  the new, principled behavior explicitly (see `tasks.md`); no
+  golden-output regeneration is needed because `top_features.csv`/the
+  `top_features` metadata list are consumed only by a summary count
+  (`generate_summary_viz.py:144`), not compared against fixture goldens.
+- **`n_top_features` type change (`int` → `float`) is not safely committed
+  on its own.** `select_top_features_from_pca()` slices numpy arrays with
+  `n_features_to_select` directly (`np.argsort(...)[::-1][:n_features_to_select]`,
+  `pca.py:104,115,125,135`); a bare Python `float` in a slice raises
+  `TypeError: slice indices must be integers...`. Changing
+  `PCAConfig.n_top_features`'s default to `10.0` in isolation — before the
+  call site casts to `int(...)` for the count branches — would crash
+  **every** strategy, including `"top_variance"` (the schema default), not
+  just `"extreme"`. The schema change, the call-site rewrite, and the
+  updated `test_pca_different_feature_selection_strategies` assertion must
+  land in one atomic commit (see `tasks.md`); they are not independently
+  committable in the order tasks are numbered.
+- **Squash-merge means a full revert undoes everything, not just the new
+  validation.** If Decision 3's validation later proves too strict for a
+  real config, `git revert` of the (squash-merged) PR commit would also
+  undo the #203 `pc_indices` fix that other work may have since built on.
+  The safe rollback path for an over-strict validation specifically is a
+  small, targeted follow-up patch to `pipeline/config/utils.py`, not a
+  revert of this change.
+
+## Migration Plan
+
+1. Land `select_n_features_by_variance()` in `pca.py` with unit tests
+   (mirrors `select_n_components()` test patterns in `test_pca.py`),
+   including the `threshold <= 0` and exact-boundary cases. This function
+   is uncalled by production code at this point — zero blast radius,
+   independently committable.
+2. In a **single commit**: update `PCAConfig.n_top_features`'s type
+   (`int` → `float`) and docstring in `components.py`; update
+   `PCAAnalysisStep.execute()`'s call site to always pass
+   `pc_indices=list(range(n_components))` and branch on
+   `feature_selection_strategy`/`n_top_features` to resolve
+   `n_features_to_select` per Decisions 1–2 (casting to `int(...)` for
+   every count branch); and update `test_step_pca_analysis.py`'s
+   regression tests, including rewriting
+   `test_pca_different_feature_selection_strategies`'s
+   `len(top_features) >= config.pca.n_top_features` assertion, which no
+   longer holds for `"extreme"`. See the Risks section above for why these
+   three pieces cannot be split across commits without a red-CI window.
+3. Add the Decision 3 validation to both `validate_qc_config()` and
+   `validate_viz_config()`, with tests in `tests/test_pipeline_config.py`
+   and `tests/test_viz_pipeline_config.py` respectively (where each
+   function's existing PCA-validation tests already live).
+4. Update docs/configs (proposal's "Docs" section): the 28 files
+   identified in Decision 1, plus the additional stale-comment locations
+   catalogued in `tasks.md` section 4.2.
+5. Rollback: see the squash-merge caveat in Risks above — prefer a
+   targeted follow-up patch over a full revert if only Decision 3's
+   validation needs walking back post-merge.
+
+## Open Questions
+
+None outstanding — both design questions #206 raised are resolved above.

--- a/openspec/changes/fix-pca-top-feature-selection/design.md
+++ b/openspec/changes/fix-pca-top-feature-selection/design.md
@@ -156,23 +156,45 @@ calls it only when `feature_selection_strategy == "top_variance"` and
 `n_top_features < 1`, to resolve a concrete int, then calls
 `select_top_features_from_pca()` exactly as it does today with that int.
 
-**Considered and deliberately not done**: extracting a shared
-`_first_index_crossing_threshold(cumulative, threshold, total) -> int`
-helper used by both `select_n_features_by_variance()` and
-`select_n_components()` (which independently implements the same
-`np.argmax(cumulative >= threshold) + 1` crossing rule over
-`explained_variance_ratio_`'s cumulative sum, `pca.py:181-192`). The two
-are structurally similar but not identical — `select_n_components()`
-additionally clamps against `n_samples - 1`/`max_components`, concerns
-that don't apply to a feature-contributions DataFrame — and
-`select_n_components()` is an existing, tested function used by
-`perform_pca_analysis()` and `run_pca_and_export_artifacts()`, both outside
-this proposal's scope. Refactoring it for a marginal DRY win when only two
-call sites exist is disproportionate to the benefit (per this project's
-"Simplicity First: avoid frameworks without clear justification... only
-add complexity with... multiple proven use cases requiring abstraction,"
-`openspec/AGENTS.md`). Revisit if a third "cumulative-threshold-crossing"
-use case appears.
+**Revised after PR code review (originally "considered and deliberately not
+done" — reversed below):** the first draft of this section argued against
+extracting a shared `_first_index_crossing_threshold(cumulative, threshold,
+total) -> int` helper for `select_n_features_by_variance()` and
+`select_n_components()`'s independently-implemented
+`np.argmax(cumulative >= threshold) + 1` crossing rule, reasoning that two
+call sites didn't justify the abstraction. An adversarial PR review pass
+found a second, more consequential instance of the *same* pattern —
+`select_top_features_from_pca()`'s `"top_variance"` branch and
+`perform_pca_analysis()`'s `feature_contributions` construction
+independently recompute the identical `Σ eigenvalue · loading²` formula
+(see Decision 5 below) — and that the resulting float-summation-order
+divergence, while negligible today, is exactly the kind of "two
+independent re-derivations of one formula" this project's reproducibility
+values ask to be treated as a real, not theoretical, concern. Given a
+second occurrence of the same underlying pattern surfaced independently,
+"only two call sites" was the wrong bar — extract both shared helpers now
+rather than wait for a third:
+
+```python
+def _first_index_crossing_threshold(
+    cumulative: np.ndarray, threshold: float, total: int
+) -> int:
+    if cumulative[-1] >= threshold:
+        n = int(np.argmax(cumulative >= threshold)) + 1
+    else:
+        n = total
+    return max(1, min(n, total))
+```
+
+`select_n_components()` calls it with `cumulative_variance`,
+`explained_variance_threshold`, `max_components`; `select_n_features_by_variance()`
+calls it with the `fractional_contribution` cumulative sum, `threshold`,
+`n_total` (after its own `threshold <= 0` special-case, which has no
+`select_n_components()` analog and stays local to that function). Both
+callers' existing test suites are unchanged assertions — this is a
+behavior-preserving refactor (byte-identical outputs), not a new
+capability, verified by running the full existing regression suite for
+both functions after the extraction.
 
 **Known, accepted footgun**: `n_top_features == 1.0` takes the `>= 1`
 count branch (selects exactly 1 feature), not "100% of variance." This
@@ -184,6 +206,54 @@ defines it (mirroring, not reinterpreting, that convention per the Goals
 above) — documented in the `PCAConfig.n_top_features` docstring and in the
 spec's scenario for the `1.0`/boundary case (see the `visualization-pipeline`
 delta), not silently left to surprise a user.
+
+### Decision 5: unify the two independent variance-contribution formulas (added after PR review)
+
+`perform_pca_analysis()` computes each feature's total variance
+contribution vectorized — `total_contributions = np.sum(loadings_used**2 *
+eigenvalues_used, axis=1)` (`pca.py:925`, pre-refactor line numbers) — to
+build the `feature_contributions` DataFrame `select_n_features_by_variance()`
+consumes. `select_top_features_from_pca()`'s `"top_variance"` method
+independently re-derives the *same* quantity via a Python accumulation
+loop — `for i in range(n_pcs): contributions += eigenvalues[i] *
+loadings[:n_features, i] ** 2` (`pca.py:117-125`, in the same, pre-existing
+function this proposal does not otherwise modify). Mathematically
+identical; not guaranteed bit-identical, since `np.sum`'s internal
+pairwise-summation order differs from a naive per-column accumulation
+loop. In the vanishingly rare case of an exact tie at a selection boundary,
+this could make `select_n_features_by_variance()`'s resolved *count*
+(computed from one summation order) disagree by one feature with what
+`select_top_features_from_pca(method="top_variance")`'s actual *selection*
+(the other summation order) would rank as "top N" — deterministic on any
+given run, but a silent discrepancy between the two, and exactly the kind
+of "two paths computing the same scientific quantity, unverified to
+agree" risk this project's statistical-rigor conventions ask to be
+eliminated at the source rather than documented as a caveat.
+
+**Fix**: extract a single shared helper both call:
+
+```python
+def _total_variance_contribution(loadings, eigenvalues, n_features=None):
+    if n_features is not None:
+        loadings = loadings[:n_features]
+    n_pcs = min(loadings.shape[1], len(eigenvalues))
+    return np.sum(loadings[:, :n_pcs] ** 2 * eigenvalues[:n_pcs], axis=1)
+```
+
+`perform_pca_analysis()` calls it with its full `loadings`/`eigenvalues`
+(no `n_features` restriction — it already operates on the complete
+feature set); `select_top_features_from_pca()`'s `"top_variance"` branch
+calls it with its own `n_features` (already computed at the top of that
+function as `min(n_features_total, loadings.shape[0])`). Given the same
+`loadings`/`eigenvalues` inputs — which is always true along the
+`PCAAnalysisStep` → `perform_pca_analysis()` → `select_top_features_from_pca()`
+call chain this proposal's own scoping fix (#203) established — the two
+now compute the *literal same array*, not just a numerically close one.
+This is a behavior-preserving refactor for every existing caller of
+`select_top_features_from_pca()`, including the two out-of-scope callers
+(`create_pca_biplot`, `create_umap_colored_by_top_traits`) that pass their
+own `top_n_features`/`n_traits` counts — their `"top_variance"` behavior is
+unchanged (same formula, now computed one way instead of two).
 
 ### Decision 3: Reject invalid `n_top_features` values for methods that don't support a threshold, at config-validation time — and explicitly not with a step-level guard
 

--- a/openspec/changes/fix-pca-top-feature-selection/proposal.md
+++ b/openspec/changes/fix-pca-top-feature-selection/proposal.md
@@ -1,0 +1,158 @@
+## Why
+
+Fixes #206 and resolves the open "decide" checkbox in #203.
+
+`pca.n_top_features` (`components.py:422`, default `10`) is a plain integer
+count. It has no visible effect on any plot a user actually looks at — its
+only real consumer is `PCAAnalysisStep` (`pca_analysis.py:109-115`), which
+writes `top_features.csv` and a metadata list consumed only by a summary
+count. Worse, for `feature_selection_strategy: "extreme"` (used by most
+active viz configs), the count is fundamentally arbitrary — every config
+hand-picks a different value (`1` in some, `5` in others; see
+`configs/active/viz/*.yaml`).
+
+Separately (#203), `PCAAnalysisStep` never passes `pc_indices` to
+`select_top_features_from_pca()`, so it silently defaults to `[0, 1]`
+(`pca.py:64-65`) regardless of how many PCs `n_components` actually
+retained. For `"extreme"`, `"top_absolute"`, and `"top_contribution"` — all
+of which respect `pc_indices` — a run with `n_components: 0.75` (5+ PCs)
+still only considers PC1/PC2, silently discarding every other retained
+component's contribution.
+
+## What Changes
+
+- **Fix #203**: `PCAAnalysisStep` always passes
+  `pc_indices=list(range(n_components))` explicitly to
+  `select_top_features_from_pca()` — never relies on the `[0, 1]` default.
+- **`extreme` gets no count parameter** (#206 Part 1): when
+  `feature_selection_strategy == "extreme"`, `PCAAnalysisStep` calls
+  `select_top_features_from_pca(n_features_to_select=1, ...)` unconditionally
+  — `config.pca.n_top_features` is not read for this method. Combined with
+  the `pc_indices` fix above, this always selects exactly the single most-
+  positive and single most-negative loading trait per retained PC.
+  **Design decision** (see `design.md` for the full justification): the
+  now-inert `n_top_features` value under `"extreme"` is handled by
+  documentation, not a validation error — `PCAConfig.n_top_features`'s
+  docstring states explicitly that it is ignored for `"extreme"`, mirroring
+  the existing precedent in the same file
+  (`select_top_features_from_pca`'s own docstring already documents that
+  `pc_indices` is "ignored entirely by `top_variance`" with no runtime
+  warning). The 28 active configs that currently pair
+  `feature_selection_strategy: "extreme"` with an explicit `n_top_features`
+  (27 files under `configs/active/viz/`, plus the flat pre-reorg duplicate
+  `configs/active/viz_turface_150genotypes.yaml`; **zero** under
+  `configs/active/qc/` — none of those pair the two fields) have that
+  now-meaningless line removed as part of this change. As a cheap
+  additional safeguard (added after adversarial review — see `design.md`
+  Decision 1), `PCAAnalysisStep` also emits a `logger.info()` whenever
+  `feature_selection_strategy == "extreme"`, stating that `n_top_features`
+  is not read for this method — not a validation error, but not silent
+  either, so a config from outside this repo (a fork, a collaborator's
+  local copy) that still sets the now-inert field gets a visible runtime
+  signal, not just a docstring.
+- **`top_variance` gets a variance-threshold option** (#206 Part 2):
+  `PCAConfig.n_top_features` changes type from `int` to `float`, reusing the
+  exact overload convention already used by `PCAConfig.n_components`
+  ("Number of components (or variance ratio if < 1)"): a value `< 1` means
+  "stop once the selected features' cumulative `fractional_contribution`
+  reaches this fraction"; a value `>= 1` preserves today's fixed-count
+  behavior. A new helper, `select_n_features_by_variance()` in `pca.py`,
+  resolves a `< 1` threshold to a concrete feature count, structurally
+  mirroring the existing `select_n_components()` pattern
+  (`np.argmax(cumulative >= threshold) + 1`) but walking
+  `feature_contributions["fractional_contribution"]` instead of
+  `explained_variance_ratio_`. `PCAAnalysisStep` calls this helper only when
+  `feature_selection_strategy == "top_variance"` and `n_top_features < 1`,
+  then calls `select_top_features_from_pca()` exactly as before with the
+  resolved integer.
+  - **Scope**: only `"extreme"` and `"top_variance"` appear in any active
+    config today. The threshold option is implemented for `"top_variance"`
+    only; `"top_absolute"` and `"top_contribution"` keep today's
+    count-only behavior as an explicit, documented follow-up (not silently
+    unsupported — see the new config validation below). `"vector_length"`
+    is **not** part of this scope note: `pca.feature_selection_strategy`'s
+    existing validation enum (`validate_qc_config()` / `validate_viz_config()`,
+    `pipeline/config/utils.py`) has never accepted `"vector_length"` as a
+    value for *this* field — that string is only a valid value for the
+    separate `create_pca_biplot(feature_selection=...)` parameter. Widening
+    the `pca.feature_selection_strategy` enum is unrelated scope creep and
+    is not done here.
+- **Config validation** (`validate_qc_config()` / `validate_viz_config()`):
+  add two new checks alongside the existing PCA validation block:
+  1. reject `n_top_features < 1` when `feature_selection_strategy` is
+     `"top_absolute"` or `"top_contribution"` (methods that still require a
+     plain count and would silently misbehave — e.g. `int(0.5) == 0`
+     selected features — if given a fractional value). No restriction is
+     added for `"extreme"` (the field is ignored regardless of value) or
+     `"top_variance"` (this is exactly the new supported case).
+  2. reject a non-whole-number `n_top_features >= 1` (checked with a small
+     floating-point tolerance, not exact equality) for every strategy
+     except `"extreme"` (i.e. for `"top_variance"`'s count branch,
+     `"top_absolute"`, and `"top_contribution"`) — e.g. `n_top_features: 5.7`
+     would otherwise silently truncate to `int(5.7) == 5` with no warning,
+     the same class of silent-no-op this change is otherwise trying to
+     eliminate.
+- **Docs**: rewrite `PCAConfig.n_top_features`'s docstring, and update
+  `configs/active/viz/*.yaml`/`configs/examples/viz_*.yaml` comments to
+  match the new semantics — this supersedes patching the individual wrong
+  "UMAP coloring" / "interesting genotypes" claims found during the original
+  investigation (they are rewritten here rather than fixed in place).
+- **Close #203** with a comment cross-linking to this PR once merged (same
+  pattern as #64/#68).
+
+## Impact
+
+- Affected specs: `visualization-pipeline` (a new, standalone requirement
+  for `PCAAnalysisStep`'s feature-selection resolution — see `design.md`
+  Decision 4 for why this is `ADDED` rather than folded into the existing,
+  already-large "Pipeline Step Parameter Passing" requirement),
+  `config-management` (new cross-field validation for `n_top_features` vs.
+  `feature_selection_strategy`).
+- Affected code:
+  - `src/sleap_roots_analyze/pca.py` (`select_n_features_by_variance`, new)
+  - `src/sleap_roots_analyze/pipeline/config/components.py` (`PCAConfig`)
+  - `src/sleap_roots_analyze/pipeline/config/utils.py`
+    (`validate_qc_config`, `validate_viz_config`)
+  - `src/sleap_roots_analyze/pipeline/steps/pca_analysis.py`
+  - `configs/active/viz/*.yaml` (27 files) and
+    `configs/active/viz_turface_150genotypes.yaml` (1 flat pre-reorg
+    duplicate) — **not** `configs/active/qc/*.yaml`, which has no file
+    pairing `"extreme"` with an explicit `n_top_features`
+  - `configs/examples/viz_*.yaml`
+  - `tests/test_pca.py`, `tests/test_step_pca_analysis.py`,
+    `tests/test_pipeline_config.py`, `tests/test_viz_pipeline_config.py`
+    (the last two are where `validate_qc_config`/`validate_viz_config`'s
+    existing PCA-validation tests actually live today — there is no
+    separate `test_pca_validation.py`)
+  - `docs/CHANGELOG.md` `[Unreleased]` — new `### Changed`/`### Fixed`
+    entries
+- **Behavior change (not purely a bug fix)**: `top_features.csv` output
+  changes for every active config using `"extreme"` (now scoped to all
+  retained PCs, not just PC1/PC2, and always exactly 1 per direction per PC
+  regardless of any prior `n_top_features` value) and for any config that
+  adopts the new `< 1` threshold under `"top_variance"`. No output change
+  for configs using `"top_variance"` with the existing `>= 1` count
+  behavior, or for `"top_absolute"`/`"top_contribution"` configs (none
+  exist today). This is also why the change is named `fix-` rather than
+  `refactor-` — it changes observable output, not just internal structure.
+- **bloommcp compatibility**: already verified safe (see #206's comment
+  thread). `bloommcp` calls `perform_pca_analysis`/`create_pca_biplot`/
+  `create_feature_contribution_plot`/`create_umap_colored_by_top_traits`
+  directly, bypassing the QC/Viz YAML config entirely — it has no
+  `n_top_features`/`feature_selection_strategy` fields, and this change
+  does not touch `select_top_features_from_pca()`'s public signature.
+- Explicitly out of scope (tracked separately, not touched here):
+  - `create_pca_biplot`'s `top_n_features` / `static_viz.pca_biplot_top_features`
+    — a separate config field controlling biplot display, unrelated to
+    `pca.n_top_features`.
+  - #207's fix in `create_umap_colored_by_top_traits` (already merged).
+  - Threshold support for `"top_absolute"`/`"top_contribution"` — left
+    count-based, flagged as a follow-up.
+  - Widening `pca.feature_selection_strategy`'s validation enum to accept
+    `"vector_length"` — that string is currently only reachable through
+    `create_pca_biplot`'s separate `feature_selection` parameter, not
+    through this config field; not touched here.
+  - A step-level (`PCAAnalysisStep`) defense-in-depth guard for the new
+    validation, analogous to `FilterHeritabilityStep`'s guard for bypassed
+    config validation — see `design.md` Decision 3 for why this is
+    explicitly not added.

--- a/openspec/changes/fix-pca-top-feature-selection/specs/config-management/spec.md
+++ b/openspec/changes/fix-pca-top-feature-selection/specs/config-management/spec.md
@@ -1,0 +1,74 @@
+## ADDED Requirements
+
+### Requirement: PCA Feature Selection Config Validation
+
+The system SHALL validate that `pca.n_top_features` is a whole number
+`>= 1` (within a small floating-point tolerance, not exact equality)
+whenever `pca.feature_selection_strategy` is one of `"top_absolute"` or
+`"top_contribution"` — methods that read `n_top_features` directly as an
+integer count and would silently truncate (to zero, or dropping a
+fractional part) if given a value that isn't a positive whole number. The
+same whole-number requirement applies to `"top_variance"` whenever
+`n_top_features >= 1` (its count branch), but `"top_variance"`
+additionally accepts any value `< 1` as a variance-fraction threshold. No
+restriction is added for `feature_selection_strategy == "extreme"` (the
+field is ignored entirely by this method, so any value is harmless).
+
+Validation occurs in both `validate_qc_config()` and
+`validate_viz_config()`, which run at pipeline startup before any steps
+execute. `"vector_length"` is intentionally not one of the strategies this
+requirement names: `pca.feature_selection_strategy`'s own pre-existing
+validation enum (in the same two functions) has never accepted
+`"vector_length"` as a value for this field — that string is a valid value
+only for the separate `create_pca_biplot(feature_selection=...)`
+parameter. This requirement does not widen that enum.
+
+#### Scenario: Reject a fractional n_top_features below 1 for count-only methods
+
+- **WHEN** a config has `pca.feature_selection_strategy` set to
+  `"top_absolute"` or `"top_contribution"` and `pca.n_top_features` set to
+  a value `< 1`
+- **THEN** `validate_qc_config()` / `validate_viz_config()` SHALL raise a
+  `ValueError` before any pipeline steps execute
+- **AND** the error message SHALL name both config fields, the offending
+  strategy, and state that an integer `>= 1` is required for that strategy
+
+#### Scenario: Reject a non-integer n_top_features at or above 1
+
+- **WHEN** a config has `pca.n_top_features` set to a non-integer value
+  `>= 1` (e.g. `5.7`) and `pca.feature_selection_strategy` set to any value
+  other than `"extreme"` (including `"top_variance"`, `"top_absolute"`, or
+  `"top_contribution"`)
+- **THEN** `validate_qc_config()` / `validate_viz_config()` SHALL raise a
+  `ValueError` before any pipeline steps execute
+- **AND** the error message SHALL state that the fractional part would be
+  silently truncated
+
+#### Scenario: Accept a variance-fraction threshold for top_variance
+
+- **WHEN** a config has `pca.feature_selection_strategy="top_variance"` and
+  `pca.n_top_features` set to a value `< 1` (e.g. `0.8`)
+- **THEN** `validate_qc_config()` / `validate_viz_config()` SHALL pass
+  without error
+
+#### Scenario: Accept any n_top_features value for extreme
+
+- **WHEN** a config has `pca.feature_selection_strategy="extreme"` and
+  `pca.n_top_features` set to any value, including a fractional value or
+  one `< 1`
+- **THEN** `validate_qc_config()` / `validate_viz_config()` SHALL pass
+  without error, since the field is not read for this method
+
+#### Scenario: Accept a whole-number count for any strategy
+
+- **WHEN** a config has `pca.n_top_features` set to a whole-number value
+  `>= 1`, regardless of `pca.feature_selection_strategy`
+- **THEN** `validate_qc_config()` / `validate_viz_config()` SHALL pass
+  without error
+
+#### Scenario: Default config values pass validation
+
+- **WHEN** a `PCAConfig` is constructed with default values
+  (`feature_selection_strategy="top_variance"`, `n_top_features=10.0`)
+- **THEN** `validate_qc_config()` / `validate_viz_config()` SHALL pass
+  without error

--- a/openspec/changes/fix-pca-top-feature-selection/specs/visualization-pipeline/spec.md
+++ b/openspec/changes/fix-pca-top-feature-selection/specs/visualization-pipeline/spec.md
@@ -1,0 +1,111 @@
+## ADDED Requirements
+
+### Requirement: PCA Analysis Step Feature Selection Resolution
+
+`PCAAnalysisStep` SHALL always pass `pc_indices=list(range(n_components))`
+(where `n_components` is `pca_results["n_components_selected"]`) to
+`select_top_features_from_pca()`, never relying on that function's `[0, 1]`
+default, so feature selection is scoped to every retained PC regardless of
+how many components `pca.n_components` selected.
+
+For `feature_selection_strategy == "extreme"`, `PCAAnalysisStep` SHALL call
+`select_top_features_from_pca()` with `n_features_to_select=1`
+unconditionally — `config.pca.n_top_features` SHALL NOT be read for this
+method, regardless of its value. Combined with the PC-scoping requirement
+above, this always selects exactly one most-positive-loading and one
+most-negative-loading trait per retained PC.
+
+For `feature_selection_strategy == "top_variance"`, when
+`config.pca.n_top_features < 1`, `PCAAnalysisStep` SHALL resolve a concrete
+feature count by calling `select_n_features_by_variance(
+pca_results["feature_contributions"], config.pca.n_top_features)` before
+calling `select_top_features_from_pca()`, and SHALL pass that resolved
+integer as `n_features_to_select`. When `config.pca.n_top_features >= 1`,
+`PCAAnalysisStep` SHALL pass `int(config.pca.n_top_features)` directly,
+unchanged from current behavior — including when the value is exactly
+`1.0`, which SHALL be treated as the count `1`, not as a 100%-variance
+threshold.
+
+For `feature_selection_strategy` set to `"top_absolute"` or
+`"top_contribution"`, `PCAAnalysisStep` SHALL pass
+`int(config.pca.n_top_features)` directly, unchanged from current
+behavior.
+
+#### Scenario: PCAAnalysisStep scopes selection to all retained PCs for every pc_indices-respecting method
+
+- **GIVEN** a run configured with `pca.n_components` selecting 3 or more
+  PCs (e.g. a variance threshold like `0.75`)
+- **WHEN** `PCAAnalysisStep` executes with `feature_selection_strategy` set
+  to `"extreme"`, `"top_absolute"`, or `"top_contribution"`
+- **THEN** `top_features.csv` and the `top_features` metadata list SHALL
+  reflect features selected across every retained PC, not only PC1 and PC2
+
+#### Scenario: PCAAnalysisStep extreme selection ignores n_top_features
+
+- **WHEN** `PCAAnalysisStep` executes with
+  `feature_selection_strategy="extreme"` and `pca.n_components` selects `k`
+  PCs, regardless of what `pca.n_top_features` is set to (including values
+  that would previously have produced a different count)
+- **THEN** `top_features.csv` and the `top_features` metadata list SHALL
+  contain exactly one most-positive-loading and one most-negative-loading
+  trait per retained PC (at most `2 * k` entries, fewer if a trait is
+  extreme on more than one PC)
+
+#### Scenario: PCAAnalysisStep logs that n_top_features is ignored under extreme
+
+- **WHEN** `PCAAnalysisStep` executes with
+  `feature_selection_strategy="extreme"`, regardless of whether
+  `pca.n_top_features` was explicitly set in the config
+- **THEN** the step SHALL emit a `logger.info()` message stating that
+  `n_top_features` is not read for this method
+- **AND** this SHALL NOT raise a warning or exception, and SHALL NOT
+  affect `top_features.csv` output
+
+#### Scenario: PCAAnalysisStep extreme selection with a single retained PC
+
+- **GIVEN** `pca.n_components` selects exactly 1 PC
+- **WHEN** `PCAAnalysisStep` executes with
+  `feature_selection_strategy="extreme"`
+- **THEN** `top_features.csv` and the `top_features` metadata list SHALL
+  contain at most 2 entries (1 most-positive-loading, 1
+  most-negative-loading), deduplicated to 1 entry if only a single feature
+  is available
+
+#### Scenario: PCAAnalysisStep resolves a top_variance variance-fraction threshold to a feature count
+
+- **WHEN** `PCAAnalysisStep` executes with
+  `feature_selection_strategy="top_variance"` and `pca.n_top_features` set
+  to a value `< 1` (e.g. `0.8`)
+- **THEN** the step SHALL call `select_n_features_by_variance()` with the
+  PCA run's `feature_contributions` DataFrame and that threshold to resolve
+  a concrete feature count before calling `select_top_features_from_pca()`
+- **AND** the cumulative `fractional_contribution` of the selected features
+  SHALL meet or exceed the configured threshold
+- **AND** the cumulative `fractional_contribution` of the selected features
+  minus the smallest selected feature's own `fractional_contribution` SHALL
+  be less than the configured threshold (no unnecessary over-selection)
+
+#### Scenario: PCAAnalysisStep resolves a non-positive top_variance threshold to a single feature
+
+- **WHEN** `PCAAnalysisStep` executes with
+  `feature_selection_strategy="top_variance"` and `pca.n_top_features` set
+  to `0` or a negative value
+- **THEN** the step SHALL select exactly 1 feature (the single highest
+  `total_contribution` feature), without raising an exception
+
+#### Scenario: PCAAnalysisStep treats a top_variance n_top_features of exactly 1.0 as a count, not a 100%-variance threshold
+
+- **WHEN** `PCAAnalysisStep` executes with
+  `feature_selection_strategy="top_variance"` and `pca.n_top_features` set
+  to exactly `1.0`
+- **THEN** the step SHALL select exactly 1 feature (the `>= 1` count
+  branch), and SHALL NOT interpret `1.0` as "select enough features to
+  reach 100% cumulative variance"
+
+#### Scenario: PCAAnalysisStep preserves count-based top_variance behavior for n_top_features >= 1
+
+- **WHEN** `PCAAnalysisStep` executes with
+  `feature_selection_strategy="top_variance"` and `pca.n_top_features` set
+  to a value `>= 1`
+- **THEN** the step SHALL select exactly that many features by total
+  variance contribution, identical to current behavior

--- a/openspec/changes/fix-pca-top-feature-selection/tasks.md
+++ b/openspec/changes/fix-pca-top-feature-selection/tasks.md
@@ -3,19 +3,19 @@
 Independently committable — this function is uncalled by production code
 until section 2, so it carries zero blast radius on its own.
 
-- [ ] 1.1 Write failing tests in `tests/test_pca.py` for
+- [x] 1.1 Write failing tests in `tests/test_pca.py` for
       `select_n_features_by_variance(feature_contributions_df, threshold)`:
       threshold met exactly at a row boundary, threshold requiring all
       features, threshold met by fewer than all features (verify cumulative
       `fractional_contribution` meets but doesn't wildly overshoot),
       `threshold <= 0` (resolves to exactly 1 feature, no exception), and a
       single-feature DataFrame.
-- [ ] 1.2 Implement `select_n_features_by_variance()` in `pca.py`,
+- [x] 1.2 Implement `select_n_features_by_variance()` in `pca.py`,
       mirroring `select_n_components()`'s
       `np.argmax(cumulative >= threshold) + 1` pattern over
       `fractional_contribution`, with the explicit `threshold <= 0` branch
       per `design.md` Decision 2.
-- [ ] 1.3 Run `uv run pytest tests/test_pca.py -k variance` and confirm green.
+- [x] 1.3 Run `uv run pytest tests/test_pca.py -k variance` and confirm green.
 
 ## 2. `PCAConfig` schema + `PCAAnalysisStep` call site (single atomic commit)
 
@@ -28,7 +28,7 @@ crashes every `feature_selection_strategy` (not just `"extreme"`) with
 slicing. The schema change, the call-site rewrite, and the test updates
 below must land together.
 
-- [ ] 2.1 Write failing tests in `tests/test_step_pca_analysis.py`:
+- [x] 2.1 Write failing tests in `tests/test_step_pca_analysis.py`:
       - a run with `n_components` selecting >=3 PCs and
         `feature_selection_strategy` set to `"extreme"`, `"top_absolute"`,
         and `"top_contribution"` (all three, not just `"extreme"`) selects
@@ -57,24 +57,24 @@ below must land together.
         assertion (`len(top_features) >= config.pca.n_top_features`), which
         no longer holds for `"extreme"` under the new contract — in this
         same commit, not left broken across a commit boundary.
-- [ ] 2.2 Update `PCAConfig.n_top_features` in `components.py`: change
+- [x] 2.2 Update `PCAConfig.n_top_features` in `components.py`: change
       `n_top_features: int = 10` to `n_top_features: float = 10.0`, and
       rewrite its docstring to document all three cases: ignored for
       `"extreme"`; `< 1` = variance-fraction threshold / `>= 1` = count
       (including the `1.0`-is-a-count-not-100%-threshold footgun) for
       `"top_variance"`; plain whole-number count (validated `>= 1`, see
       section 3) for `"top_absolute"`/`"top_contribution"`.
-- [ ] 2.3 Update `PCAAnalysisStep.execute()`: always pass
+- [x] 2.3 Update `PCAAnalysisStep.execute()`: always pass
       `pc_indices=list(range(n_components))`; branch on
       `feature_selection_strategy`/`n_top_features` per `design.md`
       Decisions 1–2 to resolve `n_features_to_select`, casting to
       `int(...)` for every count branch; emit the `logger.info()` message
       from Decision 1 whenever `feature_selection_strategy == "extreme"`.
-- [ ] 2.4 Run `uv run pytest tests/test_step_pca_analysis.py` and confirm green.
+- [x] 2.4 Run `uv run pytest tests/test_step_pca_analysis.py` and confirm green.
 
 ## 3. Config validation (`pipeline/config/utils.py`)
 
-- [ ] 3.1 Write failing tests in `tests/test_pipeline_config.py` (for
+- [x] 3.1 Write failing tests in `tests/test_pipeline_config.py` (for
       `validate_qc_config()`) and `tests/test_viz_pipeline_config.py` (for
       `validate_viz_config()`) — these are the two files where each
       function's existing PCA-validation tests already live
@@ -103,15 +103,15 @@ below must land together.
         accepted for `"extreme"`.
       - default config values (`feature_selection_strategy="top_variance"`,
         `n_top_features=10.0`) pass.
-- [ ] 3.2 Add the two `design.md` Decision 3 checks to both
+- [x] 3.2 Add the two `design.md` Decision 3 checks to both
       `validate_qc_config()` and `validate_viz_config()`, using a tolerance
       comparison (`abs(n_top - round(n_top)) > 1e-9`), not exact `!=`, for
       the whole-number check.
-- [ ] 3.3 Run both test files and confirm green.
+- [x] 3.3 Run both test files and confirm green.
 
 ## 4. Config and docs cleanup
 
-- [ ] 4.1 Remove the now-meaningless `n_top_features` line from every
+- [x] 4.1 Remove the now-meaningless `n_top_features` line from every
       active config pairing `feature_selection_strategy: "extreme"` with an
       explicit `n_top_features` — verified list of **28 files**: the 27
       under `configs/active/viz/` (`alfalfa_gwas_groups_1_to_6_combined.yaml`,
@@ -133,7 +133,7 @@ below must land together.
       flat pre-reorg duplicate `configs/active/viz_turface_150genotypes.yaml`.
       **`configs/active/qc/*.yaml` needs no edits for this task** — verified
       no QC config pairs `"extreme"` with an explicit `n_top_features`.
-- [ ] 4.2 Rewrite stale `n_top_features`-related comments (not just the
+- [x] 4.2 Rewrite stale `n_top_features`-related comments (not just the
       key itself) in every one of these locations:
       - `configs/active/viz/viz_alfalfa_gwas_wave_1_grouped.yaml` (`pca:` block comment)
       - `configs/active/viz/alfalfa_gwas_wave1_canola_models.yaml` (`pca:` block
@@ -160,7 +160,7 @@ below must land together.
       All rewrites describe the new semantics: ignored under `"extreme"`;
       threshold-vs-count under `"top_variance"`; whole-number count,
       validated, for `"top_absolute"`/`"top_contribution"`.
-- [ ] 4.3 Add a parametrized regression test (e.g. in
+- [x] 4.3 Add a parametrized regression test (e.g. in
       `tests/test_pipeline_config.py` or a new `tests/test_viz_configs_load.py`)
       that calls `load_viz_config()` then `validate_viz_config()` on all 28
       files edited in 4.1 (the 27 under `configs/active/viz/` plus the flat
@@ -168,7 +168,7 @@ below must land together.
       exception — a concrete, re-runnable guard against a YAML syntax error
       or indentation break introduced by removing the `n_top_features`
       line, replacing the earlier vague "spot-check a sample" plan.
-- [ ] 4.4 Add a `docs/CHANGELOG.md` `[Unreleased]` entry: a `### Fixed`
+- [x] 4.4 Add a `docs/CHANGELOG.md` `[Unreleased]` entry: a `### Fixed`
       entry for #203 (PC scoping) and a `### Changed` entry for #206
       (variance-driven selection), matching the file's existing
       `[Unreleased]` section structure (`### Added` / `### Fixed` /
@@ -176,13 +176,13 @@ below must land together.
 
 ## 5. Full verification and PR
 
-- [ ] 5.1 Run
+- [x] 5.1 Run
       `uv run pytest --cov=src/sleap_roots_analyze --cov-report=xml --durations=20 -m "not integration" tests/`
       (exact CI invocation, `.github/workflows/ci.yml`) — full suite green.
-- [ ] 5.2 Run `uv run black src/sleap_roots_analyze tests` and
+- [x] 5.2 Run `uv run black src/sleap_roots_analyze tests` and
       `uv run ruff check src/sleap_roots_analyze tests`.
-- [ ] 5.3 Run `openspec validate fix-pca-top-feature-selection --strict`.
-- [ ] 5.4 Open PR (commit plan below); after merge, comment on #203
+- [x] 5.3 Run `openspec validate fix-pca-top-feature-selection --strict`.
+- [x] 5.4 Open PR (commit plan below); after merge, comment on #203
       cross-linking to the PR and close it as resolved (same pattern as
       #64/#68).
 
@@ -195,27 +195,39 @@ suites for every affected function still pass unchanged (proving byte-for-byte
 behavior preservation), plus one new equivalence test proving the specific
 divergence this closes is actually closed.
 
-- [ ] 6.1 Write a unit test for a new `_first_index_crossing_threshold(cumulative,
+- [x] 6.1 Write a unit test for a new `_first_index_crossing_threshold(cumulative,
       threshold, total) -> int` helper in `tests/test_pca.py` (exact
       boundary, threshold never reached → `total`, single-element input).
-- [ ] 6.2 Implement `_first_index_crossing_threshold()` in `pca.py`; refactor
+- [x] 6.2 Implement `_first_index_crossing_threshold()` in `pca.py`; refactor
       `select_n_components()` and `select_n_features_by_variance()` to call
       it (keeping `select_n_features_by_variance()`'s own `threshold <= 0`
       special-case local to that function, since it has no
       `select_n_components()` analog).
-- [ ] 6.3 Run the full existing test suites for both functions
+- [x] 6.3 Run the full existing test suites for both functions
       (`TestSelectNComponents`, `TestSelectNFeaturesByVariance` in
       `tests/test_pca.py`) unchanged and confirm all still pass — this is
       the behavior-preservation proof for 6.2.
-- [ ] 6.4 Write a failing equivalence test in `tests/test_pca.py`: run
-      `perform_pca_analysis()` on real (seeded) data, then assert
-      `select_top_features_from_pca(method="top_variance", ...)`'s
-      internal per-feature contribution values are *exactly* equal
-      (`np.array_equal`, not `np.allclose`) to
-      `pca_results["feature_contributions"]["total_contribution"]` — this
-      should fail before the fix (different summation order) and pass
-      after.
-- [ ] 6.5 Implement a new `_total_variance_contribution(loadings,
+- [x] 6.4 Write a failing equivalence test in `tests/test_pca.py`.
+      **As actually implemented** (revised from the original plan below
+      after discovering `select_top_features_from_pca()` doesn't expose
+      its internal contribution array, only argsort-truncated indices,
+      and that real random data essentially never produces an observable
+      *ordering* divergence even when the underlying values differ at the
+      bit level — verified empirically across 200 seeds before writing
+      this test): construct a deliberate 50-feature x 30-PC case with a
+      fixed `np.random.RandomState(42)` where a naive per-column
+      accumulation loop is directly shown (`np.array_equal` is `False`)
+      to diverge from a vectorized `np.sum` at the bit level for the
+      identical formula, plus a separate exact-equality check between
+      `perform_pca_analysis()`'s stored `total_contribution` and a direct
+      call to the new shared helper with the same inputs.
+      *(Original plan, superseded by the above: run `perform_pca_analysis()`
+      on real seeded data and assert `select_top_features_from_pca(method=
+      "top_variance", ...)`'s internal contribution values exactly equal
+      `pca_results["feature_contributions"]["total_contribution"]"` — not
+      viable without changing that function's return signature, which is
+      out of scope.)*
+- [x] 6.5 Implement a new `_total_variance_contribution(loadings,
       eigenvalues, n_features=None)` helper in `pca.py` per design.md
       Decision 5; refactor `perform_pca_analysis()`'s `total_contributions`
       computation and `select_top_features_from_pca()`'s `"top_variance"`
@@ -223,15 +235,28 @@ divergence this closes is actually closed.
       existing `test_pca.py`/`test_visualization.py` suites (covering
       `create_pca_biplot`/`create_umap_colored_by_top_traits`'s
       `"top_variance"` behavior) still pass unchanged.
-- [ ] 6.6 Add a named `_WHOLE_NUMBER_TOLERANCE = 1e-9` module-level constant
+- [x] 6.6 Add a named `_WHOLE_NUMBER_TOLERANCE = 1e-9` module-level constant
       in `pipeline/config/utils.py`, replacing the bare `1e-9` literal
       duplicated in both `validate_qc_config()` and `validate_viz_config()`.
-- [ ] 6.7 Fix the leftover double-blank-line in
+- [x] 6.7 Fix the leftover double-blank-line in
       `configs/active/viz/suyash_arabidopsis_pgm1_pac_2026_05_22.yaml` left
       by the section-4 `n_top_features` line removal (cosmetic; direct fix,
       no test needed).
-- [ ] 6.8 Run the full suite, black, ruff, and `openspec validate --strict`
+- [x] 6.8 Run the full suite, black, ruff, and `openspec validate --strict`
       once more before pushing.
+- [x] 6.9 Sync `.mypy-baseline.txt` (`mypy . | mypy-baseline sync`) — 6.2's
+      `int(...)`-returning helper incidentally resolved a pre-existing
+      baselined mypy error in `select_n_components()`'s old inline
+      `np.argmax(...) + 1`, which otherwise fails CI's "Type check
+      (mypy baseline)" job as a stale-baseline mismatch, not a new error.
+- [x] 6.10 Found by a 4th adversarial review round scoped to 6.1–6.9's
+      diff: add tests exercising `_first_index_crossing_threshold()`'s
+      empty-`cumulative` input (add a `ValueError` guard — it previously
+      crashed with an unguided `IndexError`) and `total > len(cumulative)`;
+      add a test exercising `_total_variance_contribution()`'s `n_pcs =
+      min(...)` clamp with `eigenvalues` shorter than `loadings.shape[1]`
+      (a scenario the function's own docstring anticipates for a future
+      scoped caller, but that no current caller exercises).
 
 ### Suggested commit sequence
 

--- a/openspec/changes/fix-pca-top-feature-selection/tasks.md
+++ b/openspec/changes/fix-pca-top-feature-selection/tasks.md
@@ -1,0 +1,195 @@
+## 1. `select_n_features_by_variance()` helper (`pca.py`)
+
+Independently committable — this function is uncalled by production code
+until section 2, so it carries zero blast radius on its own.
+
+- [ ] 1.1 Write failing tests in `tests/test_pca.py` for
+      `select_n_features_by_variance(feature_contributions_df, threshold)`:
+      threshold met exactly at a row boundary, threshold requiring all
+      features, threshold met by fewer than all features (verify cumulative
+      `fractional_contribution` meets but doesn't wildly overshoot),
+      `threshold <= 0` (resolves to exactly 1 feature, no exception), and a
+      single-feature DataFrame.
+- [ ] 1.2 Implement `select_n_features_by_variance()` in `pca.py`,
+      mirroring `select_n_components()`'s
+      `np.argmax(cumulative >= threshold) + 1` pattern over
+      `fractional_contribution`, with the explicit `threshold <= 0` branch
+      per `design.md` Decision 2.
+- [ ] 1.3 Run `uv run pytest tests/test_pca.py -k variance` and confirm green.
+
+## 2. `PCAConfig` schema + `PCAAnalysisStep` call site (single atomic commit)
+
+**Do not split this section across commits.** Per `design.md`'s Risks
+section: changing `PCAConfig.n_top_features`'s default to `10.0` without
+also updating the call site to cast to `int(...)` for count branches
+crashes every `feature_selection_strategy` (not just `"extreme"`) with
+`TypeError: slice indices must be integers...` inside
+`select_top_features_from_pca()`'s `np.argsort(...)[::-1][:n_features_to_select]`
+slicing. The schema change, the call-site rewrite, and the test updates
+below must land together.
+
+- [ ] 2.1 Write failing tests in `tests/test_step_pca_analysis.py`:
+      - a run with `n_components` selecting >=3 PCs and
+        `feature_selection_strategy` set to `"extreme"`, `"top_absolute"`,
+        and `"top_contribution"` (all three, not just `"extreme"`) selects
+        features from PCs beyond PC1/PC2 (fixes #203 for these methods).
+      - `feature_selection_strategy="extreme"` always yields exactly
+        1-most-positive + 1-most-negative per retained PC, regardless of
+        `n_top_features`'s value (including old configs' `1`/`5`).
+      - `feature_selection_strategy="extreme"` with `n_components=1`
+        (single retained PC) yields at most 2 features, deduplicated to 1
+        if only a single feature is available.
+      - `feature_selection_strategy="top_variance"` with `n_top_features=0.8`
+        selects a feature count whose cumulative `fractional_contribution`
+        meets but doesn't wildly overshoot `0.8`.
+      - `feature_selection_strategy="top_variance"` with `n_top_features=0`
+        (or negative) selects exactly 1 feature, no exception.
+      - `feature_selection_strategy="top_variance"` with
+        `n_top_features=1.0` (exact boundary) selects exactly 1 feature,
+        not "enough features for 100% variance."
+      - `feature_selection_strategy="top_variance"` with `n_top_features=5`
+        (unchanged, `>= 1`) still selects exactly 5 features.
+      - `feature_selection_strategy="extreme"` emits a `logger.info` record
+        (assert via `caplog`) stating `n_top_features` is not read for this
+        method, regardless of `n_top_features`'s value; no such record is
+        emitted for any other strategy.
+      - update the existing `test_pca_different_feature_selection_strategies`
+        assertion (`len(top_features) >= config.pca.n_top_features`), which
+        no longer holds for `"extreme"` under the new contract — in this
+        same commit, not left broken across a commit boundary.
+- [ ] 2.2 Update `PCAConfig.n_top_features` in `components.py`: change
+      `n_top_features: int = 10` to `n_top_features: float = 10.0`, and
+      rewrite its docstring to document all three cases: ignored for
+      `"extreme"`; `< 1` = variance-fraction threshold / `>= 1` = count
+      (including the `1.0`-is-a-count-not-100%-threshold footgun) for
+      `"top_variance"`; plain whole-number count (validated `>= 1`, see
+      section 3) for `"top_absolute"`/`"top_contribution"`.
+- [ ] 2.3 Update `PCAAnalysisStep.execute()`: always pass
+      `pc_indices=list(range(n_components))`; branch on
+      `feature_selection_strategy`/`n_top_features` per `design.md`
+      Decisions 1–2 to resolve `n_features_to_select`, casting to
+      `int(...)` for every count branch; emit the `logger.info()` message
+      from Decision 1 whenever `feature_selection_strategy == "extreme"`.
+- [ ] 2.4 Run `uv run pytest tests/test_step_pca_analysis.py` and confirm green.
+
+## 3. Config validation (`pipeline/config/utils.py`)
+
+- [ ] 3.1 Write failing tests in `tests/test_pipeline_config.py` (for
+      `validate_qc_config()`) and `tests/test_viz_pipeline_config.py` (for
+      `validate_viz_config()`) — these are the two files where each
+      function's existing PCA-validation tests already live
+      (`test_validate_config_invalid_pca_components`,
+      `test_validate_config_invalid_pca_strategy`,
+      `test_validate_config_valid_pca_strategies` in the former;
+      `test_invalid_pca_n_components_raises`, `test_invalid_pca_strategy_raises`
+      in the latter) — covering every scenario in the `config-management`
+      spec delta:
+      - `n_top_features < 1` rejected for `"top_absolute"`/
+        `"top_contribution"`, asserting via `pytest.raises(ValueError,
+        match=...)` that the message names both config fields, the
+        offending strategy, and requires an integer `>= 1` (per the
+        spec's own message-content requirement — don't just assert
+        `ValueError` is raised).
+      - a non-whole-number `n_top_features >= 1` (e.g. `5.7`) rejected for
+        every strategy except `"extreme"` (`"top_variance"`,
+        `"top_absolute"`, `"top_contribution"`), asserting the message
+        states the fractional part would be truncated.
+      - a whole-number `n_top_features` (e.g. `5.0` or `5`) `>= 1` is
+        **accepted** for every one of the four strategies
+        (`"extreme"`, `"top_absolute"`, `"top_contribution"`,
+        `"top_variance"`) — not just `"top_variance"`.
+      - a threshold `n_top_features < 1` is accepted for `"top_variance"`.
+      - any `n_top_features` value, including `< 1` or fractional, is
+        accepted for `"extreme"`.
+      - default config values (`feature_selection_strategy="top_variance"`,
+        `n_top_features=10.0`) pass.
+- [ ] 3.2 Add the two `design.md` Decision 3 checks to both
+      `validate_qc_config()` and `validate_viz_config()`, using a tolerance
+      comparison (`abs(n_top - round(n_top)) > 1e-9`), not exact `!=`, for
+      the whole-number check.
+- [ ] 3.3 Run both test files and confirm green.
+
+## 4. Config and docs cleanup
+
+- [ ] 4.1 Remove the now-meaningless `n_top_features` line from every
+      active config pairing `feature_selection_strategy: "extreme"` with an
+      explicit `n_top_features` — verified list of **28 files**: the 27
+      under `configs/active/viz/` (`alfalfa_gwas_groups_1_to_6_combined.yaml`,
+      `alfalfa_gwas_groups_1_to_6_combined_no_root_widths.yaml`,
+      `alfalfa_gwas_w1w2_combined.yaml`, `alfalfa_gwas_wave1.yaml`,
+      `alfalfa_gwas_wave1_canola.yaml`, `alfalfa_gwas_wave1_canola_models.yaml`,
+      `amaranth_tis108_exp1.yaml`, `canola_diversity_screen_qc.yaml`,
+      `emily_shane_pennycress_2026_02_09.yaml`, `emily_shane_soybean_2026_01_15.yaml`,
+      `emily_shane_soybean_2026_03_03.yaml`, `emily_shane_soybean_2026_03_03_grouped.yaml`,
+      `giftol_pennycress_s32_2026_05_11.yaml`, `javier_ttc_salk_soybean.yaml`,
+      `javier_ttc_salk_soybean_brightness.yaml`,
+      `javier_ttc_salk_soybean_full_experiment_9wave.yaml`,
+      `javier_ttc_salk_soybean_full_experiment_9wave_per_wave.yaml`,
+      `shree_weep_soybean.yaml`, `suyash_arabidopsis_pgm1_pac_2026_05_22.yaml`,
+      `turface_alfalfa_gwas.yaml`, `viz_alfalfa_gwas_wave_1_grouped.yaml`,
+      `viz_cylinder_edpie.yaml`, `viz_field_2024_clean.yaml`,
+      `viz_root_coring.yaml`, `viz_turface_150genotypes.yaml`,
+      `viz_turface_19genotypes.yaml`, `weep_maurizio_wave1.yaml`) plus the
+      flat pre-reorg duplicate `configs/active/viz_turface_150genotypes.yaml`.
+      **`configs/active/qc/*.yaml` needs no edits for this task** — verified
+      no QC config pairs `"extreme"` with an explicit `n_top_features`.
+- [ ] 4.2 Rewrite stale `n_top_features`-related comments (not just the
+      key itself) in every one of these locations:
+      - `configs/active/viz/viz_alfalfa_gwas_wave_1_grouped.yaml` (`pca:` block comment)
+      - `configs/active/viz/alfalfa_gwas_wave1_canola_models.yaml` (`pca:` block
+        paragraph explaining "5 means 5 per direction per PC")
+      - `configs/active/viz/viz_cylinder_edpie.yaml` — both the `pca:` block
+        comment AND the separate `static_viz:` comment ("PCA biplot feature
+        control - matches pca.n_top_features for extreme strategy")
+      - `configs/active/viz/viz_field_2024_clean.yaml` (`# Top features for
+        biplot` inline comment, which conflates this field with the
+        separate `static_viz.pca_biplot_top_features`)
+      - `configs/active/viz/viz_root_coring.yaml` (`# Matches
+        N_TOP_FEATURES_BIPLOT` inline comment)
+      - `configs/active/viz/viz_turface_19genotypes.yaml` — both the `pca:`
+        block comment AND the `static_viz:` comment
+      - `configs/examples/viz_comprehensive.yaml`, `viz_publication.yaml`,
+        `viz_standard.yaml` — both the `pca:` block comment ("controls how
+        many features are selected for ANALYSIS purposes... interesting
+        genotype identification" — also fixing the unrelated pre-existing
+        wrong claim per #206's original investigation) AND the
+        `static_viz:` biplot comment ("For "extreme" selection strategies,
+        set this to match the desired per-extreme count...")
+      - `configs/examples/viz_minimal.yaml` (`pca:` block comment only —
+        its biplot comment doesn't reference `"extreme"` and needs no change)
+      All rewrites describe the new semantics: ignored under `"extreme"`;
+      threshold-vs-count under `"top_variance"`; whole-number count,
+      validated, for `"top_absolute"`/`"top_contribution"`.
+- [ ] 4.3 Add a parametrized regression test (e.g. in
+      `tests/test_pipeline_config.py` or a new `tests/test_viz_configs_load.py`)
+      that calls `load_viz_config()` then `validate_viz_config()` on all 28
+      files edited in 4.1 (the 27 under `configs/active/viz/` plus the flat
+      `configs/active/viz_turface_150genotypes.yaml`), asserting no
+      exception — a concrete, re-runnable guard against a YAML syntax error
+      or indentation break introduced by removing the `n_top_features`
+      line, replacing the earlier vague "spot-check a sample" plan.
+- [ ] 4.4 Add a `docs/CHANGELOG.md` `[Unreleased]` entry: a `### Fixed`
+      entry for #203 (PC scoping) and a `### Changed` entry for #206
+      (variance-driven selection), matching the file's existing
+      `[Unreleased]` section structure (`### Added` / `### Fixed` /
+      `### Changed`, in that order).
+
+## 5. Full verification and PR
+
+- [ ] 5.1 Run
+      `uv run pytest --cov=src/sleap_roots_analyze --cov-report=xml --durations=20 -m "not integration" tests/`
+      (exact CI invocation, `.github/workflows/ci.yml`) — full suite green.
+- [ ] 5.2 Run `uv run black src/sleap_roots_analyze tests` and
+      `uv run ruff check src/sleap_roots_analyze tests`.
+- [ ] 5.3 Run `openspec validate fix-pca-top-feature-selection --strict`.
+- [ ] 5.4 Open PR (commit plan below); after merge, comment on #203
+      cross-linking to the PR and close it as resolved (same pattern as
+      #64/#68).
+
+### Suggested commit sequence
+
+1. `feat: add select_n_features_by_variance() PCA helper` — section 1 files.
+2. `fix(#203, #206): scope pc_indices to retained PCs and resolve n_top_features per strategy` — all of section 2 (schema + call site + test updates), as one commit per the atomicity note above.
+3. `fix: reject fractional/non-integer n_top_features for count-based PCA selection strategies` — section 3.
+4. `chore: remove stale n_top_features config lines and comments for extreme PCA selection` — section 4.1–4.3 (line removal, comment rewrites, and the accompanying config-load regression test land together, since the test is what verifies the edits).
+5. `docs: changelog entries for PCA feature-selection fixes (#203, #206)` — section 4.4.

--- a/openspec/changes/fix-pca-top-feature-selection/tasks.md
+++ b/openspec/changes/fix-pca-top-feature-selection/tasks.md
@@ -186,6 +186,53 @@ below must land together.
       cross-linking to the PR and close it as resolved (same pattern as
       #64/#68).
 
+## 6. Follow-up refactors from PR review (design.md Decisions 2 & 5)
+
+Both are behavior-preserving refactors (no observable output change for any
+existing caller) — TDD here means: add a direct unit test for the new
+helper, refactor callers to use it, then confirm the *existing* regression
+suites for every affected function still pass unchanged (proving byte-for-byte
+behavior preservation), plus one new equivalence test proving the specific
+divergence this closes is actually closed.
+
+- [ ] 6.1 Write a unit test for a new `_first_index_crossing_threshold(cumulative,
+      threshold, total) -> int` helper in `tests/test_pca.py` (exact
+      boundary, threshold never reached → `total`, single-element input).
+- [ ] 6.2 Implement `_first_index_crossing_threshold()` in `pca.py`; refactor
+      `select_n_components()` and `select_n_features_by_variance()` to call
+      it (keeping `select_n_features_by_variance()`'s own `threshold <= 0`
+      special-case local to that function, since it has no
+      `select_n_components()` analog).
+- [ ] 6.3 Run the full existing test suites for both functions
+      (`TestSelectNComponents`, `TestSelectNFeaturesByVariance` in
+      `tests/test_pca.py`) unchanged and confirm all still pass — this is
+      the behavior-preservation proof for 6.2.
+- [ ] 6.4 Write a failing equivalence test in `tests/test_pca.py`: run
+      `perform_pca_analysis()` on real (seeded) data, then assert
+      `select_top_features_from_pca(method="top_variance", ...)`'s
+      internal per-feature contribution values are *exactly* equal
+      (`np.array_equal`, not `np.allclose`) to
+      `pca_results["feature_contributions"]["total_contribution"]` — this
+      should fail before the fix (different summation order) and pass
+      after.
+- [ ] 6.5 Implement a new `_total_variance_contribution(loadings,
+      eigenvalues, n_features=None)` helper in `pca.py` per design.md
+      Decision 5; refactor `perform_pca_analysis()`'s `total_contributions`
+      computation and `select_top_features_from_pca()`'s `"top_variance"`
+      branch to both call it. Confirm 6.4's test now passes, and the full
+      existing `test_pca.py`/`test_visualization.py` suites (covering
+      `create_pca_biplot`/`create_umap_colored_by_top_traits`'s
+      `"top_variance"` behavior) still pass unchanged.
+- [ ] 6.6 Add a named `_WHOLE_NUMBER_TOLERANCE = 1e-9` module-level constant
+      in `pipeline/config/utils.py`, replacing the bare `1e-9` literal
+      duplicated in both `validate_qc_config()` and `validate_viz_config()`.
+- [ ] 6.7 Fix the leftover double-blank-line in
+      `configs/active/viz/suyash_arabidopsis_pgm1_pac_2026_05_22.yaml` left
+      by the section-4 `n_top_features` line removal (cosmetic; direct fix,
+      no test needed).
+- [ ] 6.8 Run the full suite, black, ruff, and `openspec validate --strict`
+      once more before pushing.
+
 ### Suggested commit sequence
 
 1. `feat: add select_n_features_by_variance() PCA helper` — section 1 files.
@@ -193,3 +240,4 @@ below must land together.
 3. `fix: reject fractional/non-integer n_top_features for count-based PCA selection strategies` — section 3.
 4. `chore: remove stale n_top_features config lines and comments for extreme PCA selection` — section 4.1–4.3 (line removal, comment rewrites, and the accompanying config-load regression test land together, since the test is what verifies the edits).
 5. `docs: changelog entries for PCA feature-selection fixes (#203, #206)` — section 4.4.
+6. `refactor: extract shared crossing-threshold and variance-contribution helpers` — section 6.1–6.7, as one commit (the two extractions are independent of each other but each individually needs its helper + both refactored callers + passing regression suite to land atomically).

--- a/src/sleap_roots_analyze/pca.py
+++ b/src/sleap_roots_analyze/pca.py
@@ -18,6 +18,34 @@ VALID_SELECTION_METHODS = frozenset(
 )
 
 
+def _total_variance_contribution(
+    loadings: np.ndarray,
+    eigenvalues: np.ndarray,
+    n_features: Optional[int] = None,
+) -> np.ndarray:
+    """Per-feature total variance contribution, vectorized.
+
+    Σ eigenvalue · loading² across every available PC — the single
+    source of truth both `perform_pca_analysis()`'s `feature_contributions`
+    and `select_top_features_from_pca()`'s `"top_variance"` method compute,
+    so the two can never numerically diverge at a tie boundary from using
+    different summation orders (vectorized here vs. accumulated in a loop).
+
+    Args:
+        loadings: Loading matrix (n_features_total, n_components).
+        eigenvalues: Eigenvalues per component.
+        n_features: Restrict to the first `n_features` rows of `loadings`.
+            Uses every row if `None`.
+
+    Returns:
+        1D array of per-feature total variance contribution.
+    """
+    if n_features is not None:
+        loadings = loadings[:n_features]
+    n_pcs = min(loadings.shape[1], len(eigenvalues))
+    return np.sum(loadings[:, :n_pcs] ** 2 * eigenvalues[:n_pcs], axis=1)
+
+
 def select_top_features_from_pca(
     loadings: np.ndarray,
     eigenvalues: np.ndarray,
@@ -116,11 +144,7 @@ def select_top_features_from_pca(
 
     elif method == "top_variance":
         # Use total variance contribution across all available PCs
-        n_pcs = min(loadings.shape[1], len(eigenvalues))
-        contributions = np.zeros(n_features)
-
-        for i in range(n_pcs):
-            contributions += eigenvalues[i] * loadings[:n_features, i] ** 2
+        contributions = _total_variance_contribution(loadings, eigenvalues, n_features)
 
         return np.argsort(contributions)[::-1][:n_features_to_select].tolist()
 
@@ -139,6 +163,33 @@ def select_top_features_from_pca(
             f"Unknown selection method: {method!r}. Expected one of "
             f"{sorted(VALID_SELECTION_METHODS)}."
         )
+
+
+def _first_index_crossing_threshold(
+    cumulative: np.ndarray, threshold: float, total: int
+) -> int:
+    """Smallest leading-element count whose cumulative value meets threshold.
+
+    Shared crossing-index rule for `select_n_components()` (over cumulative
+    explained variance ratio) and `select_n_features_by_variance()` (over
+    cumulative `fractional_contribution`) — kept as a single helper so the
+    two independently-tuned "how many components/features satisfy a
+    cumulative threshold" call sites can't drift apart.
+
+    Args:
+        cumulative: Monotonically non-decreasing cumulative-sum array.
+        threshold: Cumulative value to reach.
+        total: Total number of elements available; also the upper clamp.
+
+    Returns:
+        The smallest count in `[1, total]` whose cumulative value meets
+        `threshold`, or `total` if the threshold is never reached.
+    """
+    if cumulative[-1] >= threshold:
+        n = int(np.argmax(cumulative >= threshold)) + 1
+    else:
+        n = total
+    return max(1, min(n, total))
 
 
 def select_n_components(
@@ -180,16 +231,9 @@ def select_n_components(
 
     cumulative_variance = np.cumsum(pca_full.explained_variance_ratio_)
 
-    if cumulative_variance[-1] >= explained_variance_threshold:
-        # Find the minimum number of components needed
-        n_components = (
-            np.argmax(cumulative_variance >= explained_variance_threshold) + 1
-        )
-    else:
-        # Use all available components
-        n_components = max_components
-
-    return max(1, min(n_components, max_components))
+    return _first_index_crossing_threshold(
+        cumulative_variance, explained_variance_threshold, max_components
+    )
 
 
 def select_n_features_by_variance(
@@ -198,11 +242,12 @@ def select_n_features_by_variance(
 ) -> int:
     """Resolve a cumulative-variance-fraction threshold to a feature count.
 
-    Structurally mirrors `select_n_components()`'s cumulative-threshold
-    crossing rule, but walks a `feature_contributions` DataFrame's
-    `fractional_contribution` column (see `perform_pca_analysis()`) instead
-    of `explained_variance_ratio_`. The DataFrame must already be sorted
-    descending by contribution, as `perform_pca_analysis()` returns it.
+    Shares `_first_index_crossing_threshold()`'s cumulative-threshold
+    crossing rule with `select_n_components()`, but walks a
+    `feature_contributions` DataFrame's `fractional_contribution` column
+    (see `perform_pca_analysis()`) instead of `explained_variance_ratio_`.
+    The DataFrame must already be sorted descending by contribution, as
+    `perform_pca_analysis()` returns it.
 
     Args:
         feature_contributions_df: DataFrame with a `fractional_contribution`
@@ -223,15 +268,10 @@ def select_n_features_by_variance(
         raise ValueError("feature_contributions_df must have at least one row")
 
     if threshold <= 0:
-        n = 1
-    else:
-        cumulative = feature_contributions_df["fractional_contribution"].cumsum()
-        if cumulative.iloc[-1] >= threshold:
-            n = int(np.argmax(cumulative.to_numpy() >= threshold)) + 1
-        else:
-            n = n_total
+        return 1
 
-    return max(1, min(n, n_total))
+    cumulative = feature_contributions_df["fractional_contribution"].cumsum().to_numpy()
+    return _first_index_crossing_threshold(cumulative, threshold, n_total)
 
 
 def fit_pca(
@@ -920,9 +960,7 @@ def perform_pca_analysis(
     n_components = result["n_components_selected"]
 
     # Calculate per-feature total contributions
-    loadings_used = loadings[:, :n_components]
-    eigenvalues_used = eigenvalues[:n_components]
-    total_contributions = np.sum(loadings_used**2 * eigenvalues_used, axis=1)
+    total_contributions = _total_variance_contribution(loadings, eigenvalues)
 
     # Normalize to get fractional contributions
     fractional_contributions = total_contributions / np.sum(total_contributions)

--- a/src/sleap_roots_analyze/pca.py
+++ b/src/sleap_roots_analyze/pca.py
@@ -192,6 +192,48 @@ def select_n_components(
     return max(1, min(n_components, max_components))
 
 
+def select_n_features_by_variance(
+    feature_contributions_df: pd.DataFrame,
+    threshold: float,
+) -> int:
+    """Resolve a cumulative-variance-fraction threshold to a feature count.
+
+    Structurally mirrors `select_n_components()`'s cumulative-threshold
+    crossing rule, but walks a `feature_contributions` DataFrame's
+    `fractional_contribution` column (see `perform_pca_analysis()`) instead
+    of `explained_variance_ratio_`. The DataFrame must already be sorted
+    descending by contribution, as `perform_pca_analysis()` returns it.
+
+    Args:
+        feature_contributions_df: DataFrame with a `fractional_contribution`
+            column, sorted descending, summing to 1 (e.g.
+            `perform_pca_analysis(...)["feature_contributions"]`).
+        threshold: Cumulative fractional-contribution threshold to reach.
+            Values `<= 0` resolve to a single feature.
+
+    Returns:
+        Number of top-ranked features whose cumulative
+        `fractional_contribution` first meets or exceeds `threshold`.
+
+    Raises:
+        ValueError: If `feature_contributions_df` has no rows.
+    """
+    n_total = len(feature_contributions_df)
+    if n_total == 0:
+        raise ValueError("feature_contributions_df must have at least one row")
+
+    if threshold <= 0:
+        n = 1
+    else:
+        cumulative = feature_contributions_df["fractional_contribution"].cumsum()
+        if cumulative.iloc[-1] >= threshold:
+            n = int(np.argmax(cumulative.to_numpy() >= threshold)) + 1
+        else:
+            n = n_total
+
+    return max(1, min(n, n_total))
+
+
 def fit_pca(
     X: np.ndarray,
     n_components: int,

--- a/src/sleap_roots_analyze/pca.py
+++ b/src/sleap_roots_analyze/pca.py
@@ -184,7 +184,13 @@ def _first_index_crossing_threshold(
     Returns:
         The smallest count in `[1, total]` whose cumulative value meets
         `threshold`, or `total` if the threshold is never reached.
+
+    Raises:
+        ValueError: If `cumulative` is empty.
     """
+    if len(cumulative) == 0:
+        raise ValueError("cumulative must have at least one element")
+
     if cumulative[-1] >= threshold:
         n = int(np.argmax(cumulative >= threshold)) + 1
     else:

--- a/src/sleap_roots_analyze/pipeline/config/components.py
+++ b/src/sleap_roots_analyze/pipeline/config/components.py
@@ -424,13 +424,15 @@ class PCAConfig:
               is a cumulative fractional-variance-contribution threshold
               (features are added, highest-contribution first, until their
               combined fractional_contribution reaches this fraction); a
-              value >= 1 is a fixed feature count (legacy behavior).
+              value >= 1 is a fixed feature count and, like the two
+              strategies below, must be a whole number (legacy behavior).
               Note: exactly 1.0 takes the count branch (selects 1 feature),
               not "100% of variance" — it is not a special threshold value.
             - "top_absolute", "top_contribution": a fixed feature count
               only; must be a whole number >= 1 (validated at config-load
               time — a value < 1 or a non-whole number is rejected, since
-              e.g. int(0.5) == 0 would silently select nothing).
+              e.g. int(0.5) == 0 or truncating 5.7 to 5 would silently
+              select the wrong count).
     """
 
     n_components: float = 0.95

--- a/src/sleap_roots_analyze/pipeline/config/components.py
+++ b/src/sleap_roots_analyze/pipeline/config/components.py
@@ -413,13 +413,30 @@ class PCAConfig:
         n_components: Number of components (or variance ratio if < 1).
         standardize: Whether to standardize data before PCA.
         feature_selection_strategy: Strategy for selecting top features.
-        n_top_features: Number of top features to select per component.
+        n_top_features: Feature-selection count or threshold; meaning
+            depends on feature_selection_strategy:
+            - "extreme": ignored entirely (any value, including one < 1).
+              Always selects exactly 1 most-positive-loading and 1
+              most-negative-loading feature per retained PC (2 per PC),
+              regardless of this value. A one-time log message notes this
+              at run time.
+            - "top_variance": overloaded like n_components — a value < 1
+              is a cumulative fractional-variance-contribution threshold
+              (features are added, highest-contribution first, until their
+              combined fractional_contribution reaches this fraction); a
+              value >= 1 is a fixed feature count (legacy behavior).
+              Note: exactly 1.0 takes the count branch (selects 1 feature),
+              not "100% of variance" — it is not a special threshold value.
+            - "top_absolute", "top_contribution": a fixed feature count
+              only; must be a whole number >= 1 (validated at config-load
+              time — a value < 1 or a non-whole number is rejected, since
+              e.g. int(0.5) == 0 would silently select nothing).
     """
 
     n_components: float = 0.95
     standardize: bool = True
     feature_selection_strategy: str = "top_variance"
-    n_top_features: int = 10
+    n_top_features: float = 10.0
 
 
 @dataclass

--- a/src/sleap_roots_analyze/pipeline/config/utils.py
+++ b/src/sleap_roots_analyze/pipeline/config/utils.py
@@ -18,6 +18,12 @@ from sleap_roots_analyze.pipeline.config.viz_config import VizPipelineConfig
 from sleap_roots_analyze.pipeline.config.components import CrossPlatformConfig
 from sleap_roots_analyze.validation import VALIDATE_INPUT_MODES
 
+# Tolerance for pca.n_top_features' "whole number" check in
+# validate_qc_config()/validate_viz_config() — hand-typed YAML literals
+# should be exact, but this hedges against float-accumulation noise from a
+# future config-generation path (e.g. 9.999999999999998 instead of 10.0).
+_WHOLE_NUMBER_TOLERANCE = 1e-9
+
 
 # ============================================================================
 # QC Pipeline Configuration Utilities
@@ -285,7 +291,11 @@ def validate_qc_config(config: QCPipelineConfig, check_files: bool = True) -> No
             f"'{strategy}' with n_top_features={n_top}. Use an integer >= 1 "
             "for this strategy."
         )
-    if n_top >= 1 and strategy != "extreme" and abs(n_top - round(n_top)) > 1e-9:
+    if (
+        n_top >= 1
+        and strategy != "extreme"
+        and abs(n_top - round(n_top)) > _WHOLE_NUMBER_TOLERANCE
+    ):
         raise ValueError(
             f"pca.n_top_features must be a whole number when >= 1 (got "
             f"{n_top} for pca.feature_selection_strategy='{strategy}'); the "
@@ -516,7 +526,11 @@ def validate_viz_config(config: VizPipelineConfig) -> None:
             f"'{strategy}' with n_top_features={n_top}. Use an integer >= 1 "
             "for this strategy."
         )
-    if n_top >= 1 and strategy != "extreme" and abs(n_top - round(n_top)) > 1e-9:
+    if (
+        n_top >= 1
+        and strategy != "extreme"
+        and abs(n_top - round(n_top)) > _WHOLE_NUMBER_TOLERANCE
+    ):
         raise ValueError(
             f"pca.n_top_features must be a whole number when >= 1 (got "
             f"{n_top} for pca.feature_selection_strategy='{strategy}'); the "

--- a/src/sleap_roots_analyze/pipeline/config/utils.py
+++ b/src/sleap_roots_analyze/pipeline/config/utils.py
@@ -6,6 +6,7 @@ pipeline configurations.
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from typing import Any, Dict
 
@@ -272,6 +273,11 @@ def validate_qc_config(config: QCPipelineConfig, check_files: bool = True) -> No
     # value is harmless for that strategy — both checks below skip it.
     n_top = config.pca.n_top_features
     strategy = config.pca.feature_selection_strategy
+    if strategy != "extreme" and not math.isfinite(n_top):
+        raise ValueError(
+            f"pca.n_top_features must be a finite number (got {n_top!r} for "
+            f"pca.feature_selection_strategy='{strategy}')."
+        )
     if n_top < 1 and strategy not in ("extreme", "top_variance"):
         raise ValueError(
             "pca.n_top_features < 1 (variance-fraction threshold) is only "
@@ -498,6 +504,11 @@ def validate_viz_config(config: VizPipelineConfig) -> None:
     # value is harmless for that strategy — both checks below skip it.
     n_top = config.pca.n_top_features
     strategy = config.pca.feature_selection_strategy
+    if strategy != "extreme" and not math.isfinite(n_top):
+        raise ValueError(
+            f"pca.n_top_features must be a finite number (got {n_top!r} for "
+            f"pca.feature_selection_strategy='{strategy}')."
+        )
     if n_top < 1 and strategy not in ("extreme", "top_variance"):
         raise ValueError(
             "pca.n_top_features < 1 (variance-fraction threshold) is only "

--- a/src/sleap_roots_analyze/pipeline/config/utils.py
+++ b/src/sleap_roots_analyze/pipeline/config/utils.py
@@ -268,6 +268,24 @@ def validate_qc_config(config: QCPipelineConfig, check_files: bool = True) -> No
             f"pca.feature_selection_strategy must be one of {valid_pca_strategies}"
         )
 
+    # n_top_features is ignored entirely for "extreme" (issue #206), so any
+    # value is harmless for that strategy — both checks below skip it.
+    n_top = config.pca.n_top_features
+    strategy = config.pca.feature_selection_strategy
+    if n_top < 1 and strategy not in ("extreme", "top_variance"):
+        raise ValueError(
+            "pca.n_top_features < 1 (variance-fraction threshold) is only "
+            "supported for pca.feature_selection_strategy='top_variance'; got "
+            f"'{strategy}' with n_top_features={n_top}. Use an integer >= 1 "
+            "for this strategy."
+        )
+    if n_top >= 1 and strategy != "extreme" and abs(n_top - round(n_top)) > 1e-9:
+        raise ValueError(
+            f"pca.n_top_features must be a whole number when >= 1 (got "
+            f"{n_top} for pca.feature_selection_strategy='{strategy}'); the "
+            "fractional part would be silently truncated."
+        )
+
     # Validate clustering config
     valid_cluster_methods = ["kmeans", "gmm", "hierarchical"]
     if config.clustering.enabled:
@@ -474,6 +492,24 @@ def validate_viz_config(config: VizPipelineConfig) -> None:
     if config.pca.feature_selection_strategy not in valid_pca_strategies:
         raise ValueError(
             f"pca.feature_selection_strategy must be one of {valid_pca_strategies}"
+        )
+
+    # n_top_features is ignored entirely for "extreme" (issue #206), so any
+    # value is harmless for that strategy — both checks below skip it.
+    n_top = config.pca.n_top_features
+    strategy = config.pca.feature_selection_strategy
+    if n_top < 1 and strategy not in ("extreme", "top_variance"):
+        raise ValueError(
+            "pca.n_top_features < 1 (variance-fraction threshold) is only "
+            "supported for pca.feature_selection_strategy='top_variance'; got "
+            f"'{strategy}' with n_top_features={n_top}. Use an integer >= 1 "
+            "for this strategy."
+        )
+    if n_top >= 1 and strategy != "extreme" and abs(n_top - round(n_top)) > 1e-9:
+        raise ValueError(
+            f"pca.n_top_features must be a whole number when >= 1 (got "
+            f"{n_top} for pca.feature_selection_strategy='{strategy}'); the "
+            "fractional part would be silently truncated."
         )
 
     # Validate clustering config if enabled

--- a/src/sleap_roots_analyze/pipeline/steps/pca_analysis.py
+++ b/src/sleap_roots_analyze/pipeline/steps/pca_analysis.py
@@ -11,6 +11,7 @@ import pandas as pd
 
 from sleap_roots_analyze.pca import (
     perform_pca_analysis,
+    select_n_features_by_variance,
     select_top_features_from_pca,
 )
 from sleap_roots_analyze.pipeline.core import BaseStep, StepResult
@@ -105,13 +106,32 @@ class PCAAnalysisStep(BaseStep):
 
         logger.info(f"PCA used {len(feature_names)} of {len(trait_cols)} traits")
 
+        # Resolve n_features_to_select per feature_selection_strategy (issue #206).
+        # pc_indices is always explicit, scoped to every retained PC (issue #203) —
+        # never relies on select_top_features_from_pca()'s [0, 1] default.
+        strategy = config.pca.feature_selection_strategy
+        if strategy == "extreme":
+            n_features_to_select = 1
+            logger.info(
+                "feature_selection_strategy='extreme': pca.n_top_features is not "
+                "read for this method (always 1 most-positive + 1 most-negative "
+                "loading feature per retained PC)."
+            )
+        elif strategy == "top_variance" and config.pca.n_top_features < 1:
+            n_features_to_select = select_n_features_by_variance(
+                pca_results["feature_contributions"], config.pca.n_top_features
+            )
+        else:
+            n_features_to_select = int(config.pca.n_top_features)
+
         # Select top features using filtered feature names
         top_feature_indices = select_top_features_from_pca(
             loadings=pca_results["loadings"],
             eigenvalues=pca_results["eigenvalues"],
             n_features_total=len(feature_names),
-            n_features_to_select=config.pca.n_top_features,
-            method=config.pca.feature_selection_strategy,
+            n_features_to_select=n_features_to_select,
+            method=strategy,
+            pc_indices=list(range(n_components)),
         )
 
         top_features = [feature_names[i] for i in top_feature_indices]

--- a/src/sleap_roots_analyze/pipeline/steps/pca_analysis.py
+++ b/src/sleap_roots_analyze/pipeline/steps/pca_analysis.py
@@ -122,7 +122,12 @@ class PCAAnalysisStep(BaseStep):
                 pca_results["feature_contributions"], config.pca.n_top_features
             )
         else:
-            n_features_to_select = int(config.pca.n_top_features)
+            # round(), not int(): validate_qc_config()/validate_viz_config() only
+            # guarantee n_top_features is within 1e-9 of a whole number, not that
+            # it equals one exactly (e.g. float-accumulation noise). int() would
+            # truncate a value like 9.999999999999998 down to 9, silently
+            # reproducing the exact class of bug this validation exists to catch.
+            n_features_to_select = round(config.pca.n_top_features)
 
         # Select top features using filtered feature names
         top_feature_indices = select_top_features_from_pca(

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -264,6 +264,19 @@ class TestFirstIndexCrossingThreshold:
         # full cumulative array — result must still respect that cap.
         assert _first_index_crossing_threshold(cumulative, 1.0, total=2) == 2
 
+    def test_total_larger_than_cumulative_length(self):
+        """Total may exceed len(cumulative); the crossing index is unaffected."""
+        cumulative = np.array([0.5, 0.8, 0.95, 1.0])
+        # No real caller does this today (both pass total == len(cumulative)),
+        # but the contract should hold regardless: the result is bounded by
+        # len(cumulative), not artificially inflated by a larger total.
+        assert _first_index_crossing_threshold(cumulative, 0.8, total=10) == 2
+
+    def test_empty_cumulative_raises(self):
+        """An empty cumulative array is a caller error, not an IndexError crash."""
+        with pytest.raises(ValueError, match="at least one element"):
+            _first_index_crossing_threshold(np.array([]), 0.5, total=0)
+
 
 class TestTotalVarianceContribution:
     """Test suite for the shared _total_variance_contribution() helper.
@@ -299,6 +312,29 @@ class TestTotalVarianceContribution:
         result = _total_variance_contribution(loadings, eigenvalues, n_features=2)
 
         assert len(result) == 2
+
+    def test_eigenvalues_shorter_than_loadings_columns_clamps_to_n_pcs(self):
+        """Only the first len(eigenvalues) PCs contribute (the n_pcs clamp).
+
+        Documented as a deliberate defense for a scoped-`"top_variance"`
+        caller that pre-slices `loadings`/`eigenvalues` to different
+        lengths (per this function's own docstring convention) — no
+        current caller does this, but the clamp exists on purpose and
+        should be exercised directly.
+        """
+        loadings = np.array([[0.6, 0.2, 0.9], [0.8, -0.1, 0.4], [-0.3, 0.9, -0.5]])
+        eigenvalues = np.array([2.0, 0.5])  # Only 2 of the 3 PC columns.
+
+        result = _total_variance_contribution(loadings, eigenvalues)
+
+        expected = np.array(
+            [
+                2.0 * 0.6**2 + 0.5 * 0.2**2,
+                2.0 * 0.8**2 + 0.5 * (-0.1) ** 2,
+                2.0 * (-0.3) ** 2 + 0.5 * 0.9**2,
+            ]
+        )
+        np.testing.assert_allclose(result, expected)
 
     def test_matches_a_naive_accumulation_loop_up_to_float_noise(self):
         """Same formula as a naive loop, not necessarily the same bits.

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -10,6 +10,8 @@ from sklearn.decomposition import PCA as SklearnPCA
 from sklearn.preprocessing import StandardScaler
 
 from sleap_roots_analyze.pca import (
+    _first_index_crossing_threshold,
+    _total_variance_contribution,
     calculate_mahalanobis_distances,
     calculate_pca_metrics,
     calculate_pca_reconstruction_error,
@@ -230,6 +232,124 @@ class TestSelectNFeaturesByVariance:
         df = pd.DataFrame({"total_contribution": [], "fractional_contribution": []})
         with pytest.raises(ValueError, match="at least one row"):
             select_n_features_by_variance(df, threshold=0.5)
+
+
+class TestFirstIndexCrossingThreshold:
+    """Test suite for the shared _first_index_crossing_threshold() helper.
+
+    Used by both select_n_components() and select_n_features_by_variance()
+    (design.md Decision 2) — tested directly here since it's the single
+    source of truth both callers' own test suites now rely on implicitly.
+    """
+
+    def test_exact_boundary(self):
+        """A threshold exactly equal to a cumulative-sum row is met by that row."""
+        cumulative = np.array([0.5, 0.8, 0.95, 1.0])
+        assert _first_index_crossing_threshold(cumulative, 0.8, total=4) == 2
+
+    def test_threshold_never_reached_returns_total(self):
+        """A threshold above the full cumulative sum returns total, not fewer."""
+        cumulative = np.array([0.5, 0.8, 0.95, 1.0])
+        assert _first_index_crossing_threshold(cumulative, 1.5, total=4) == 4
+
+    def test_single_element(self):
+        """A single-element cumulative array always resolves to 1."""
+        cumulative = np.array([1.0])
+        assert _first_index_crossing_threshold(cumulative, 0.5, total=1) == 1
+
+    def test_clamps_to_total(self):
+        """The result never exceeds total, even if cumulative has more rows."""
+        cumulative = np.array([0.5, 0.8, 0.95, 1.0])
+        # total=2 simulates a caller restricting to fewer elements than the
+        # full cumulative array — result must still respect that cap.
+        assert _first_index_crossing_threshold(cumulative, 1.0, total=2) == 2
+
+
+class TestTotalVarianceContribution:
+    """Test suite for the shared _total_variance_contribution() helper.
+
+    perform_pca_analysis() and select_top_features_from_pca()'s
+    "top_variance" method both call this single helper (design.md
+    Decision 5) so their per-feature contribution values can never
+    numerically diverge from independently re-deriving the same formula
+    (Σ eigenvalue · loading²) via two different summation orders.
+    """
+
+    def test_matches_hand_calculated_values(self):
+        """Sigma eigenvalue * loading^2 per feature, computed by hand."""
+        loadings = np.array([[0.6, 0.2], [0.8, -0.1], [-0.3, 0.9]])
+        eigenvalues = np.array([2.0, 0.5])
+
+        result = _total_variance_contribution(loadings, eigenvalues)
+
+        expected = np.array(
+            [
+                2.0 * 0.6**2 + 0.5 * 0.2**2,
+                2.0 * 0.8**2 + 0.5 * (-0.1) ** 2,
+                2.0 * (-0.3) ** 2 + 0.5 * 0.9**2,
+            ]
+        )
+        np.testing.assert_allclose(result, expected)
+
+    def test_n_features_restricts_rows(self):
+        """An explicit n_features restricts to that many leading rows."""
+        loadings = np.array([[0.6, 0.2], [0.8, -0.1], [-0.3, 0.9]])
+        eigenvalues = np.array([2.0, 0.5])
+
+        result = _total_variance_contribution(loadings, eigenvalues, n_features=2)
+
+        assert len(result) == 2
+
+    def test_matches_a_naive_accumulation_loop_up_to_float_noise(self):
+        """Same formula as a naive loop, not necessarily the same bits.
+
+        Not necessarily bit-identical to a naive per-PC accumulation loop
+        — that gap is exactly the divergence this refactor eliminates by
+        leaving only one implementation.
+
+        With enough PCs, a naive per-column accumulation loop (the pattern
+        previously duplicated in select_top_features_from_pca()'s
+        "top_variance" branch before this refactor) can disagree with a
+        vectorized `np.sum` by float-summation-order noise. Confirmed here
+        with a fixed seed where the two demonstrably differ at the bit
+        level, to make the "no longer two independent implementations"
+        guarantee concrete rather than theoretical.
+        """
+        rng = np.random.RandomState(42)
+        loadings = rng.randn(50, 30)
+        eigenvalues = np.abs(rng.randn(30)) + 0.01
+
+        naive_loop_result = np.zeros(50)
+        for i in range(30):
+            naive_loop_result += eigenvalues[i] * loadings[:, i] ** 2
+
+        result = _total_variance_contribution(loadings, eigenvalues)
+
+        np.testing.assert_allclose(result, naive_loop_result)  # same formula...
+        assert not np.array_equal(result, naive_loop_result)  # ...different bits
+
+    def test_matches_perform_pca_analysis_feature_contributions_exactly(self):
+        """Stored total_contribution must equal a direct call to the helper.
+
+        perform_pca_analysis()'s stored value and a direct call to this
+        same shared helper with the same inputs — the single-source-of-truth
+        guarantee design.md Decision 5 exists for.
+        """
+        np.random.seed(0)
+        df = pd.DataFrame(
+            np.random.randn(30, 6), columns=[f"trait{i}" for i in range(6)]
+        )
+        pca_results = perform_pca_analysis(df, n_components=4)
+
+        direct = _total_variance_contribution(
+            pca_results["loadings"], pca_results["eigenvalues"]
+        )
+        stored = (
+            pca_results["feature_contributions"]
+            .loc[pca_results["feature_names"], "total_contribution"]
+            .to_numpy()
+        )
+        np.testing.assert_array_equal(direct, stored)
 
 
 class TestFitPCA:

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -186,6 +186,18 @@ class TestSelectNFeaturesByVariance:
         n = select_n_features_by_variance(feature_contributions_df, threshold=1.0)
         assert n == 4
 
+    def test_threshold_unreachable_even_by_full_sum_selects_all_features(
+        self, feature_contributions_df
+    ):
+        """An unreachable threshold still returns all features.
+
+        Exercises the `else` fallback branch, which a threshold of exactly
+        1.0 cannot reach since `fractional_contribution` sums to exactly
+        1.0 by construction here.
+        """
+        n = select_n_features_by_variance(feature_contributions_df, threshold=1.5)
+        assert n == 4
+
     def test_threshold_met_by_fewer_than_all_features(self, feature_contributions_df):
         """The resolved count meets the threshold without wildly overshooting it."""
         n = select_n_features_by_variance(feature_contributions_df, threshold=0.6)

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -17,6 +17,7 @@ from sleap_roots_analyze.pca import (
     perform_pca_analysis,
     perform_pca_with_variance_threshold,
     select_n_components,
+    select_n_features_by_variance,
     select_top_features_from_pca,
     standardize_data,
 )
@@ -156,6 +157,67 @@ class TestSelectNComponents:
         n_high = select_n_components(data, explained_variance_threshold=0.99)
 
         assert n_low <= n_high
+
+
+class TestSelectNFeaturesByVariance:
+    """Test suite for select_n_features_by_variance function (issue #206)."""
+
+    @pytest.fixture
+    def feature_contributions_df(self):
+        """Feature contributions matching perform_pca_analysis's shape.
+
+        Sorted descending by contribution, `fractional_contribution` sums to 1.
+        """
+        return pd.DataFrame(
+            {
+                "total_contribution": [5.0, 3.0, 1.5, 0.5],
+                "fractional_contribution": [0.5, 0.3, 0.15, 0.05],
+            },
+            index=["feat_a", "feat_b", "feat_c", "feat_d"],
+        )
+
+    def test_threshold_met_exactly_at_row_boundary(self, feature_contributions_df):
+        """A threshold exactly equal to a cumulative-sum row is met by that row."""
+        n = select_n_features_by_variance(feature_contributions_df, threshold=0.8)
+        assert n == 2
+
+    def test_threshold_requiring_all_features(self, feature_contributions_df):
+        """A threshold only reached by the full cumulative sum selects every row."""
+        n = select_n_features_by_variance(feature_contributions_df, threshold=1.0)
+        assert n == 4
+
+    def test_threshold_met_by_fewer_than_all_features(self, feature_contributions_df):
+        """The resolved count meets the threshold without wildly overshooting it."""
+        n = select_n_features_by_variance(feature_contributions_df, threshold=0.6)
+
+        cumulative = feature_contributions_df["fractional_contribution"].cumsum()
+        assert cumulative.iloc[n - 1] >= 0.6
+        # One fewer feature must NOT meet the threshold (minimal selection).
+        assert n == 1 or cumulative.iloc[n - 2] < 0.6
+
+    def test_non_positive_threshold_resolves_to_one_feature(
+        self, feature_contributions_df
+    ):
+        """Threshold <= 0 selects exactly 1 feature without raising."""
+        assert select_n_features_by_variance(feature_contributions_df, threshold=0) == 1
+        assert (
+            select_n_features_by_variance(feature_contributions_df, threshold=-0.5) == 1
+        )
+
+    def test_single_feature_dataframe(self):
+        """A single-row DataFrame always resolves to 1 feature."""
+        df = pd.DataFrame(
+            {"total_contribution": [2.0], "fractional_contribution": [1.0]},
+            index=["only_feature"],
+        )
+        assert select_n_features_by_variance(df, threshold=0.5) == 1
+        assert select_n_features_by_variance(df, threshold=0.999) == 1
+
+    def test_empty_dataframe_raises(self):
+        """An empty feature_contributions DataFrame is a caller error."""
+        df = pd.DataFrame({"total_contribution": [], "fractional_contribution": []})
+        with pytest.raises(ValueError, match="at least one row"):
+            select_n_features_by_variance(df, threshold=0.5)
 
 
 class TestFitPCA:

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -356,6 +356,8 @@ def test_validate_config_rejects_fractional_n_top_features_below_1(strategy):
         validate_qc_config(config)
     assert "pca.feature_selection_strategy" in str(exc_info.value)
     assert strategy in str(exc_info.value)
+    assert "integer" in str(exc_info.value)
+    assert ">= 1" in str(exc_info.value)
 
 
 @pytest.mark.parametrize(
@@ -371,6 +373,60 @@ def test_validate_config_rejects_non_whole_number_n_top_features_ge_1(strategy):
     with pytest.raises(ValueError, match="whole number") as exc_info:
         validate_qc_config(config)
     assert "truncated" in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "strategy", ["top_absolute", "top_contribution", "top_variance"]
+)
+def test_validate_config_rejects_nan_n_top_features(strategy):
+    """NaN must not silently bypass both range checks (both compare False against NaN)."""
+    config = QCPipelineConfig(pipeline_name="test")
+    config.data.csv_path = "data.csv"
+    config.pca.feature_selection_strategy = strategy
+    config.pca.n_top_features = float("nan")
+
+    with pytest.raises(ValueError, match="finite"):
+        validate_qc_config(config)
+
+
+@pytest.mark.parametrize(
+    "strategy", ["top_absolute", "top_contribution", "top_variance"]
+)
+def test_validate_config_rejects_infinite_n_top_features(strategy):
+    """Inf must raise ValueError, not OverflowError from round()."""
+    config = QCPipelineConfig(pipeline_name="test")
+    config.data.csv_path = "data.csv"
+    config.pca.feature_selection_strategy = strategy
+    config.pca.n_top_features = float("inf")
+
+    with pytest.raises(ValueError, match="finite"):
+        validate_qc_config(config)
+
+
+def test_validate_config_accepts_nan_or_inf_n_top_features_for_extreme():
+    """Extreme ignores the field entirely, so non-finite values are still harmless."""
+    config = QCPipelineConfig(pipeline_name="test")
+    config.data.csv_path = "data.csv"
+    config.pca.feature_selection_strategy = "extreme"
+
+    for value in [float("nan"), float("inf"), float("-inf")]:
+        config.pca.n_top_features = value
+        validate_qc_config(config)  # Should not raise
+
+
+def test_validate_config_accepts_near_whole_number_from_float_accumulation():
+    """A value validation certifies as "whole" must not become uncertifiable.
+
+    E.g. from float summation, must not then get truncated to a different
+    integer at the PCAAnalysisStep consumption site.
+    """
+    config = QCPipelineConfig(pipeline_name="test")
+    config.data.csv_path = "data.csv"
+    config.pca.feature_selection_strategy = "top_absolute"
+    # A completely ordinary float-accumulation result that isn't exactly 10.0.
+    config.pca.n_top_features = sum([0.1] * 10) * 10
+    assert config.pca.n_top_features != 10.0  # confirms the float-noise premise
+    validate_qc_config(config)  # Should not raise — within tolerance of 10
 
 
 def test_validate_config_accepts_top_variance_threshold_below_1():
@@ -404,6 +460,18 @@ def test_validate_config_accepts_whole_number_n_top_features_for_any_strategy(
     config.data.csv_path = "data.csv"
     config.pca.feature_selection_strategy = strategy
     config.pca.n_top_features = 5.0
+    validate_qc_config(config)  # Should not raise
+
+
+def test_validate_config_default_pca_values_pass():
+    """PCAConfig()'s defaults pass validation without needing any override.
+
+    Defaults: feature_selection_strategy='top_variance', n_top_features=10.0.
+    """
+    config = QCPipelineConfig(pipeline_name="test")
+    config.data.csv_path = "data.csv"
+    assert config.pca.feature_selection_strategy == "top_variance"
+    assert config.pca.n_top_features == 10.0
     validate_qc_config(config)  # Should not raise
 
 

--- a/tests/test_pipeline_config.py
+++ b/tests/test_pipeline_config.py
@@ -344,6 +344,69 @@ def test_validate_config_valid_pca_strategies():
         validate_qc_config(config)  # Should not raise
 
 
+@pytest.mark.parametrize("strategy", ["top_absolute", "top_contribution"])
+def test_validate_config_rejects_fractional_n_top_features_below_1(strategy):
+    """Reject n_top_features < 1 for count-only strategies (issue #206)."""
+    config = QCPipelineConfig(pipeline_name="test")
+    config.data.csv_path = "data.csv"
+    config.pca.feature_selection_strategy = strategy
+    config.pca.n_top_features = 0.5
+
+    with pytest.raises(ValueError, match="pca.n_top_features") as exc_info:
+        validate_qc_config(config)
+    assert "pca.feature_selection_strategy" in str(exc_info.value)
+    assert strategy in str(exc_info.value)
+
+
+@pytest.mark.parametrize(
+    "strategy", ["top_variance", "top_absolute", "top_contribution"]
+)
+def test_validate_config_rejects_non_whole_number_n_top_features_ge_1(strategy):
+    """Reject a non-whole-number n_top_features >= 1 for non-extreme strategies."""
+    config = QCPipelineConfig(pipeline_name="test")
+    config.data.csv_path = "data.csv"
+    config.pca.feature_selection_strategy = strategy
+    config.pca.n_top_features = 5.7
+
+    with pytest.raises(ValueError, match="whole number") as exc_info:
+        validate_qc_config(config)
+    assert "truncated" in str(exc_info.value)
+
+
+def test_validate_config_accepts_top_variance_threshold_below_1():
+    """A < 1 threshold is accepted for top_variance."""
+    config = QCPipelineConfig(pipeline_name="test")
+    config.data.csv_path = "data.csv"
+    config.pca.feature_selection_strategy = "top_variance"
+    config.pca.n_top_features = 0.8
+    validate_qc_config(config)  # Should not raise
+
+
+def test_validate_config_accepts_any_n_top_features_for_extreme():
+    """Any n_top_features value, including fractional or < 1, is accepted for extreme."""
+    config = QCPipelineConfig(pipeline_name="test")
+    config.data.csv_path = "data.csv"
+    config.pca.feature_selection_strategy = "extreme"
+
+    for value in [0.5, 5.7, -1, 0]:
+        config.pca.n_top_features = value
+        validate_qc_config(config)  # Should not raise
+
+
+@pytest.mark.parametrize(
+    "strategy", ["extreme", "top_absolute", "top_contribution", "top_variance"]
+)
+def test_validate_config_accepts_whole_number_n_top_features_for_any_strategy(
+    strategy,
+):
+    """A whole-number count >= 1 is accepted regardless of strategy."""
+    config = QCPipelineConfig(pipeline_name="test")
+    config.data.csv_path = "data.csv"
+    config.pca.feature_selection_strategy = strategy
+    config.pca.n_top_features = 5.0
+    validate_qc_config(config)  # Should not raise
+
+
 def test_validate_config_invalid_clustering_method():
     """Test validation fails for invalid clustering method."""
     config = QCPipelineConfig(pipeline_name="test")

--- a/tests/test_step_pca_analysis.py
+++ b/tests/test_step_pca_analysis.py
@@ -1061,3 +1061,24 @@ class TestPCAAnalysisStepFeatureSelectionResolution:
         )
 
         assert len(result.metadata["top_features"]) == 5
+
+    def test_count_selection_rounds_rather_than_truncates_near_whole_numbers(
+        self, config, sample_data, prev_result, tmp_path
+    ):
+        """A value certified as "whole" must resolve to that same integer here.
+
+        validate_*_config() only guarantees "whole" within tolerance; this
+        step must not silently truncate down to a different neighbor.
+        """
+        config.pca.feature_selection_strategy = "top_absolute"
+        config.pca.n_top_features = 5.0 - 1e-15  # int() truncates to 4; round() gives 5
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=sample_data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=prev_result,
+        )
+
+        assert len(result.metadata["top_features"]) == 5

--- a/tests/test_step_pca_analysis.py
+++ b/tests/test_step_pca_analysis.py
@@ -2,14 +2,17 @@
 
 from __future__ import annotations
 
+import logging
 import warnings
 from pathlib import Path
+from unittest import mock
 from unittest.mock import MagicMock
 
 import numpy as np
 import pandas as pd
 import pytest
 
+from sleap_roots_analyze.pca import select_top_features_from_pca
 from sleap_roots_analyze.pipeline import (
     ColumnConfig,
     DataConfig,
@@ -176,9 +179,16 @@ class TestPCAAnalysisStep:
                 prev_result=prev_result,
             )
 
-            # All strategies should return at least the requested number (some may return more)
-            # The "extreme" strategy may return all features if they all have extreme values
-            assert len(result.metadata["top_features"]) >= config.pca.n_top_features
+            if strategy == "extreme":
+                # "extreme" ignores n_top_features entirely (issue #206): always
+                # at most 1-most-positive + 1-most-negative per retained PC.
+                assert (
+                    len(result.metadata["top_features"]) <= 2 * config.pca.n_components
+                )
+            else:
+                # Other strategies return at least the requested number
+                # (some may return more).
+                assert len(result.metadata["top_features"]) >= config.pca.n_top_features
             assert all(
                 f in prev_result.metadata["trait_cols"]
                 for f in result.metadata["top_features"]
@@ -852,3 +862,202 @@ class TestPCATraitNamesMetadataPropagation:
         assert result.metadata["trait_names"] == trait_cols
         assert result.metadata["valid_trait_names"] == trait_cols
         assert result.metadata["original_trait_names"] == trait_cols
+
+
+class TestPCAAnalysisStepFeatureSelectionResolution:
+    """Regression tests for issues #203 and #206.
+
+    `PCAAnalysisStep` must always pass `pc_indices` explicitly (scoped to
+    every retained PC, never relying on `select_top_features_from_pca()`'s
+    `[0, 1]` default), must ignore `n_top_features` entirely for
+    `"extreme"`, and must resolve a `< 1` `n_top_features` under
+    `"top_variance"` via `select_n_features_by_variance()`.
+    """
+
+    @pytest.fixture
+    def config_3pc(self):
+        """Config selecting exactly 3 PCs (beyond the buggy [0, 1] default)."""
+        return QCPipelineConfig(
+            pipeline_name="test_pca_3pc",
+            columns=ColumnConfig(barcode="Barcode", genotype="geno", replicate="rep"),
+            data=DataConfig(csv_path="test.csv"),
+            pca=PCAConfig(
+                n_components=3,
+                standardize=True,
+                n_top_features=2,
+                feature_selection_strategy="extreme",
+            ),
+        )
+
+    @pytest.mark.parametrize(
+        "strategy", ["extreme", "top_absolute", "top_contribution"]
+    )
+    def test_pc_indices_always_passed_scoped_to_n_components(
+        self, config_3pc, sample_data, prev_result, tmp_path, strategy
+    ):
+        """pc_indices is always explicit and scoped to every retained PC (#203)."""
+        config_3pc.pca.feature_selection_strategy = strategy
+        step = PCAAnalysisStep()
+
+        with mock.patch(
+            "sleap_roots_analyze.pipeline.steps.pca_analysis.select_top_features_from_pca",
+            wraps=select_top_features_from_pca,
+        ) as spy:
+            step.execute(
+                data=sample_data,
+                config=config_3pc,
+                run_dir=tmp_path,
+                prev_result=prev_result,
+            )
+
+        spy.assert_called_once()
+        assert spy.call_args.kwargs["pc_indices"] == [0, 1, 2]
+
+    def test_extreme_uses_n_features_to_select_1_ignoring_n_top_features(
+        self, config, sample_data, prev_result, tmp_path
+    ):
+        """The "extreme" strategy always requests 1-per-direction, regardless of n_top_features."""
+        config.pca.feature_selection_strategy = "extreme"
+        config.pca.n_top_features = 999  # Arbitrary stale value; must be ignored.
+        step = PCAAnalysisStep()
+
+        with mock.patch(
+            "sleap_roots_analyze.pipeline.steps.pca_analysis.select_top_features_from_pca",
+            wraps=select_top_features_from_pca,
+        ) as spy:
+            step.execute(
+                data=sample_data,
+                config=config,
+                run_dir=tmp_path,
+                prev_result=prev_result,
+            )
+
+        assert spy.call_args.kwargs["n_features_to_select"] == 1
+
+    def test_extreme_single_retained_pc(
+        self, config, sample_data, prev_result, tmp_path
+    ):
+        """A single retained PC under "extreme" yields at most 2 features."""
+        config.pca.n_components = 1
+        config.pca.feature_selection_strategy = "extreme"
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=sample_data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=prev_result,
+        )
+
+        assert len(result.metadata["top_features"]) <= 2
+
+    def test_extreme_logs_info_that_n_top_features_is_ignored(
+        self, config, sample_data, prev_result, tmp_path, caplog
+    ):
+        """A logger.info notice fires for "extreme", not for other strategies."""
+        config.pca.feature_selection_strategy = "extreme"
+        step = PCAAnalysisStep()
+
+        with caplog.at_level(logging.INFO):
+            step.execute(
+                data=sample_data,
+                config=config,
+                run_dir=tmp_path,
+                prev_result=prev_result,
+            )
+
+        assert any(
+            "n_top_features" in record.message and "extreme" in record.message
+            for record in caplog.records
+        )
+
+    def test_no_ignored_notice_for_non_extreme_strategies(
+        self, config, sample_data, prev_result, tmp_path, caplog
+    ):
+        """No "ignored" notice fires when n_top_features is actually read."""
+        config.pca.feature_selection_strategy = "top_absolute"
+        step = PCAAnalysisStep()
+
+        with caplog.at_level(logging.INFO):
+            step.execute(
+                data=sample_data,
+                config=config,
+                run_dir=tmp_path,
+                prev_result=prev_result,
+            )
+
+        assert not any("n_top_features" in record.message for record in caplog.records)
+
+    def test_top_variance_threshold_resolves_feature_count(
+        self, config, sample_data, prev_result, tmp_path
+    ):
+        """A < 1 threshold selects a count meeting but not overshooting it."""
+        config.pca.feature_selection_strategy = "top_variance"
+        config.pca.n_top_features = 0.8
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=sample_data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=prev_result,
+        )
+
+        n_selected = len(result.metadata["top_features"])
+        feature_contributions = result.metadata["pca_results"]["feature_contributions"]
+        cumulative = feature_contributions["fractional_contribution"].cumsum()
+
+        assert cumulative.iloc[n_selected - 1] >= 0.8
+        assert n_selected == 1 or cumulative.iloc[n_selected - 2] < 0.8
+
+    @pytest.mark.parametrize("threshold", [0, -0.5])
+    def test_top_variance_non_positive_threshold_selects_one_feature(
+        self, config, sample_data, prev_result, tmp_path, threshold
+    ):
+        """A threshold <= 0 selects exactly 1 feature, no exception."""
+        config.pca.feature_selection_strategy = "top_variance"
+        config.pca.n_top_features = threshold
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=sample_data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=prev_result,
+        )
+
+        assert len(result.metadata["top_features"]) == 1
+
+    def test_top_variance_1_0_is_a_count_not_a_100_percent_threshold(
+        self, config, sample_data, prev_result, tmp_path
+    ):
+        """n_top_features == 1.0 selects exactly 1 feature (count branch)."""
+        config.pca.feature_selection_strategy = "top_variance"
+        config.pca.n_top_features = 1.0
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=sample_data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=prev_result,
+        )
+
+        assert len(result.metadata["top_features"]) == 1
+
+    def test_top_variance_count_unchanged_for_n_top_features_ge_1(
+        self, config, sample_data, prev_result, tmp_path
+    ):
+        """n_top_features >= 1 preserves the existing fixed-count behavior."""
+        config.pca.feature_selection_strategy = "top_variance"
+        config.pca.n_top_features = 5
+        step = PCAAnalysisStep()
+
+        result = step.execute(
+            data=sample_data,
+            config=config,
+            run_dir=tmp_path,
+            prev_result=prev_result,
+        )
+
+        assert len(result.metadata["top_features"]) == 5

--- a/tests/test_viz_pipeline_config.py
+++ b/tests/test_viz_pipeline_config.py
@@ -193,6 +193,59 @@ class TestValidateVizConfig:
         ):
             validate_viz_config(config)
 
+    @pytest.mark.parametrize("strategy", ["top_absolute", "top_contribution"])
+    def test_fractional_n_top_features_below_1_raises(self, strategy):
+        """Reject n_top_features < 1 for count-only strategies (issue #206)."""
+        config = VizPipelineConfig(pipeline_name="test")
+        config.data.csv_path = "test.csv"
+        config.pca.feature_selection_strategy = strategy
+        config.pca.n_top_features = 0.5
+        with pytest.raises(ValueError, match="pca.n_top_features") as exc_info:
+            validate_viz_config(config)
+        assert "pca.feature_selection_strategy" in str(exc_info.value)
+        assert strategy in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "strategy", ["top_variance", "top_absolute", "top_contribution"]
+    )
+    def test_non_whole_number_n_top_features_ge_1_raises(self, strategy):
+        """Reject a non-whole-number n_top_features >= 1 for non-extreme strategies."""
+        config = VizPipelineConfig(pipeline_name="test")
+        config.data.csv_path = "test.csv"
+        config.pca.feature_selection_strategy = strategy
+        config.pca.n_top_features = 5.7
+        with pytest.raises(ValueError, match="whole number") as exc_info:
+            validate_viz_config(config)
+        assert "truncated" in str(exc_info.value)
+
+    def test_top_variance_threshold_below_1_accepted(self):
+        """A < 1 threshold is accepted for top_variance."""
+        config = VizPipelineConfig(pipeline_name="test")
+        config.data.csv_path = "test.csv"
+        config.pca.feature_selection_strategy = "top_variance"
+        config.pca.n_top_features = 0.8
+        validate_viz_config(config)  # Should not raise
+
+    def test_any_n_top_features_accepted_for_extreme(self):
+        """Any n_top_features value, including fractional or < 1, is accepted for extreme."""
+        config = VizPipelineConfig(pipeline_name="test")
+        config.data.csv_path = "test.csv"
+        config.pca.feature_selection_strategy = "extreme"
+        for value in [0.5, 5.7, -1, 0]:
+            config.pca.n_top_features = value
+            validate_viz_config(config)  # Should not raise
+
+    @pytest.mark.parametrize(
+        "strategy", ["extreme", "top_absolute", "top_contribution", "top_variance"]
+    )
+    def test_whole_number_n_top_features_accepted_for_any_strategy(self, strategy):
+        """A whole-number count >= 1 is accepted regardless of strategy."""
+        config = VizPipelineConfig(pipeline_name="test")
+        config.data.csv_path = "test.csv"
+        config.pca.feature_selection_strategy = strategy
+        config.pca.n_top_features = 5.0
+        validate_viz_config(config)  # Should not raise
+
     def test_invalid_clustering_method_raises(self):
         """Test that invalid clustering method raises error."""
         config = VizPipelineConfig(pipeline_name="test")
@@ -647,3 +700,61 @@ class TestConfigIntegration:
 
         assert final_config.data.csv_path == "override.csv"
         assert final_config.pca.n_components == 10
+
+
+# The 28 active configs edited to remove their now-meaningless n_top_features
+# line under feature_selection_strategy: "extreme" (issue #206) — a concrete,
+# re-runnable guard against a YAML syntax error or indentation break
+# introduced by that cleanup.
+_EDITED_EXTREME_CONFIGS = [
+    "viz/alfalfa_gwas_groups_1_to_6_combined.yaml",
+    "viz/alfalfa_gwas_groups_1_to_6_combined_no_root_widths.yaml",
+    "viz/alfalfa_gwas_w1w2_combined.yaml",
+    "viz/alfalfa_gwas_wave1.yaml",
+    "viz/alfalfa_gwas_wave1_canola.yaml",
+    "viz/alfalfa_gwas_wave1_canola_models.yaml",
+    "viz/amaranth_tis108_exp1.yaml",
+    "viz/canola_diversity_screen_qc.yaml",
+    "viz/emily_shane_pennycress_2026_02_09.yaml",
+    "viz/emily_shane_soybean_2026_01_15.yaml",
+    "viz/emily_shane_soybean_2026_03_03.yaml",
+    "viz/emily_shane_soybean_2026_03_03_grouped.yaml",
+    "viz/giftol_pennycress_s32_2026_05_11.yaml",
+    "viz/javier_ttc_salk_soybean.yaml",
+    "viz/javier_ttc_salk_soybean_brightness.yaml",
+    "viz/javier_ttc_salk_soybean_full_experiment_9wave.yaml",
+    "viz/javier_ttc_salk_soybean_full_experiment_9wave_per_wave.yaml",
+    "viz/shree_weep_soybean.yaml",
+    "viz/suyash_arabidopsis_pgm1_pac_2026_05_22.yaml",
+    "viz/turface_alfalfa_gwas.yaml",
+    "viz/viz_alfalfa_gwas_wave_1_grouped.yaml",
+    "viz/viz_cylinder_edpie.yaml",
+    "viz/viz_field_2024_clean.yaml",
+    "viz/viz_root_coring.yaml",
+    "viz/viz_turface_150genotypes.yaml",
+    "viz/viz_turface_19genotypes.yaml",
+    "viz/weep_maurizio_wave1.yaml",
+    "viz_turface_150genotypes.yaml",
+]
+
+
+class TestEditedExtremeConfigsStillValidate:
+    """Regression guard for the issue #206 config cleanup.
+
+    Every config that had its now-meaningless `n_top_features` line removed
+    under `feature_selection_strategy: "extreme"` must still parse and pass
+    `validate_viz_config()` — catching a YAML syntax error or indentation
+    break the line removal might have introduced.
+    """
+
+    @pytest.mark.parametrize("relative_path", _EDITED_EXTREME_CONFIGS)
+    def test_edited_config_loads_and_validates(self, relative_path):
+        """Load and validate one edited config, parametrized over all 28."""
+        repo_root = Path(__file__).parent.parent
+        config_path = repo_root / "configs" / "active" / relative_path
+        assert config_path.exists(), f"Expected config not found: {config_path}"
+
+        config = load_viz_config(config_path)
+
+        assert config.pca.feature_selection_strategy == "extreme"
+        validate_viz_config(config)  # Should not raise

--- a/tests/test_viz_pipeline_config.py
+++ b/tests/test_viz_pipeline_config.py
@@ -204,6 +204,8 @@ class TestValidateVizConfig:
             validate_viz_config(config)
         assert "pca.feature_selection_strategy" in str(exc_info.value)
         assert strategy in str(exc_info.value)
+        assert "integer" in str(exc_info.value)
+        assert ">= 1" in str(exc_info.value)
 
     @pytest.mark.parametrize(
         "strategy", ["top_variance", "top_absolute", "top_contribution"]
@@ -217,6 +219,39 @@ class TestValidateVizConfig:
         with pytest.raises(ValueError, match="whole number") as exc_info:
             validate_viz_config(config)
         assert "truncated" in str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "strategy", ["top_absolute", "top_contribution", "top_variance"]
+    )
+    def test_nan_n_top_features_raises(self, strategy):
+        """NaN must not silently bypass both range checks (both compare False against NaN)."""
+        config = VizPipelineConfig(pipeline_name="test")
+        config.data.csv_path = "test.csv"
+        config.pca.feature_selection_strategy = strategy
+        config.pca.n_top_features = float("nan")
+        with pytest.raises(ValueError, match="finite"):
+            validate_viz_config(config)
+
+    @pytest.mark.parametrize(
+        "strategy", ["top_absolute", "top_contribution", "top_variance"]
+    )
+    def test_infinite_n_top_features_raises(self, strategy):
+        """Inf must raise ValueError, not OverflowError from round()."""
+        config = VizPipelineConfig(pipeline_name="test")
+        config.data.csv_path = "test.csv"
+        config.pca.feature_selection_strategy = strategy
+        config.pca.n_top_features = float("inf")
+        with pytest.raises(ValueError, match="finite"):
+            validate_viz_config(config)
+
+    def test_nan_or_inf_n_top_features_accepted_for_extreme(self):
+        """Extreme ignores the field entirely, so non-finite values are still harmless."""
+        config = VizPipelineConfig(pipeline_name="test")
+        config.data.csv_path = "test.csv"
+        config.pca.feature_selection_strategy = "extreme"
+        for value in [float("nan"), float("inf"), float("-inf")]:
+            config.pca.n_top_features = value
+            validate_viz_config(config)  # Should not raise
 
     def test_top_variance_threshold_below_1_accepted(self):
         """A < 1 threshold is accepted for top_variance."""


### PR DESCRIPTION
## Summary

Fixes #206 and resolves the open "decide" checkbox in #203.

- **#203**: `PCAAnalysisStep` now always passes `pc_indices=list(range(n_components))` to `select_top_features_from_pca()`, instead of silently relying on that function's `[0, 1]` default. Runs with `n_components >= 3` previously only ever considered PC1/PC2 for `"extreme"`/`"top_absolute"`/`"top_contribution"`.
- **#206 Part 1**: `feature_selection_strategy: "extreme"` no longer takes an arbitrary count — it always selects exactly 1 most-positive-loading and 1 most-negative-loading trait per retained PC. `pca.n_top_features` is not read for this method (a `logger.info()` notice fires if it's set alongside `"extreme"`), and the 28 active configs pairing the two have had the now-meaningless line removed.
- **#206 Part 2**: `pca.n_top_features` changes type from `int` to `float` and gains a variance-threshold overload for `"top_variance"`, mirroring `pca.n_components`'s existing `< 1` = ratio / `>= 1` = count convention. A new `select_n_features_by_variance()` helper resolves the threshold to a concrete count.
- New config validation (`validate_qc_config()`/`validate_viz_config()`) rejects `n_top_features < 1` for `"top_absolute"`/`"top_contribution"` and rejects a non-whole-number `n_top_features >= 1` for every strategy except `"extreme"`.

Full design rationale (including the "ignore vs. validate" decision for `"extreme"`, why the new helper is a separate function, and why `"vector_length"` is intentionally excluded) is in the OpenSpec proposal: `openspec/changes/fix-pca-top-feature-selection/`. The proposal went through two rounds of adversarial multi-agent review before implementation.

## Test plan

- [x] New unit tests for `select_n_features_by_variance()` (`tests/test_pca.py`)
- [x] New regression tests for `PCAAnalysisStep`'s pc_indices scoping, extreme's n_top_features-ignoring + logging, and top_variance's threshold resolution (`tests/test_step_pca_analysis.py`)
- [x] New config-validation tests for the fractional/non-whole-number rejection (`tests/test_pipeline_config.py`, `tests/test_viz_pipeline_config.py`)
- [x] New parametrized regression test loading + validating all 28 edited configs (`tests/test_viz_pipeline_config.py`)
- [x] Full suite: `uv run pytest --cov=src/sleap_roots_analyze --cov-report=xml --durations=20 -m "not integration" tests/` — 2950 passed, 37 skipped, 0 failed
- [x] `uv run black --check` / `uv run ruff check` clean on all touched files
- [x] `openspec validate fix-pca-top-feature-selection --strict` passes

## Follow-up after merge

Per the proposal, #203 will be commented on with a cross-link to this PR and closed as resolved (its "decide" checkbox is answered here), matching the pattern used for #64/#68.

🤖 Generated with [Claude Code](https://claude.com/claude-code)