### PR TITLE
fix: viz config replicate column must match paired QC config (#212 recurrence)

### DIFF
--- a/.claude/commands/configure-run-all.md
+++ b/.claude/commands/configure-run-all.md
@@ -424,7 +424,18 @@ If a file exists:
 3. **Use sanitized column names** in the Viz config:
    - `columns.barcode: "Barcode"`
    - `columns.genotype: "Genotype"`
-   - `columns.replicate: "Replicate"`
+   - `columns.replicate`: **must match the QC config's own `columns.replicate` setting for this
+     same analysis** — `"Replicate"` if the QC config sets a real replicate column, or `null` if
+     the QC config omits `columns.replicate` entirely (e.g. cylinder data with no replicate
+     factor). The QC pipeline only sanitizes a column to the literal name `Replicate` when its own
+     `columns.replicate` was set (see `cleanup_traits.py`: `"Replicate" if config.columns.replicate
+     else None`) — if the QC config omitted it, no `Replicate` column exists anywhere downstream,
+     and hardcoding `"Replicate"` here makes `calculate_heritability_estimates` fail with
+     `Missing required columns: ['Replicate']` on EVERY trait, silently (exit code 0, no log
+     error) for both `08_heritability_results.csv` and `08_blup_adjusted_means.csv`. This is not
+     hypothetical — it has broken real deliverables twice already (see sleap-roots-analyze#212):
+     do not copy the template's literal `"Replicate"` value without checking the paired QC config
+     first.
    - `columns.image_path: "Image_Path"` (if images available, else `null`)
    - Explain: "These are the standardized names that the QC pipeline outputs after column renaming."
 
@@ -487,6 +498,20 @@ validate_qc_config(qc_config)  # Will raise ValueError if invalid
 # Validate Viz config
 viz_config = load_viz_config("configs/active/viz/<analysis_name>.yaml")
 validate_viz_config(viz_config)  # Will raise ValueError if invalid
+```
+
+**Cross-config column check (sleap-roots-analyze#212 recurrence prevention):** `validate_*_config`
+only checks each file in isolation and will NOT catch a viz config expecting a `Replicate` column
+that the paired QC config never produces. Explicitly compare the two:
+
+```python
+qc_replicate_set = bool(qc_config.columns.replicate)
+viz_replicate_set = bool(viz_config.columns.replicate)
+if qc_replicate_set != viz_replicate_set:
+    # STOP — mismatch will silently break every trait's heritability/BLUP at runtime
+    # (exit code 0, no log error). Fix viz_config.columns.replicate to match the QC
+    # config's choice (null if QC omits replicate, "Replicate" if QC sets one) before
+    # proceeding to Step 8.
 ```
 
 If validation fails:

--- a/configs/active/viz/mauricio_alfalfa_groups_7_22_combined.yaml
+++ b/configs/active/viz/mauricio_alfalfa_groups_7_22_combined.yaml
@@ -33,7 +33,7 @@ data:
 columns:
   barcode: "Barcode"
   genotype: "Genotype"
-  replicate: "Replicate"
+  replicate: null  # cylinder data has no replicate factor -- matches QC config's omission (issue #142: replicate values are never used in the model)
   image_path: null
 
 statistics:


### PR DESCRIPTION
## Summary
- Fixed `configs/active/viz/mauricio_alfalfa_groups_7_22_combined.yaml`: `columns.replicate` was the template-default `"Replicate"`, but the paired QC config (`configs/active/qc/mauricio_alfalfa_groups_7_22_combined.yaml`) deliberately omits `columns.replicate` (cylinder data has no replicate factor). The mismatch silently broke heritability/BLUP computation for every trait in both groups (`plant_age_days_9`, `plant_age_days_12`) — exit code 0, no log error, just an `error` row in `08_heritability_results.csv` and an empty `08_blup_adjusted_means.csv`.
- This is the same failure mode as #212 (filed 2026-07-30 against `mo_soybean_2021_grouped.yaml`), recurring on a second, independent dataset three weeks later — see the comment added to #212 for the full writeup.
- Traced to the actual root cause this time: `.claude/commands/configure-run-all.md` Step 6.2.3 unconditionally instructed writing `columns.replicate: "Replicate"` into every viz config, regardless of the paired QC config's own setting. That instruction — not any individual config file — is what's been producing this bug repeatedly.
- Fixed the instruction to check the QC config's `columns.replicate` first, and added an explicit QC/viz cross-check in Step 7 (config validation) so this is caught at config-authoring time, not ~30 minutes into a viz run.

Does not close #212 — the deeper ask there (fail loudly, or treat a configured-but-missing replicate column as equivalent to an omitted one) is still open and is the more durable fix. This PR is a process-level guardrail only.

## Test plan
- [x] Re-ran viz for both `plant_age_days_9` and `plant_age_days_12` against the already-completed QC output with `columns.replicate: null` — both now show 925/925 traits with non-error heritability values and populated `08_blup_adjusted_means.csv` (previously 0 rows).
- [ ] No automated test for the `configure-run-all.md` cross-check (it's a prompt-level instruction, not code) — tracked as still-open in #212's acceptance checklist for the code-level fix.