### PR TITLE
Fix #209: honor feature_selection in interactive PCA loading arrows

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -113,6 +113,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (PR #193 review).
 
 ### Fixed
+- `create_interactive_pca_with_images` and `create_interactive_pca_plot` now
+  accept a `feature_selection` parameter and delegate their loading-arrow
+  feature selection to `select_top_features_from_pca()` (#209), instead of
+  hardcoding `feature_contributions.nlargest(n_loadings, "total_contribution")`
+  with no strategy awareness — the last unresolved consumer from the
+  `select_top_features_from_pca()` consolidation effort (#202/#203/#204/#206/
+  #207). Default `feature_selection="top_variance"` is numerically equivalent
+  to the prior hardcoded ranking (both derive from the same total-variance-
+  contribution basis), so existing callers — including the interactive-PCA
+  step of every `trait_viz_*.ipynb` analysis notebook — get identical output
+  without passing the new parameter. Unlike `create_pca_biplot`, whose public
+  `pc_x`/`pc_y` are 1-indexed and require a `-1` conversion before use as
+  `pc_indices`, these two functions' `components` tuple is already 0-indexed
+  and is passed through unmodified.
 - `PCAAnalysisStep` now always passes `pc_indices=list(range(n_components))`
   explicitly to `select_top_features_from_pca()` (#203), instead of relying
   on that function's `[0, 1]` default. Runs configured with `pca.n_components`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -119,14 +119,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   hardcoding `feature_contributions.nlargest(n_loadings, "total_contribution")`
   with no strategy awareness — the last unresolved consumer from the
   `select_top_features_from_pca()` consolidation effort (#202/#203/#204/#206/
-  #207). Default `feature_selection="top_variance"` is numerically equivalent
-  to the prior hardcoded ranking (both derive from the same total-variance-
-  contribution basis), so existing callers — including the interactive-PCA
-  step of every `trait_viz_*.ipynb` analysis notebook — get identical output
-  without passing the new parameter. Unlike `create_pca_biplot`, whose public
-  `pc_x`/`pc_y` are 1-indexed and require a `-1` conversion before use as
-  `pc_indices`, these two functions' `components` tuple is already 0-indexed
-  and is passed through unmodified.
+  #207). Default `feature_selection="top_variance"` ranks by the same
+  total-variance-contribution basis as the prior hardcoded ranking, so
+  existing callers — including the interactive-PCA step of every
+  `trait_viz_*.ipynb` analysis notebook — get the same selected features in
+  the typical case; the two implementations diverge only if a feature's
+  total contribution is NaN or multiple features tie exactly at the
+  selection cutoff (both effectively impossible for continuous
+  variance-contribution values from real data). Unlike `create_pca_biplot`,
+  whose public `pc_x`/`pc_y` are 1-indexed and require a `-1` conversion
+  before use as `pc_indices`, these two functions' `components` tuple is
+  already 0-indexed and is passed through unmodified. Also fixes a
+  pre-existing bug in `select_top_features_from_pca()`'s `"extreme"` method,
+  newly reachable through this parameter: `n_features_to_select=0` returned
+  every feature instead of none, due to Python's negative-slice quirk
+  (`arr[-0:] == arr[0:]`, the full array).
 - `PCAAnalysisStep` now always passes `pc_indices=list(range(n_components))`
   explicitly to `select_top_features_from_pca()` (#203), instead of relying
   on that function's `[0, 1]` default. Runs configured with `pca.n_components`

--- a/openspec/changes/fix-interactive-pca-feature-selection/proposal.md
+++ b/openspec/changes/fix-interactive-pca-feature-selection/proposal.md
@@ -1,0 +1,77 @@
+## Why
+
+`talmolab/sleap-roots-analyze#209` is the last open item in the PCA
+feature-selection consolidation effort (`#202`, `#203`, `#204`, `#206`, `#207`
+all closed and merged). One consumer of PCA loadings still bypasses the
+shared `select_top_features_from_pca()` (`pca.py:49`):
+`create_interactive_pca_with_images` and `create_interactive_pca_plot`
+(`interactive_visualization.py:259` and `:1275`) both hardcode
+`feature_contributions.nlargest(n_loadings, "total_contribution")` to pick
+which features get loading arrows when `show_loadings=True`, with no
+`feature_selection` parameter and no strategy awareness.
+
+The issue itself hedges on whether this is worth fixing, since neither
+pipeline call site passes `show_loadings=True` (`generate_interactive.py`)
+and no external consumer (`bloommcp`, `staging`) uses either function. It asks
+whoever picks this up to check notebooks/docs for real usage before deciding
+between delegating to `select_top_features_from_pca()` or just documenting
+why the simpler path is intentional.
+
+That check turned up real, current usage: 14 of the most recent
+`trait_viz_*.ipynb` notebooks (through 2025-11-30) call
+`create_interactive_pca_with_images(..., show_loadings=True, n_loadings=N_LOADINGS_INTERACTIVE)`
+as a standard step in the analysis workflow, and `docs/PCA.md` documents the
+same call as "Example 4: Interactive Visualization". This is not dead code —
+it resolves toward delegation, matching the pattern already established for
+`create_pca_biplot` and `create_umap_colored_by_top_traits`.
+
+## What Changes
+
+- Add a `feature_selection: str = "top_variance"` parameter to both
+  `create_interactive_pca_with_images` and `create_interactive_pca_plot`.
+- Both functions delegate their loading-arrow feature selection to
+  `select_top_features_from_pca()` instead of hardcoding
+  `nlargest(n_loadings, "total_contribution")`, validating `feature_selection`
+  against the shared `VALID_SELECTION_METHODS` the same way `create_pca_biplot`
+  does.
+- Default `"top_variance"` is numerically equivalent to today's hardcoded
+  ranking (both derive from the same total-variance-contribution basis), so
+  existing callers that pass `show_loadings=True` without `feature_selection`
+  (all 14 notebooks above) get identical output — this is a behavior-preserving
+  default, not a behavior change.
+
+## Impact
+
+- Affected code: `src/sleap_roots_analyze/interactive_visualization.py`
+  (`create_interactive_pca_with_images`, `create_interactive_pca_plot`).
+- Affected tests: `tests/test_interactive_visualization.py`.
+- Affected spec: `visualization-pipeline` (adds a requirement covering
+  interactive PCA loading-arrow feature selection).
+- No config changes: no pipeline call site passes `show_loadings=True` today,
+  so no `InteractiveVizConfig` plumbing is needed.
+- No changes to `create_umap_colored_by_top_traits` (already fixed by `#207`)
+  or `create_feature_contribution_plot` (resolved toward removal by `#202`,
+  not addressed here).
+- Closes `talmolab/sleap-roots-analyze#209`.
+
+## Notes for implementation (from proposal review)
+
+- **`pc_indices` are already 0-indexed here** — unlike `create_pca_biplot`,
+  whose public `pc_x`/`pc_y` are 1-indexed and get a `-1` conversion before
+  being passed as `pc_indices`, both interactive functions' `components`
+  tuple (`pc_x, pc_y = components`) is already 0-indexed and used directly
+  against `loadings[feature_idx, pc_x]`. Pass `[pc_x, pc_y]` unmodified — do
+  **not** copy the biplot's `-1` adjustment by analogy, which would silently
+  rank non-default methods against the wrong PC pair (the same bug class
+  `#203`/`#207` already had to fix elsewhere in this effort).
+- **Validate `feature_selection` unconditionally**, not only inside the
+  `if show_loadings:` branch, so an invalid value fails fast regardless of
+  whether loadings are actually displayed (matches `create_pca_biplot`'s
+  unconditional validation).
+- **Default-equivalence tests must compute the old ranking independently**
+  (call `feature_contributions.nlargest(n_loadings, "total_contribution").index`
+  directly in the test) rather than re-deriving it from the new
+  `select_top_features_from_pca()` call, to avoid a circular test that can't
+  catch a regression in the equivalence claim itself. Compare as sets, not
+  exact order — `nlargest` and `np.argsort` break ties differently and are
+  not guaranteed to agree on ordering for equal contribution values.

--- a/openspec/changes/fix-interactive-pca-feature-selection/proposal.md
+++ b/openspec/changes/fix-interactive-pca-feature-selection/proposal.md
@@ -34,11 +34,19 @@ it resolves toward delegation, matching the pattern already established for
   `nlargest(n_loadings, "total_contribution")`, validating `feature_selection`
   against the shared `VALID_SELECTION_METHODS` the same way `create_pca_biplot`
   does.
-- Default `"top_variance"` is numerically equivalent to today's hardcoded
-  ranking (both derive from the same total-variance-contribution basis), so
-  existing callers that pass `show_loadings=True` without `feature_selection`
-  (all 14 notebooks above) get identical output — this is a behavior-preserving
-  default, not a behavior change.
+- Default `"top_variance"` ranks by the same total-variance-contribution basis
+  as today's hardcoded `nlargest(n, "total_contribution")` (both derive from
+  `_total_variance_contribution()`), so existing callers that pass
+  `show_loadings=True` without `feature_selection` (all 14 notebooks above)
+  get the same selected features in the typical case. The two ranking
+  implementations are not a mathematical guarantee of an identical result in
+  every case: `nlargest` excludes NaN rows and breaks ties by original order,
+  while `select_top_features_from_pca`'s `np.argsort`-based ranking sorts NaN
+  as largest and uses a non-stable sort — divergence is possible only if a
+  feature's total contribution is NaN (a sign of upstream PCA failure, not a
+  normal data condition) or multiple features tie exactly at the selection
+  cutoff. Continuous variance-contribution values make an exact tie
+  vanishingly unlikely in practice.
 
 ## Impact
 

--- a/openspec/changes/fix-interactive-pca-feature-selection/specs/visualization-pipeline/spec.md
+++ b/openspec/changes/fix-interactive-pca-feature-selection/specs/visualization-pipeline/spec.md
@@ -15,6 +15,12 @@ parameter, rather than a hardcoded ranking.
 - **THEN** the function SHALL default `feature_selection` to `"top_variance"`
 - **AND** the selected loading-arrow features SHALL match those previously
   produced by `feature_contributions.nlargest(n_loadings, "total_contribution")`
+  for any input where no feature's total contribution is NaN and no two
+  features tie exactly at the selection cutoff (both effectively impossible
+  for continuous variance-contribution values from real data; `nlargest`
+  excludes NaN and breaks ties by original order, while
+  `select_top_features_from_pca`'s `np.argsort`-based ranking sorts NaN as
+  largest and is not tie-stable)
 
 #### Scenario: Alternate feature_selection method changes selected features
 

--- a/openspec/changes/fix-interactive-pca-feature-selection/specs/visualization-pipeline/spec.md
+++ b/openspec/changes/fix-interactive-pca-feature-selection/specs/visualization-pipeline/spec.md
@@ -1,0 +1,47 @@
+## ADDED Requirements
+
+### Requirement: Interactive PCA Loading Feature Selection
+
+`create_interactive_pca_with_images` and `create_interactive_pca_plot` SHALL
+select the features shown as loading arrows (when `show_loadings=True`) via
+`select_top_features_from_pca()`, using a `feature_selection` parameter that
+accepts the same method names as `create_pca_biplot`'s `feature_selection`
+parameter, rather than a hardcoded ranking.
+
+#### Scenario: Default feature_selection matches prior hardcoded behavior
+
+- **WHEN** `create_interactive_pca_with_images` or `create_interactive_pca_plot`
+  is called with `show_loadings=True` and no `feature_selection` argument
+- **THEN** the function SHALL default `feature_selection` to `"top_variance"`
+- **AND** the selected loading-arrow features SHALL match those previously
+  produced by `feature_contributions.nlargest(n_loadings, "total_contribution")`
+
+#### Scenario: Alternate feature_selection method changes selected features
+
+- **WHEN** `create_interactive_pca_with_images` or `create_interactive_pca_plot`
+  is called with `show_loadings=True` and `feature_selection` set to
+  `"extreme"`, `"top_absolute"`, `"top_contribution"`, or `"vector_length"`
+- **THEN** the selected loading-arrow features SHALL exactly match the
+  indices returned by directly calling `select_top_features_from_pca()`
+  with the same `loadings`, `eigenvalues`, `n_features_to_select=n_loadings`,
+  `method=feature_selection`, and `pc_indices=[pc_x, pc_y]`
+
+#### Scenario: PC indices passed to selection are not re-adjusted
+
+- **WHEN** `create_interactive_pca_with_images` or `create_interactive_pca_plot`
+  is called with `components=(pc_x, pc_y)` (already 0-indexed, as used
+  elsewhere in these functions) and a `feature_selection` other than
+  `"top_variance"`
+- **THEN** `select_top_features_from_pca()` SHALL be called with
+  `pc_indices=[pc_x, pc_y]` unmodified — no additional offset SHALL be
+  applied, unlike `create_pca_biplot`'s 1-indexed-to-0-indexed conversion,
+  which does not apply here
+
+#### Scenario: Unrecognized feature_selection value rejected regardless of show_loadings
+
+- **WHEN** `create_interactive_pca_with_images` or `create_interactive_pca_plot`
+  is called with a `feature_selection` value not in `VALID_SELECTION_METHODS`
+- **THEN** the function SHALL raise a `ValueError` naming the invalid value
+  and listing the valid options
+- **AND** this validation SHALL occur regardless of whether `show_loadings`
+  is `True` or `False`

--- a/openspec/changes/fix-interactive-pca-feature-selection/tasks.md
+++ b/openspec/changes/fix-interactive-pca-feature-selection/tasks.md
@@ -61,6 +61,15 @@
       functions, closing `#209`, matching the entries already present for
       `#202`/`#203`/`#204`/`#206`.
 - [x] 3.3 Run `uv run pytest --cov --cov-branch` and confirm no regressions.
-- [ ] 3.4 Run `/pre-merge-check` (black, ruff, full suite, coverage, OpenSpec
+- [x] 3.4 Run `/pre-merge-check` (black, ruff, full suite, coverage, OpenSpec
       validation, Copilot triage) as the closing check for the whole
-      `#202`/`#203`/`#204`/`#206`/`#207`/`#209` effort.
+      `#202`/`#203`/`#204`/`#206`/`#207`/`#209` effort. A 5-agent pre-PR
+      self-review (`/review-pr`) additionally caught and fixed: a
+      pre-existing `select_top_features_from_pca()` "extreme" +
+      `n_features_to_select=0` bug newly reachable via this parameter, a
+      fragile name-based index re-lookup, an overstated equivalence claim
+      (now qualified for NaN/exact-tie edge cases), and a `mypy` baseline
+      violation from the bugfix. PR #223 opened; all 13 CI checks green.
+      Copilot's auto-review did not trigger and could not be forced via the
+      CLI — left for a human reviewer to request from the GitHub UI if
+      desired.

--- a/openspec/changes/fix-interactive-pca-feature-selection/tasks.md
+++ b/openspec/changes/fix-interactive-pca-feature-selection/tasks.md
@@ -1,0 +1,66 @@
+## 1. `create_interactive_pca_with_images`
+
+- [x] 1.1 Write failing tests in `tests/test_interactive_visualization.py`:
+      - Default-equivalence: call with `show_loadings=True`, no
+        `feature_selection`; independently compute the expected feature set
+        via `pca_viz_results["feature_contributions"].nlargest(n_loadings, "total_contribution").index`
+        directly in the test (not by re-deriving it from the new code path);
+        assert the actual annotated features equal that set.
+      - `@pytest.mark.parametrize("feature_selection", ["extreme", "top_absolute", "top_contribution", "vector_length"])`:
+        for each, independently call `select_top_features_from_pca(loadings=pca_viz_results["loadings"], eigenvalues=pca_viz_results["eigenvalues"], n_features_total=len(pca_viz_results["feature_names"]), n_features_to_select=n_loadings, method=feature_selection, pc_indices=[pc_x, pc_y])`
+        and assert the function's annotated features equal that set exactly
+        (set equality, not order — `nlargest`/`np.argsort` tie-breaking is
+        not guaranteed identical).
+      - PC-indexing regression test: call with `components=(2, 3)` (a pair
+        that diverges from the `(0, 1)` default) and a PC-sensitive method
+        (e.g. `"extreme"`); assert the selected features match
+        `select_top_features_from_pca(..., pc_indices=[2, 3])`, not
+        `pc_indices=[1, 2]` (which is what copying `create_pca_biplot`'s
+        1-indexed-to-0-indexed `-1` conversion by analogy would produce) —
+        this pins down that `components` here is already 0-indexed.
+      - Invalid `feature_selection` (e.g. `"bogus"`) raises `ValueError`,
+        tested with **both** `show_loadings=True` and `show_loadings=False`
+        (validation must be unconditional).
+      - `n_loadings=0` → no loading-arrow annotations added.
+      - `n_loadings` greater than the total number of features → no error,
+        all available features selected.
+- [x] 1.2 Add `feature_selection: str = "top_variance"` parameter. Validate
+      unconditionally against `VALID_SELECTION_METHODS` (imported from
+      `sleap_roots_analyze.pca`), before the `show_loadings` branch. Replace
+      the `feature_contributions.nlargest(...)` call with
+      `select_top_features_from_pca(loadings=..., eigenvalues=pca_results["eigenvalues"], n_features_total=len(pca_results["feature_names"]), n_features_to_select=n_loadings, method=feature_selection, pc_indices=None if feature_selection == "top_variance" else [pc_x, pc_y])`,
+      mapping returned integer indices back to feature names via
+      `pca_results["feature_names"][idx]`. Do **not** apply any `-1` offset
+      to `pc_x`/`pc_y` — they are already 0-indexed here.
+- [x] 1.3 Update the docstring: add a `feature_selection` `Args:` entry with
+      a bulleted list of the five valid values and one-line descriptions
+      (matching `create_pca_biplot`'s docstring style in `visualization.py`),
+      and a `Raises: ValueError` entry for an unrecognized value.
+- [x] 1.4 Run the new tests and confirm they pass.
+
+## 2. `create_interactive_pca_plot`
+
+- [x] 2.1 Write the same failing-test shape as 1.1 for this function
+      (default-equivalence, parametrized methods with independent ground
+      truth, PC-indexing regression test, unconditional-validation test,
+      `n_loadings=0`, `n_loadings` overflow).
+- [x] 2.2 Apply the same `feature_selection` parameter, unconditional
+      validation, and delegation as 1.2.
+- [x] 2.3 Update the docstring with the same `Args`/`Raises` format as 1.3.
+- [x] 2.4 Run the new tests and confirm they pass.
+
+## 3. Verification
+
+- [x] 3.1 Confirm `create_umap_colored_by_top_traits`'s `top_variance` branch
+      is unchanged (no code edit — grep/read to reconfirm after this change,
+      since it's the other half of this issue's acceptance criteria; its
+      existing `#207` test coverage is what actually guards it, not this
+      task). This is a sanity check, not a commit.
+- [x] 3.2 Add a changelog entry to `docs/CHANGELOG.md`'s `[Unreleased]`
+      section documenting the new `feature_selection` parameter on both
+      functions, closing `#209`, matching the entries already present for
+      `#202`/`#203`/`#204`/`#206`.
+- [x] 3.3 Run `uv run pytest --cov --cov-branch` and confirm no regressions.
+- [ ] 3.4 Run `/pre-merge-check` (black, ruff, full suite, coverage, OpenSpec
+      validation, Copilot triage) as the closing check for the whole
+      `#202`/`#203`/`#204`/`#206`/`#207`/`#209` effort.

--- a/src/sleap_roots_analyze/interactive_visualization.py
+++ b/src/sleap_roots_analyze/interactive_visualization.py
@@ -17,6 +17,11 @@ from typing import Dict, List, Tuple, Optional, Union
 from PIL import Image
 import io
 
+from sleap_roots_analyze.pca import (
+    select_top_features_from_pca,
+    VALID_SELECTION_METHODS,
+)
+
 
 def encode_image_to_base64(image_path: Union[str, Path]) -> str:
     """Encode an image file to base64 string for embedding in HTML.
@@ -268,6 +273,7 @@ def create_interactive_pca_with_images(
     height: int = 800,
     show_loadings: bool = False,
     n_loadings: int = 10,
+    feature_selection: str = "top_variance",
     id_col: str = "Barcode",
 ) -> go.Figure:
     """Create an interactive PCA plot with image hover.
@@ -284,11 +290,29 @@ def create_interactive_pca_with_images(
         height: Plot height.
         show_loadings: Whether to show feature loadings as arrows.
         n_loadings: Number of top loadings to show.
+        feature_selection: Method for selecting which features get loading
+            arrows (only used when show_loadings=True):
+            - "top_variance": Top N by total variance contribution (all
+              retained PCs, not just the plotted components) (default)
+            - "extreme": Top N most positive and negative for each PC
+            - "top_absolute": Top N by absolute loading magnitude
+            - "top_contribution": Top N by variance contribution to the
+              displayed PCs
+            - "vector_length": Top N by Euclidean distance in PC plane
         id_col: Column containing sample IDs (default: "Barcode").
 
     Returns:
         Interactive PCA plot with images.
+
+    Raises:
+        ValueError: If feature_selection is not a recognized method.
     """
+    if feature_selection not in VALID_SELECTION_METHODS:
+        raise ValueError(
+            f"Unrecognized feature_selection: {feature_selection!r}. Expected "
+            f"one of {sorted(VALID_SELECTION_METHODS)}."
+        )
+
     # Get PC scores
     pc_x, pc_y = components
     X_pca = pca_results["transformed_data"]
@@ -340,12 +364,21 @@ def create_interactive_pca_with_images(
     # Add loadings if requested
     if show_loadings and "loadings" in pca_results:
         loadings = pca_results["loadings"]
-        feature_contributions = pca_results["feature_contributions"]
+        feature_names = pca_results["feature_names"]
 
-        # Get top contributing features
-        top_features = feature_contributions.nlargest(
-            n_loadings, "total_contribution"
-        ).index
+        # Select top contributing features via the shared selection function.
+        # components here are already 0-indexed, so pc_x/pc_y are passed to
+        # pc_indices unmodified (no -1 offset, unlike create_pca_biplot's
+        # 1-indexed pc_x/pc_y).
+        top_indices = select_top_features_from_pca(
+            loadings=loadings,
+            eigenvalues=pca_results["eigenvalues"],
+            n_features_total=len(feature_names),
+            n_features_to_select=n_loadings,
+            method=feature_selection,
+            pc_indices=None if feature_selection == "top_variance" else [pc_x, pc_y],
+        )
+        top_features = [feature_names[i] for i in top_indices]
 
         # Scale loadings for visualization
         max_score = max(
@@ -363,7 +396,7 @@ def create_interactive_pca_with_images(
         offsets = [-0.3, 0, 0.3, -0.2, 0.2, -0.4, 0.1, 0.4, -0.1, 0.35]
 
         for i, feature in enumerate(top_features):
-            feature_idx = list(pca_results["feature_names"]).index(feature)
+            feature_idx = feature_names.index(feature)
 
             # Calculate arrow end position
             x_end = loadings[feature_idx, pc_x] * scale
@@ -1284,6 +1317,7 @@ def create_interactive_pca_plot(
     height: int = 600,
     show_loadings: bool = False,
     n_loadings: int = 10,
+    feature_selection: str = "top_variance",
 ) -> go.Figure:
     """Create an interactive PCA plot using Plotly.
 
@@ -1299,10 +1333,28 @@ def create_interactive_pca_plot(
         height: Plot height.
         show_loadings: Whether to show feature loadings as arrows.
         n_loadings: Number of top loadings to show.
+        feature_selection: Method for selecting which features get loading
+            arrows (only used when show_loadings=True):
+            - "top_variance": Top N by total variance contribution (all
+              retained PCs, not just the plotted components) (default)
+            - "extreme": Top N most positive and negative for each PC
+            - "top_absolute": Top N by absolute loading magnitude
+            - "top_contribution": Top N by variance contribution to the
+              displayed PCs
+            - "vector_length": Top N by Euclidean distance in PC plane
 
     Returns:
         Plotly figure object.
+
+    Raises:
+        ValueError: If feature_selection is not a recognized method.
     """
+    if feature_selection not in VALID_SELECTION_METHODS:
+        raise ValueError(
+            f"Unrecognized feature_selection: {feature_selection!r}. Expected "
+            f"one of {sorted(VALID_SELECTION_METHODS)}."
+        )
+
     # Get PC scores
     pc_x, pc_y = components
     X_pca = pca_results["transformed_data"]
@@ -1353,12 +1405,21 @@ def create_interactive_pca_plot(
     # Add loadings if requested
     if show_loadings and "loadings" in pca_results:
         loadings = pca_results["loadings"]
-        feature_contributions = pca_results["feature_contributions"]
+        feature_names = pca_results["feature_names"]
 
-        # Get top contributing features
-        top_features = feature_contributions.nlargest(
-            n_loadings, "total_contribution"
-        ).index
+        # Select top contributing features via the shared selection function.
+        # components here are already 0-indexed, so pc_x/pc_y are passed to
+        # pc_indices unmodified (no -1 offset, unlike create_pca_biplot's
+        # 1-indexed pc_x/pc_y).
+        top_indices = select_top_features_from_pca(
+            loadings=loadings,
+            eigenvalues=pca_results["eigenvalues"],
+            n_features_total=len(feature_names),
+            n_features_to_select=n_loadings,
+            method=feature_selection,
+            pc_indices=None if feature_selection == "top_variance" else [pc_x, pc_y],
+        )
+        top_features = [feature_names[i] for i in top_indices]
 
         # Scale loadings for visualization
         max_score = max(
@@ -1376,7 +1437,7 @@ def create_interactive_pca_plot(
         offsets = [-0.3, 0, 0.3, -0.2, 0.2, -0.4, 0.1, 0.4, -0.1, 0.35]
 
         for i, feature in enumerate(top_features):
-            feature_idx = list(pca_results["feature_names"]).index(feature)
+            feature_idx = feature_names.index(feature)
 
             # Calculate arrow end position
             x_end = loadings[feature_idx, pc_x] * scale

--- a/src/sleap_roots_analyze/interactive_visualization.py
+++ b/src/sleap_roots_analyze/interactive_visualization.py
@@ -378,7 +378,6 @@ def create_interactive_pca_with_images(
             method=feature_selection,
             pc_indices=None if feature_selection == "top_variance" else [pc_x, pc_y],
         )
-        top_features = [feature_names[i] for i in top_indices]
 
         # Scale loadings for visualization
         max_score = max(
@@ -395,8 +394,8 @@ def create_interactive_pca_with_images(
         # Pattern of offsets for label positioning to avoid overlaps
         offsets = [-0.3, 0, 0.3, -0.2, 0.2, -0.4, 0.1, 0.4, -0.1, 0.35]
 
-        for i, feature in enumerate(top_features):
-            feature_idx = feature_names.index(feature)
+        for i, feature_idx in enumerate(top_indices):
+            feature = feature_names[feature_idx]
 
             # Calculate arrow end position
             x_end = loadings[feature_idx, pc_x] * scale
@@ -1419,7 +1418,6 @@ def create_interactive_pca_plot(
             method=feature_selection,
             pc_indices=None if feature_selection == "top_variance" else [pc_x, pc_y],
         )
-        top_features = [feature_names[i] for i in top_indices]
 
         # Scale loadings for visualization
         max_score = max(
@@ -1436,8 +1434,8 @@ def create_interactive_pca_plot(
         # Pattern of offsets for label positioning to avoid overlaps
         offsets = [-0.3, 0, 0.3, -0.2, 0.2, -0.4, 0.1, 0.4, -0.1, 0.35]
 
-        for i, feature in enumerate(top_features):
-            feature_idx = feature_names.index(feature)
+        for i, feature_idx in enumerate(top_indices):
+            feature = feature_names[feature_idx]
 
             # Calculate arrow end position
             x_end = loadings[feature_idx, pc_x] * scale

--- a/src/sleap_roots_analyze/pca.py
+++ b/src/sleap_roots_analyze/pca.py
@@ -115,8 +115,14 @@ def select_top_features_from_pca(
                     selected_indices.append(int(idx))
                     seen.add(idx)
 
-            # Most positive (in order of most positive to less positive)
-            for idx in sorted_idx[-n_features_to_select:][::-1]:
+            # Most positive (in order of most positive to less positive).
+            # Guard n_features_to_select == 0: arr[-0:] == arr[0:] (the full
+            # array), not empty, so a plain negative slice would wrongly
+            # select every feature instead of none.
+            most_positive = (
+                sorted_idx[-n_features_to_select:] if n_features_to_select else []
+            )
+            for idx in most_positive[::-1]:
                 if idx not in seen:
                     selected_indices.append(int(idx))
                     seen.add(idx)

--- a/src/sleap_roots_analyze/pca.py
+++ b/src/sleap_roots_analyze/pca.py
@@ -120,7 +120,9 @@ def select_top_features_from_pca(
             # array), not empty, so a plain negative slice would wrongly
             # select every feature instead of none.
             most_positive = (
-                sorted_idx[-n_features_to_select:] if n_features_to_select else []
+                sorted_idx[-n_features_to_select:]
+                if n_features_to_select
+                else sorted_idx[:0]
             )
             for idx in most_positive[::-1]:
                 if idx not in seen:

--- a/tests/test_interactive_visualization.py
+++ b/tests/test_interactive_visualization.py
@@ -417,16 +417,27 @@ class TestInteractivePCAPlots:
                 feature_selection="bogus",
             )
 
+    @pytest.mark.parametrize(
+        "feature_selection",
+        [
+            "top_variance",
+            "extreme",
+            "top_absolute",
+            "top_contribution",
+            "vector_length",
+        ],
+    )
     def test_create_interactive_pca_with_images_zero_loadings(
-        self, pca_viz_results, pca_viz_dataframe, sample_image_links
+        self, pca_viz_results, pca_viz_dataframe, sample_image_links, feature_selection
     ):
-        """n_loadings=0 should add no loading-arrow labels."""
+        """n_loadings=0 should add no loading-arrow labels, for every method."""
         fig = create_interactive_pca_with_images(
             pca_results=pca_viz_results,
             df=pca_viz_dataframe,
             image_links=sample_image_links,
             show_loadings=True,
             n_loadings=0,
+            feature_selection=feature_selection,
         )
 
         assert _loading_label_texts(fig) == set()
@@ -611,15 +622,26 @@ class TestInteractivePCAPlots:
                 feature_selection="bogus",
             )
 
+    @pytest.mark.parametrize(
+        "feature_selection",
+        [
+            "top_variance",
+            "extreme",
+            "top_absolute",
+            "top_contribution",
+            "vector_length",
+        ],
+    )
     def test_create_interactive_pca_plot_zero_loadings(
-        self, pca_viz_results, pca_viz_dataframe
+        self, pca_viz_results, pca_viz_dataframe, feature_selection
     ):
-        """n_loadings=0 should add no loading-arrow labels."""
+        """n_loadings=0 should add no loading-arrow labels, for every method."""
         fig = create_interactive_pca_plot(
             pca_results=pca_viz_results,
             df=pca_viz_dataframe,
             show_loadings=True,
             n_loadings=0,
+            feature_selection=feature_selection,
         )
 
         assert _loading_label_texts(fig) == set()

--- a/tests/test_interactive_visualization.py
+++ b/tests/test_interactive_visualization.py
@@ -25,6 +25,7 @@ from sleap_roots_analyze.interactive_visualization import (
     create_interactive_scatter_plot,
     create_interactive_pca_plot,
 )
+from sleap_roots_analyze.pca import select_top_features_from_pca
 
 
 # ============================================================================
@@ -250,6 +251,13 @@ class TestInteractiveScatterPlots:
 # ============================================================================
 
 
+def _loading_label_texts(fig):
+    """Feature names shown as loading-arrow labels (not the arrows themselves)."""
+    return {
+        ann.text for ann in fig.layout.annotations if not ann.showarrow and ann.text
+    }
+
+
 class TestInteractivePCAPlots:
     """Test interactive PCA plot functions."""
 
@@ -284,6 +292,163 @@ class TestInteractivePCAPlots:
 
         # Should have annotations for loadings
         assert len(fig.layout.annotations) > 0
+
+    def test_create_interactive_pca_with_images_default_feature_selection_matches_prior_behavior(
+        self, pca_viz_results, pca_viz_dataframe, sample_image_links
+    ):
+        """Default feature_selection ("top_variance") matches old behavior.
+
+        Must match the old hardcoded
+        nlargest(n_loadings, "total_contribution") ranking.
+        """
+        n_loadings = 5
+        expected = set(
+            pca_viz_results["feature_contributions"]
+            .nlargest(n_loadings, "total_contribution")
+            .index
+        )
+
+        fig = create_interactive_pca_with_images(
+            pca_results=pca_viz_results,
+            df=pca_viz_dataframe,
+            image_links=sample_image_links,
+            show_loadings=True,
+            n_loadings=n_loadings,
+        )
+
+        assert _loading_label_texts(fig) == expected
+
+    @pytest.mark.parametrize(
+        "feature_selection",
+        ["extreme", "top_absolute", "top_contribution", "vector_length"],
+    )
+    def test_create_interactive_pca_with_images_feature_selection_methods(
+        self, pca_viz_results, pca_viz_dataframe, sample_image_links, feature_selection
+    ):
+        """Non-default feature_selection methods match direct selection.
+
+        Each must match a direct select_top_features_from_pca() call with
+        the same arguments.
+        """
+        n_loadings = 5
+        pc_x, pc_y = 0, 1
+        expected_indices = select_top_features_from_pca(
+            loadings=pca_viz_results["loadings"],
+            eigenvalues=pca_viz_results["eigenvalues"],
+            n_features_total=len(pca_viz_results["feature_names"]),
+            n_features_to_select=n_loadings,
+            method=feature_selection,
+            pc_indices=[pc_x, pc_y],
+        )
+        expected = {pca_viz_results["feature_names"][i] for i in expected_indices}
+
+        fig = create_interactive_pca_with_images(
+            pca_results=pca_viz_results,
+            df=pca_viz_dataframe,
+            image_links=sample_image_links,
+            components=(pc_x, pc_y),
+            show_loadings=True,
+            n_loadings=n_loadings,
+            feature_selection=feature_selection,
+        )
+
+        assert _loading_label_texts(fig) == expected
+
+    def test_create_interactive_pca_with_images_pc_indices_not_reoffset(
+        self, pca_viz_results, pca_viz_dataframe, sample_image_links
+    ):
+        """Components here are already 0-indexed PCs, unlike create_pca_biplot.
+
+        Unlike create_pca_biplot's 1-indexed pc_x/pc_y, no -1 adjustment
+        should be applied before passing pc_indices to
+        select_top_features_from_pca.
+        """
+        n_loadings = 5
+        pc_x, pc_y = 2, 3
+        expected_indices = select_top_features_from_pca(
+            loadings=pca_viz_results["loadings"],
+            eigenvalues=pca_viz_results["eigenvalues"],
+            n_features_total=len(pca_viz_results["feature_names"]),
+            n_features_to_select=n_loadings,
+            method="extreme",
+            pc_indices=[pc_x, pc_y],
+        )
+        expected = {pca_viz_results["feature_names"][i] for i in expected_indices}
+
+        # An off-by-one implementation (subtracting 1, as create_pca_biplot
+        # does for its 1-indexed pc_x/pc_y) would instead rank pc_indices=[1, 2].
+        wrong_indices = select_top_features_from_pca(
+            loadings=pca_viz_results["loadings"],
+            eigenvalues=pca_viz_results["eigenvalues"],
+            n_features_total=len(pca_viz_results["feature_names"]),
+            n_features_to_select=n_loadings,
+            method="extreme",
+            pc_indices=[pc_x - 1, pc_y - 1],
+        )
+        wrong = {pca_viz_results["feature_names"][i] for i in wrong_indices}
+        assert expected != wrong  # sanity check the two conventions diverge
+
+        fig = create_interactive_pca_with_images(
+            pca_results=pca_viz_results,
+            df=pca_viz_dataframe,
+            image_links=sample_image_links,
+            components=(pc_x, pc_y),
+            show_loadings=True,
+            n_loadings=n_loadings,
+            feature_selection="extreme",
+        )
+
+        assert _loading_label_texts(fig) == expected
+
+    @pytest.mark.parametrize("show_loadings", [True, False])
+    def test_create_interactive_pca_with_images_rejects_invalid_feature_selection(
+        self, pca_viz_results, pca_viz_dataframe, sample_image_links, show_loadings
+    ):
+        """feature_selection is validated unconditionally.
+
+        Regardless of show_loadings.
+        """
+        with pytest.raises(ValueError, match="feature_selection"):
+            create_interactive_pca_with_images(
+                pca_results=pca_viz_results,
+                df=pca_viz_dataframe,
+                image_links=sample_image_links,
+                show_loadings=show_loadings,
+                feature_selection="bogus",
+            )
+
+    def test_create_interactive_pca_with_images_zero_loadings(
+        self, pca_viz_results, pca_viz_dataframe, sample_image_links
+    ):
+        """n_loadings=0 should add no loading-arrow labels."""
+        fig = create_interactive_pca_with_images(
+            pca_results=pca_viz_results,
+            df=pca_viz_dataframe,
+            image_links=sample_image_links,
+            show_loadings=True,
+            n_loadings=0,
+        )
+
+        assert _loading_label_texts(fig) == set()
+
+    def test_create_interactive_pca_with_images_loadings_exceed_feature_count(
+        self, pca_viz_results, pca_viz_dataframe, sample_image_links
+    ):
+        """n_loadings exceeding the total feature count selects all features.
+
+        Should select all available features without error.
+        """
+        n_features = len(pca_viz_results["feature_names"])
+
+        fig = create_interactive_pca_with_images(
+            pca_results=pca_viz_results,
+            df=pca_viz_dataframe,
+            image_links=sample_image_links,
+            show_loadings=True,
+            n_loadings=n_features + 50,
+        )
+
+        assert len(_loading_label_texts(fig)) == n_features
 
     def test_create_interactive_pca_different_components(
         self, pca_viz_results, pca_viz_dataframe, sample_image_links
@@ -327,6 +492,155 @@ class TestInteractivePCAPlots:
 
         assert isinstance(fig, go.Figure)
         assert len(fig.data) > 0
+
+    def test_create_interactive_pca_plot_default_feature_selection_matches_prior_behavior(
+        self, pca_viz_results, pca_viz_dataframe
+    ):
+        """Default feature_selection ("top_variance") matches old behavior.
+
+        Must match the old hardcoded
+        nlargest(n_loadings, "total_contribution") ranking.
+        """
+        n_loadings = 5
+        expected = set(
+            pca_viz_results["feature_contributions"]
+            .nlargest(n_loadings, "total_contribution")
+            .index
+        )
+
+        fig = create_interactive_pca_plot(
+            pca_results=pca_viz_results,
+            df=pca_viz_dataframe,
+            show_loadings=True,
+            n_loadings=n_loadings,
+        )
+
+        assert _loading_label_texts(fig) == expected
+
+    @pytest.mark.parametrize(
+        "feature_selection",
+        ["extreme", "top_absolute", "top_contribution", "vector_length"],
+    )
+    def test_create_interactive_pca_plot_feature_selection_methods(
+        self, pca_viz_results, pca_viz_dataframe, feature_selection
+    ):
+        """Non-default feature_selection methods match direct selection.
+
+        Each must match a direct select_top_features_from_pca() call with
+        the same arguments.
+        """
+        n_loadings = 5
+        pc_x, pc_y = 0, 1
+        expected_indices = select_top_features_from_pca(
+            loadings=pca_viz_results["loadings"],
+            eigenvalues=pca_viz_results["eigenvalues"],
+            n_features_total=len(pca_viz_results["feature_names"]),
+            n_features_to_select=n_loadings,
+            method=feature_selection,
+            pc_indices=[pc_x, pc_y],
+        )
+        expected = {pca_viz_results["feature_names"][i] for i in expected_indices}
+
+        fig = create_interactive_pca_plot(
+            pca_results=pca_viz_results,
+            df=pca_viz_dataframe,
+            components=(pc_x, pc_y),
+            show_loadings=True,
+            n_loadings=n_loadings,
+            feature_selection=feature_selection,
+        )
+
+        assert _loading_label_texts(fig) == expected
+
+    def test_create_interactive_pca_plot_pc_indices_not_reoffset(
+        self, pca_viz_results, pca_viz_dataframe
+    ):
+        """Components here are already 0-indexed PCs, unlike create_pca_biplot.
+
+        Unlike create_pca_biplot's 1-indexed pc_x/pc_y, no -1 adjustment
+        should be applied before passing pc_indices to
+        select_top_features_from_pca.
+        """
+        n_loadings = 5
+        pc_x, pc_y = 2, 3
+        expected_indices = select_top_features_from_pca(
+            loadings=pca_viz_results["loadings"],
+            eigenvalues=pca_viz_results["eigenvalues"],
+            n_features_total=len(pca_viz_results["feature_names"]),
+            n_features_to_select=n_loadings,
+            method="extreme",
+            pc_indices=[pc_x, pc_y],
+        )
+        expected = {pca_viz_results["feature_names"][i] for i in expected_indices}
+
+        wrong_indices = select_top_features_from_pca(
+            loadings=pca_viz_results["loadings"],
+            eigenvalues=pca_viz_results["eigenvalues"],
+            n_features_total=len(pca_viz_results["feature_names"]),
+            n_features_to_select=n_loadings,
+            method="extreme",
+            pc_indices=[pc_x - 1, pc_y - 1],
+        )
+        wrong = {pca_viz_results["feature_names"][i] for i in wrong_indices}
+        assert expected != wrong  # sanity check the two conventions diverge
+
+        fig = create_interactive_pca_plot(
+            pca_results=pca_viz_results,
+            df=pca_viz_dataframe,
+            components=(pc_x, pc_y),
+            show_loadings=True,
+            n_loadings=n_loadings,
+            feature_selection="extreme",
+        )
+
+        assert _loading_label_texts(fig) == expected
+
+    @pytest.mark.parametrize("show_loadings", [True, False])
+    def test_create_interactive_pca_plot_rejects_invalid_feature_selection(
+        self, pca_viz_results, pca_viz_dataframe, show_loadings
+    ):
+        """feature_selection is validated unconditionally.
+
+        Regardless of show_loadings.
+        """
+        with pytest.raises(ValueError, match="feature_selection"):
+            create_interactive_pca_plot(
+                pca_results=pca_viz_results,
+                df=pca_viz_dataframe,
+                show_loadings=show_loadings,
+                feature_selection="bogus",
+            )
+
+    def test_create_interactive_pca_plot_zero_loadings(
+        self, pca_viz_results, pca_viz_dataframe
+    ):
+        """n_loadings=0 should add no loading-arrow labels."""
+        fig = create_interactive_pca_plot(
+            pca_results=pca_viz_results,
+            df=pca_viz_dataframe,
+            show_loadings=True,
+            n_loadings=0,
+        )
+
+        assert _loading_label_texts(fig) == set()
+
+    def test_create_interactive_pca_plot_loadings_exceed_feature_count(
+        self, pca_viz_results, pca_viz_dataframe
+    ):
+        """n_loadings exceeding the total feature count selects all features.
+
+        Should select all available features without error.
+        """
+        n_features = len(pca_viz_results["feature_names"])
+
+        fig = create_interactive_pca_plot(
+            pca_results=pca_viz_results,
+            df=pca_viz_dataframe,
+            show_loadings=True,
+            n_loadings=n_features + 50,
+        )
+
+        assert len(_loading_label_texts(fig)) == n_features
 
 
 # ============================================================================

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -2739,6 +2739,24 @@ class TestFeatureSelection:
         # Feature 0 should only appear once
         assert selected.count(0) == 1
 
+    def test_extreme_selection_zero_features_returns_empty(self, sample_pca_data):
+        """Extreme with n_features_to_select=0 selects nothing, not everything.
+
+        Python's negative-slice quirk (arr[-0:] == arr[0:], the full array)
+        previously made the "most positive" half of the extreme branch
+        return every feature instead of none when n_features_to_select=0.
+        """
+        selected = select_top_features_from_pca(
+            loadings=sample_pca_data["loadings"],
+            eigenvalues=sample_pca_data["eigenvalues"],
+            n_features_total=sample_pca_data["n_features"],
+            n_features_to_select=0,
+            method="extreme",
+            pc_indices=[0, 1],
+        )
+
+        assert selected == []
+
     def test_variance_contribution_calculation(self, sample_pca_data):
         """Test that variance contributions are calculated correctly."""
         # Use top_variance method which should weight by eigenvalues


### PR DESCRIPTION
## Summary

Resolves the last open item from the PCA feature-selection consolidation effort (#202, #203, #204, #206, #207 — all merged).

- `create_interactive_pca_with_images` and `create_interactive_pca_plot` (`interactive_visualization.py`) previously hardcoded `feature_contributions.nlargest(n_loadings, "total_contribution")` to pick loading-arrow features, bypassing the shared `select_top_features_from_pca()`.
- The issue asked whoever picked this up to check for real usage before deciding between "delegate" or "document as intentionally simple." That check found real, current usage: 14 of the most recent `trait_viz_*.ipynb` notebooks and `docs/PCA.md`'s Example 4 all call `create_interactive_pca_with_images(..., show_loadings=True)`. So this resolves via delegation, mirroring `create_pca_biplot`'s existing pattern.
- Both functions gain a `feature_selection: str = "top_variance"` parameter, validated unconditionally against `VALID_SELECTION_METHODS`, delegating to `select_top_features_from_pca()`. Default `"top_variance"` matches the old hardcoded ranking's typical output (both derive from the same total-variance-contribution basis); see the OpenSpec proposal for the precise (narrow) NaN/exact-tie caveat on that equivalence claim.
- Unlike `create_pca_biplot` (1-indexed `pc_x`/`pc_y`, requires a `-1` conversion), these two functions' `components` tuple is already 0-indexed and is passed through unmodified — this is pinned down with a dedicated regression test, since the same off-by-one bug class was already introduced and fixed twice elsewhere in this effort (#203, #207).
- **Bonus fix**: found and fixed a pre-existing bug in `select_top_features_from_pca()`'s `"extreme"` method (`pca.py`), newly reachable through this parameter — `n_features_to_select=0` returned every feature instead of none, due to Python's `arr[-0:] == arr[0:]` negative-slice quirk.

Full history and the 5-agent adversarial review findings (spec quality, TDD, implementation correctness, docs, git workflow — proposal review; code quality, testing, statistical rigor, performance, behavioural correctness — pre-PR self-review) are in `openspec/changes/fix-interactive-pca-feature-selection/`.

## Test plan

- [x] TDD: failing tests written first for both functions (default-equivalence, all 5 selection methods via exact-set-equality against independent `select_top_features_from_pca()` calls, PC-indexing regression, unconditional validation, `n_loadings` boundaries), then minimal implementation, then green.
- [x] `create_umap_colored_by_top_traits`'s `top_variance` branch confirmed unchanged (no code touched there).
- [x] `docs/CHANGELOG.md` `[Unreleased]` entry added.
- [x] `openspec validate fix-interactive-pca-feature-selection --strict` passes.
- [x] `uv run black --check` / `uv run ruff check` clean on all touched files.
- [x] Full suite: `uv run pytest tests/` — 3050 passed, 37 skipped, 0 failed.
- [x] Targeted suite (`test_pca.py`, `test_interactive_visualization.py`, `test_visualization.py`) — 404 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)