### PR TITLE
fix: normalize genotype column to string dtype (mixed int/str sort/compare crash)

### DIFF
--- a/src/sleap_roots_analyze/interactive_visualization.py
+++ b/src/sleap_roots_analyze/interactive_visualization.py
@@ -558,6 +558,14 @@ def create_interactive_umap_with_hover_highlight(
     if genotype_col not in df.columns:
         raise ValueError(f"Genotype column '{genotype_col}' not found in dataframe")
 
+    # genotype is a categorical label, never a quantity -- normalize to a single
+    # string dtype before sorting (see outlier_visualization.py's
+    # create_outliers_per_genotype_plot for the same fix and rationale: mixed
+    # int/str values in this column raise "'<' not supported between instances
+    # of 'int' and 'str'").
+    df = df.copy()
+    df[genotype_col] = df[genotype_col].astype(str)
+
     # Get unique genotypes
     unique_genotypes = sorted(df[genotype_col].unique())
 

--- a/src/sleap_roots_analyze/outlier_visualization.py
+++ b/src/sleap_roots_analyze/outlier_visualization.py
@@ -188,6 +188,15 @@ def create_outliers_per_genotype_plot(
     Returns:
         Matplotlib figure object
     """
+    # genotype is a categorical label, never a quantity. Some pipelines carry a
+    # mix of numeric-looking accessions (int/float after upstream dtype
+    # inference) and named cultivars (str) in the same column -- sorted() then
+    # raises "'<' not supported between instances of 'int' and 'str'". Force a
+    # single consistent string dtype before sorting or comparing, regardless of
+    # what dtype the caller's DataFrame happens to carry.
+    df = df.copy()
+    df[genotype_col] = df[genotype_col].astype(str)
+
     # Collect outlier counts per genotype per method
     genotypes = sorted(df[genotype_col].unique())
     methods = [m for m in all_outlier_results.keys() if m != "combined"]

--- a/src/sleap_roots_analyze/statistics.py
+++ b/src/sleap_roots_analyze/statistics.py
@@ -438,6 +438,19 @@ def calculate_heritability_estimates(
     if missing_cols:
         return {"error": f"Missing required columns: {missing_cols}"}
 
+    # genotype is a categorical label, never a quantity. A DataFrame that has
+    # round-tripped through an intermediate CSV write/read (as pipeline steps
+    # do between stages) can lose its original dtype: numeric-looking
+    # accessions (e.g. "600824") get re-inferred as int/float on the next
+    # read_csv while named cultivars stay str, producing a mixed-type column.
+    # patsy/statsmodels then raises "'<' not supported between instances of
+    # 'int' and 'str'" while building the mixed-model design (reproduced on a
+    # real 3,343-row alfalfa GWAS dataset -- every one of 925 traits failed
+    # with this exact error before this fix). Force a single string dtype
+    # regardless of what the caller's DataFrame carries.
+    df = df.copy()
+    df[genotype_col] = df[genotype_col].astype(str)
+
     # Every fixed_effects name is interpolated directly into the formula
     # string below (issue #114); a name that isn't a valid identifier (e.g.
     # containing a patsy operator like `*` or `:`) could otherwise silently


### PR DESCRIPTION
## Summary
- Two reactive fixes for the genotype mixed int/str dtype crash described in #230: normalize `df[genotype_col]` to `str` before `sorted()`/comparison in `outlier_visualization.py`'s `create_outliers_per_genotype_plot()` and `interactive_visualization.py`'s UMAP hover-highlight helper, and before model fitting in `statistics.py`'s `calculate_heritability_estimates()`.
- The `statistics.py` fix is the highest-impact one: without it, a mixed-dtype genotype column causes every trait's mixed-model fit to fail silently (pipeline still exits 0), leaving `08_heritability_results.csv` all-NaN and `08_blup_adjusted_means.csv` with zero genotype rows.
- Verified against a real 3,343-row / 117-genotype alfalfa GWAS dataset (mix of numeric-looking accessions and named cultivars) — heritability and BLUP now populate with real values across both re-run groups.

**This is a reactive patch, not a root-cause fix** — see #230's "Investigation needed" section. The dtype degradation was NOT reproduced from a clean CSV round-trip in isolation, meaning something in the pipeline's own in-memory flow (not simply reading a saved intermediate CSV) reintroduces mixed types. #230 asks for that investigation and for reconsidering a single normalization point at pipeline entry (`load_data.py`) instead of these three scattered per-function casts.

Fixes #230 (partially — issue stays open pending the root-cause investigation and regression test called for in its acceptance checklist).

## Test plan
- [x] Verified in isolation against real intermediate data (`07_data_outliers_removed.csv`) before this run: heritability values computed (H²=0.6468/0.6873/0.6624 for a set of lateral-root-count traits) and BLUP dict populated.
- [x] Full `run-all` re-run against the real 2-group alfalfa dataset: both `plant_age_days_9` and `plant_age_days_12` now show 925/925 traits with non-NaN heritability and populated BLUP tables (112 and 117 genotype rows respectively).
- [ ] No automated regression test added yet (tracked in #230's acceptance checklist).